### PR TITLE
make sure the ingress for the route is ready

### DIFF
--- a/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -9,8 +9,14 @@
     name: kiali
     namespace: "{{ kiali_vars.deployment.namespace }}"
   register: kiali_route_raw
-  until: kiali_route_raw['resources'] is defined and kiali_route_raw['resources'][0] is defined
-  retries: 6
+  until:
+  - kiali_route_raw['resources'] is defined
+  - kiali_route_raw['resources'][0] is defined
+  - kiali_route_raw['resources'][0]['status'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] is defined
+  retries: 30
   delay: 10
   when:
   - is_openshift == True

--- a/roles/v1.0/kiali-deploy/tasks/openshift/os-oauth.yml
+++ b/roles/v1.0/kiali-deploy/tasks/openshift/os-oauth.yml
@@ -8,8 +8,14 @@
     name: kiali
     namespace: "{{ kiali_vars.deployment.namespace }}"
   register: kiali_route_raw
-  until: kiali_route_raw['resources'] is defined and kiali_route_raw['resources'][0] is defined
-  retries: 6
+  until:
+  - kiali_route_raw['resources'] is defined
+  - kiali_route_raw['resources'][0] is defined
+  - kiali_route_raw['resources'][0]['status'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] is defined
+  retries: 30
   delay: 10
   when:
   - is_openshift == True

--- a/roles/v1.12/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/v1.12/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -9,8 +9,14 @@
     name: kiali
     namespace: "{{ kiali_vars.deployment.namespace }}"
   register: kiali_route_raw
-  until: kiali_route_raw['resources'] is defined and kiali_route_raw['resources'][0] is defined
-  retries: 6
+  until:
+  - kiali_route_raw['resources'] is defined
+  - kiali_route_raw['resources'][0] is defined
+  - kiali_route_raw['resources'][0]['status'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] is defined
+  retries: 30
   delay: 10
   when:
   - is_openshift == True


### PR DESCRIPTION
Some clusters might take a while to actually get the route ingress created - even though the route is created, the ingress' host might not be available until some time after.

This ensures that a route query that is deemed successful is one that is able to retrieve the ingress host.

This also bumps up the number of retries such that it will keep trying for up to 5 minutes, giving more time for the infrastructure to successfully build the route.

backport: https://github.com/kiali/kiali-operator/pull/24