### PR TITLE
Adding config flag for istio status feat in the masthead

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -429,12 +429,14 @@ spec:
 #      url: ""
 #
 # **Istio-specific settings:
+# istio_status_enabled: Enable/Disable of istio component status into masthead indicator. It defaults to true.
 # istio_identity_domain: The annotation used by Istio to identify domains.
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
 # url_service_version: The Istio service used to determine the Istio version.
 #                      If empty, assumes it is in the istio namespace at the URL "http://istio-pilot.<istio_namespace>:8080/version"
 #    ---
 #    istio:
+#      istio_status_enabled: true
 #      istio_identity_domain: "svc.cluster.local"
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
 #      url_service_version: ""

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -429,16 +429,16 @@ spec:
 #      url: ""
 #
 # **Istio-specific settings:
-# istio_status_enabled: Enable/Disable of istio component status into masthead indicator. It defaults to true.
 # istio_identity_domain: The annotation used by Istio to identify domains.
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
+# istio_status_enabled: Enable/Disable of istio component status into masthead indicator. It defaults to true.
 # url_service_version: The Istio service used to determine the Istio version.
 #                      If empty, assumes it is in the istio namespace at the URL "http://istio-pilot.<istio_namespace>:8080/version"
 #    ---
 #    istio:
-#      istio_status_enabled: true
 #      istio_identity_domain: "svc.cluster.local"
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
+#      istio_status_enabled: true
 #      url_service_version: ""
 #
 #

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -106,6 +106,7 @@ kiali_defaults:
     istio:
       istio_identity_domain: "svc.cluster.local"
       istio_sidecar_annotation: "sidecar.istio.io/status"
+      istio_status_enabled: true
       url_service_version: ""
     prometheus:
       auth:


### PR DESCRIPTION
This task is to complement the new flag introduced in https://github.com/kiali/kiali/pull/2598

Once the flag is set to false, the istio components check feat won't be performed. Default value is set to true.

Needs https://github.com/kiali/kiali/pull/2598