### PR TITLE
Truncate version label using the old jinja API

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -358,10 +358,10 @@
   when:
   - kiali_vars.deployment.version_label == ""
 
-# Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
+# Kubernetes limits the length of version label strings - ensure the label is valid.
 - name: Trim version_label when appropriate
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(63, True, 'XXX', 0)}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(60, True, 'XXX')}}, recursive=True) }}"
   when:
   - kiali_vars.deployment.version_label | length > 63
 

--- a/roles/v1.0/kiali-deploy/tasks/main.yml
+++ b/roles/v1.0/kiali-deploy/tasks/main.yml
@@ -185,7 +185,7 @@
 # Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
 - name: Trim version_label when appropriate
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(63, True, 'XXX', 0)}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(60, True, 'XXX')}}, recursive=True) }}"
   when:
   - kiali_vars.deployment.version_label | length > 63
 

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -345,7 +345,7 @@
 # Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
 - name: Trim version_label when appropriate
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(63, True, 'XXX', 0)}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(60, True, 'XXX')}}, recursive=True) }}"
   when:
   - kiali_vars.deployment.version_label | length > 63
 


### PR DESCRIPTION
Because we need to use the old jinja API, we have to truncate to 60.
The trailing "XXX" adds three more to make the k8s maximum of 63.
We can't use elipses ("...") because k8s label values must end with an alphanum char.