### PR TITLE
fix travis badge

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 # Kiali Operator
 
-image:https://travis-ci.org/kiali/kiali-operator.svg["Build Status", link="https://travis-ci.org/kiali/kiali-operator"]
+image:https://travis-ci.com/kiali/kiali-operator.svg["Build Status", link="https://travis-ci.com/kiali/kiali-operator"]
 image:https://img.shields.io/badge/license-Apache2-blue.svg["Apache 2.0 license", link="LICENSE"]
 
 This contains the Kiali Operator source. It has a small link:Makefile[] whose only job is to build the operator image


### PR DESCRIPTION
because we are not using the legacy integration (instead we are using the GitHub App CI integration), we need to get the badge from travis' `.com` endpoint (not the older `.org`).