### PR TITLE
Add Makefile so we can build out of this v1.12 branch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 molecule/maistra-e2e/assets/secret.yaml
+_output

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+# Needed for Travis - it won't like the version regex check otherwise
+SHELL=/bin/bash
+
+# Directories based on the root project directory
+ROOTDIR=$(CURDIR)
+OUTDIR=${ROOTDIR}/_output
+
+# Identifies the current build.
+VERSION ?= v1.12.9
+COMMIT_HASH ?= $(shell git rev-parse HEAD)
+
+# Identifies the Kiali operator container image that will be built
+OPERATOR_IMAGE_ORG ?= kiali
+OPERATOR_CONTAINER_NAME ?= ${OPERATOR_IMAGE_ORG}/kiali-operator
+OPERATOR_CONTAINER_VERSION ?= ${VERSION}
+OPERATOR_QUAY_NAME ?= quay.io/${OPERATOR_CONTAINER_NAME}
+OPERATOR_QUAY_TAG = ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
+
+# Determine if we should use Docker OR Podman - value must be one of "docker" or "podman"
+DORP ?= docker
+
+.PHONY: help
+help: Makefile
+	@echo
+	@echo "Targets"
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+
+## clean: Cleans _output
+clean:
+	@rm -rf ${OUTDIR}
+
+.download-operator-sdk-if-needed:
+	@if [ "$(shell which operator-sdk 2>/dev/null || echo -n "")" == "" ]; then \
+	  mkdir -p "${OUTDIR}/operator-sdk-install" ;\
+	  if [ -x "${OUTDIR}/operator-sdk-install/operator-sdk" ]; then \
+	    echo "You do not have operator-sdk installed in your PATH. Will use the one found here: ${OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	  else \
+	    echo "You do not have operator-sdk installed in your PATH. The binary will be downloaded to ${OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	    curl -L https://github.com/operator-framework/operator-sdk/releases/download/v0.17.0/operator-sdk-v0.17.0-$$(uname -m)-linux-gnu > "${OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	    chmod +x "${OUTDIR}/operator-sdk-install/operator-sdk" ;\
+	  fi ;\
+	fi
+
+.ensure-operator-sdk-exists: .download-operator-sdk-if-needed
+	@$(eval OP_SDK ?= $(shell which operator-sdk 2>/dev/null || echo "${OUTDIR}/operator-sdk-install/operator-sdk"))
+	@"${OP_SDK}" version
+
+## build: Build Kiali operator container image.
+build: .ensure-operator-sdk-exists
+	@echo Building container image for Kiali operator using operator-sdk
+	cd "${ROOTDIR}" && "${OP_SDK}" build --image-builder ${DORP} --image-build-args "--pull" "${OPERATOR_QUAY_TAG}"
+
+## push: Pushes the operator image to quay.
+push:
+ifeq ($(DORP),docker)
+	@echo Pushing Kiali operator image using docker
+	docker push ${OPERATOR_QUAY_TAG}
+else
+	@echo Pushing Kiali operator image using podman
+	podman push ${OPERATOR_QUAY_TAG}
+endif


### PR DESCRIPTION
Note that initial VERSION is set to v1.12.9.
This is because we want the CI build workflow to make the first
release build to be v1.12.10 (and it bumps up this Makefile VERSION
to determine the new version to release).
Thus, we will know which operator builds came from this new
operator repo by looking at the patch version - all builds with a
double-digit patch version came from this kiali-operator repo.