### PR TITLE
correct value for ansible boolean is "yes"

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -241,7 +241,7 @@
   until: istiod_version_url_results_raw.status == 200
   retries: 5
   delay: 1
-  ignore_errors: true
+  ignore_errors: yes
   when:
   - kiali_vars.external_services.istio.url_service_version == ""
 


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/2792

Grrr... Ansible booleans require "yes" instead of "true". 

"true" evaluates to "false" :/