### PR TITLE
be able to specify what images to test via env vars.

### DIFF
--- a/molecule/accessible-namespaces-test/molecule.yml
+++ b/molecule/accessible-namespaces-test/molecule.yml
@@ -27,15 +27,13 @@ provisioner:
           - '**'
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: accessible-namespaces-test

--- a/molecule/affinity-tolerations-resources-test/molecule.yml
+++ b/molecule/affinity-tolerations-resources-test/molecule.yml
@@ -26,15 +26,13 @@ provisioner:
           accessible_namespaces: ["**"]
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: affinity-tolerations-resources-test

--- a/molecule/config-values-test/molecule.yml
+++ b/molecule/config-values-test/molecule.yml
@@ -26,15 +26,13 @@ provisioner:
           accessible_namespaces: ["**"]
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: config-values-test

--- a/molecule/default-namespace-test/molecule.yml
+++ b/molecule/default-namespace-test/molecule.yml
@@ -26,10 +26,8 @@ provisioner:
           accessible_namespaces: ["**"]
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           # Notice the operator will watch istio-system.
           # That is where this test will deploy the CR (cr_namespace)
           # The default namespace should be where the CR is deployed,
@@ -37,8 +35,8 @@ provisioner:
           operator_watch_namespace: anothernamespace
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: default-namespace-test

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -26,8 +26,8 @@ provisioner:
           accessible_namespaces:
           - "**"
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: ""
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
@@ -35,9 +35,9 @@ provisioner:
           operator_role_delete: "- delete"
           operator_role_patch: "- patch"
           auth_strategy: openshift
-          image_name: quay.io/kiali/kiali
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           label_selector: ""
-          image_version: latest
           # Because when the version is set to Latest, it needs to be Always
           image_pull_policy: Always
 scenario:

--- a/molecule/ldap-test/molecule.yml
+++ b/molecule/ldap-test/molecule.yml
@@ -31,17 +31,13 @@ provisioner:
           accessible_namespaces: ["**"]
           auth_strategy: ldap
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
-          #image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali
-          #image_version: dev
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: ldap-test

--- a/molecule/null-cr-values-test/molecule.yml
+++ b/molecule/null-cr-values-test/molecule.yml
@@ -26,15 +26,13 @@ provisioner:
           accessible_namespaces: ["**"]
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: null-cr-values-test

--- a/molecule/only-view-only-mode-test/molecule.yml
+++ b/molecule/only-view-only-mode-test/molecule.yml
@@ -27,10 +27,8 @@ provisioner:
           - istio-system
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
@@ -38,8 +36,8 @@ provisioner:
           operator_role_create: "# no create"
           operator_role_delete: "# no delete"
           operator_role_patch: "# no patch"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: only-view-only-mode-test

--- a/molecule/os-console-links-test/molecule.yml
+++ b/molecule/os-console-links-test/molecule.yml
@@ -27,15 +27,13 @@ provisioner:
           - '**'
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
           server_web_root: "/"
 scenario:

--- a/molecule/roles-test/molecule.yml
+++ b/molecule/roles-test/molecule.yml
@@ -27,15 +27,13 @@ provisioner:
           - istio-system
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: roles-test

--- a/molecule/rolling-restart-test/molecule.yml
+++ b/molecule/rolling-restart-test/molecule.yml
@@ -26,15 +26,13 @@ provisioner:
           accessible_namespaces: ["**"]
           auth_strategy: openshift
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: rolling-restart-test

--- a/molecule/token-test/molecule.yml
+++ b/molecule/token-test/molecule.yml
@@ -26,17 +26,13 @@ provisioner:
           accessible_namespaces: ["**"]
           auth_strategy: token
           operator_namespace: kiali-operator
-          operator_image_name: quay.io/kiali/kiali-operator
-          operator_version: latest
-          #operator_image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator
-          #operator_version: dev
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_clusterrolebindings: "- clusterrolebindings"
           operator_clusterroles: "- clusterroles"
-          image_name: quay.io/kiali/kiali
-          image_version: latest
-          #image_name: image-registry.openshift-image-registry.svc:5000/kiali/kiali
-          #image_version: dev
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
           image_pull_policy: Always
 scenario:
   name: token-test


### PR DESCRIPTION
This way we no longer have to keep editing files to switch.
PR https://github.com/kiali/kiali/pull/2724 uses these env vars in the make targets that run molecule tests. You can now run the molecule-test target with the env var `MOLECULE_USE_DEV_IMAGES=true` in order to test locally build images (not specifying that will test the "latest" image from quay.io).