### PR TITLE
do a URL check to make sure github.com is accessible

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -355,6 +355,11 @@
   - kiali_vars.auth.strategy == "openshift"
   - kiali_vars.deployment.ingress_enabled == False
 
+- name: Confirm the cluster can access github.com when it needs to determine the last release of Kiali
+  uri:
+    url: https://api.github.com/repos/kiali/kiali-operator/releases
+  when:
+  - kiali_vars.deployment.image_version == "lastrelease"
 - name: Determine image version when last release is to be installed
   shell: echo -n $(curl -s https://api.github.com/repos/kiali/kiali-operator/releases 2> /dev/null | grep "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//' | grep -v "snapshot" | sort -t "." -k 1.2g,1 -k 2g,2 -k 3g | tail -n 1)
   register: github_lastrelease


### PR DESCRIPTION
Fixes: https://github.com/kiali/kiali/issues/2795

This should return a better error message than before.

If github is not accessible, the task with the name "Confirm the cluster can access github.com when it needs to determine the last release of Kiali" will fail and be associated with an error such as this (as logged by the operator):

```
    "msg": "Failed to connect to api.github.com at port 443: [Errno 111] Connection refused", 
```