### PR TITLE
Truncate version label to the k8s maximum of 63 when appropriate.

### DIFF
--- a/molecule/config-values-test/molecule.yml
+++ b/molecule/config-values-test/molecule.yml
@@ -1,0 +1,44 @@
+---
+dependency:
+  name: galaxy
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    group_vars:
+      all:
+        kiali_operator_assets_path : "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/kiali-cr.yaml"
+        cr_namespace: kiali-operator
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          install_namespace: istio-system
+          accessible_namespaces: ["**"]
+          auth_strategy: openshift
+          operator_namespace: kiali-operator
+          operator_image_name: quay.io/kiali/kiali-operator
+          operator_version: latest
+          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
+          #operator_version: dev
+          operator_watch_namespace: kiali-operator
+          operator_clusterrolebindings: "- clusterrolebindings"
+          operator_clusterroles: "- clusterroles"
+          image_name: quay.io/kiali/kiali
+          image_version: latest
+          image_pull_policy: Always
+scenario:
+  name: config-values-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/molecule/config-values-test/playbook.yml
+++ b/molecule/config-values-test/playbook.yml
@@ -1,0 +1,25 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # This test will change some config settings to make sure things work like we expect.
+  # We will add additional tasks and asserts in the future to test other config changes.
+
+  # Make sure version label is truncated to the k8s maximum 63 chars and must start/end with alphanum char
+  - import_tasks: set-version-label.yml
+    vars:
+      new_version_label: "1234567890123456789012345678901234567890123456789012345678901234"
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+  - name: Make sure version_label was truncated properly
+    assert:
+      that:
+      - kiali_configmap.deployment.version_label == "123456789012345678901234567890123456789012345678901234567890XXX"
+      - "{{ kiali_deployment.resources[0].metadata.labels.version | length == 63 }}"

--- a/molecule/config-values-test/set-kiali-cr.yml
+++ b/molecule/config-values-test/set-kiali-cr.yml
@@ -1,0 +1,4 @@
+- name: Change Kiali CR with new Kiali CR
+  k8s:
+    namespace: '{{ cr_namespace }}'
+    definition: "{{ new_kiali_cr }}"

--- a/molecule/config-values-test/set-version-label.yml
+++ b/molecule/config-values-test/set-version-label.yml
@@ -1,0 +1,7 @@
+- name: Set new deployment.version_label in current Kiali CR
+  vars:
+    current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
+  set_fact:
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'version_label': new_version_label }}}, recursive=True) }}"
+
+- import_tasks: set-kiali-cr.yml

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -358,6 +358,13 @@
   when:
   - kiali_vars.deployment.version_label == ""
 
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
+- name: Trim version_label when appropriate
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(63, True, 'XXX', 0)}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.version_label | length > 63
+
 # Indicate which Kiali image we are going to use.
 - debug:
     msg: "IMAGE_NAME={{ kiali_vars.deployment.image_name }}; IMAGE VERSION={{ kiali_vars.deployment.image_version }}; VERSION LABEL={{ kiali_vars.deployment.version_label }}"

--- a/roles/v1.0/kiali-deploy/tasks/main.yml
+++ b/roles/v1.0/kiali-deploy/tasks/main.yml
@@ -182,6 +182,13 @@
   when:
   - kiali_vars.deployment.version_label == ""
 
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
+- name: Trim version_label when appropriate
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(63, True, 'XXX', 0)}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.version_label | length > 63
+
 # Indicate which Kiali image we are going to use.
 - debug:
     msg: "IMAGE_NAME={{ kiali_vars.deployment.image_name }}; IMAGE VERSION={{ kiali_vars.deployment.image_version }}; VERSION LABEL={{ kiali_vars.deployment.version_label }}"

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -342,6 +342,13 @@
   when:
   - kiali_vars.deployment.version_label == ""
 
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
+- name: Trim version_label when appropriate
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(63, True, 'XXX', 0)}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.version_label | length > 63
+
 # Indicate which Kiali image we are going to use.
 - debug:
     msg: "IMAGE_NAME={{ kiali_vars.deployment.image_name }}; IMAGE VERSION={{ kiali_vars.deployment.image_version }}; VERSION LABEL={{ kiali_vars.deployment.version_label }}"


### PR DESCRIPTION
This will be required when the version label is based on an image version that is a SHA.

backport PR: https://github.com/kiali/kiali-operator/pull/17