### PR TITLE
[v1.12] don't use jinja api - use array notation for easier and more predictable results

### DIFF
--- a/molecule/config-values-test/playbook.yml
+++ b/molecule/config-values-test/playbook.yml
@@ -13,7 +13,7 @@
   # Make sure version label is truncated to the k8s maximum 63 chars and must start/end with alphanum char
   - import_tasks: set-version-label.yml
     vars:
-      new_version_label: "1234567890123456789012345678901234567890123456789012345678901234"
+      new_version_label: "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee12345678901234"
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
   - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
@@ -21,5 +21,5 @@
   - name: Make sure version_label was truncated properly
     assert:
       that:
-      - kiali_configmap.deployment.version_label == "123456789012345678901234567890123456789012345678901234567890XXX"
+      - kiali_configmap.deployment.version_label == "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee1234567890XXX"
       - "{{ kiali_deployment.resources[0].metadata.labels.version | length == 63 }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -342,10 +342,10 @@
   when:
   - kiali_vars.deployment.version_label == ""
 
-# Kubernetes limits the length of version label strings - ensure the label is valid.
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure the label is valid.
 - name: Trim version_label when appropriate
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(60, True, 'XXX')}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label[:60] + 'XXX' }}, recursive=True) }}"
   when:
   - kiali_vars.deployment.version_label | length > 63
 

--- a/roles/v1.0/kiali-deploy/tasks/main.yml
+++ b/roles/v1.0/kiali-deploy/tasks/main.yml
@@ -182,10 +182,10 @@
   when:
   - kiali_vars.deployment.version_label == ""
 
-# Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure the label is valid
 - name: Trim version_label when appropriate
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(60, True, 'XXX')}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label[:60] + 'XXX' }}, recursive=True) }}"
   when:
   - kiali_vars.deployment.version_label | length > 63
 

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -342,10 +342,10 @@
   when:
   - kiali_vars.deployment.version_label == ""
 
-# Kubernetes limits the length of version label strings to 63 characters or less - make sure our label is valid
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure the label is valid
 - name: Trim version_label when appropriate
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label | truncate(60, True, 'XXX')}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label[:60] + 'XXX' }}, recursive=True) }}"
   when:
   - kiali_vars.deployment.version_label | length > 63
 


### PR DESCRIPTION
backport of https://github.com/kiali/kiali-operator/pull/26