### PR TITLE
move up to 0.17.0 of the sdk - needed for arm64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean:
 	    echo "You do not have operator-sdk installed in your PATH. Will use the one found here: ${OUTDIR}/operator-sdk-install/operator-sdk" ;\
 	  else \
 	    echo "You do not have operator-sdk installed in your PATH. The binary will be downloaded to ${OUTDIR}/operator-sdk-install/operator-sdk" ;\
-	    curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.16.0/operator-sdk-v0.16.0-x86_64-linux-gnu > "${OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	    curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.17.0/operator-sdk-v0.17.0-x86_64-linux-gnu > "${OUTDIR}/operator-sdk-install/operator-sdk" ;\
 	    chmod +x "${OUTDIR}/operator-sdk-install/operator-sdk" ;\
 	  fi ;\
 	fi

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v0.16.0
+FROM quay.io/operator-framework/ansible-operator:v0.17.0
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/


### PR DESCRIPTION
moves the operator base image to 0.17.0 (which has ARM builds).

I ran the molecule tests and all pass. This new base image doesn't cause any problems.