### PR TITLE
Add support for authentication through an OpenId provider

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -691,8 +691,8 @@ spec:
 #    ---
 #    port: 20001
 #
-# Defines the public domain where Kiali is being served. This the "domain" part
-# of the URL (usually it's a full-qualified domain name).
+# Defines the public domain where Kiali is being served. This is the "domain" part
+# of the URL (usually it's a fully-qualified domain name).
 # For example, "kiali.example.org".
 # When empty, Kiali will try to guess this value from HTTP headers.
 #    ---
@@ -710,4 +710,3 @@ spec:
 # When empty, Kiali will try to guess this value from HTTP headers.
 #    ---
 #    web_schema: ""
-

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -188,7 +188,7 @@ spec:
 # the issued token.
 #
 # When users are logging in, Kiali will wait at most 5 minutes after the "Login" button is pressed
-# in Kiali and redirected to the OpenID provider. If users don't login withing 5 minutes, Kiali will
+# in Kiali and redirected to the OpenID provider. If users don't login within 5 minutes, Kiali will
 # reject login even if the user authenticates successfully. You can change this time by adjusting
 # the 'authentication_timeout' option.
 #
@@ -202,7 +202,7 @@ spec:
 #      client_id: ""
 #      insecure_skip_verify_tls: false
 #      issuer_uri: ""
-#      scopes: ["profile", "email"]
+#      scopes: ["openid", "profile", "email"]
 #      username_claim: "sub"
 
 ##########
@@ -691,10 +691,23 @@ spec:
 #    ---
 #    port: 20001
 #
+# Defines the public domain where Kiali is being served. This the "domain" part
+# of the URL (usually it's a full-qualified domain name).
+# For example, "kiali.example.org".
+# When empty, Kiali will try to guess this value from HTTP headers.
+#    ---
+#    web_fqdn: ""
+#
 # Defines the context root path for the Kiali console and API endpoints and readiness probes.
 # When providing a context root path that is not "/", do not add a trailing slash.
 # For example, use "/kiali" not "/kiali/".
 # When empty, will default to "/" on OpenShift and "/kiali" on Kubernetes.
 #    ---
 #    web_root: ""
+#
+# Defines the public HTTP schema used to serve Kiali. This can only take
+# two possible values: either "http" or "https".
+# When empty, Kiali will try to guess this value from HTTP headers.
+#    ---
+#    web_schema: ""
 

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -163,7 +163,6 @@ spec:
 #      ldap_user_filter: "(cn=%s)"
 #      ldap_user_id_key: "cn"
 #
-#    ---
 # When "openid" strategy is chosen for authentication, you will need to fill some
 # required configurations in the following openid section. The "openid" authentication strategy
 # assumes that your Kubernetes cluster is properly configured to accept OpenID connect
@@ -188,12 +187,13 @@ spec:
 # suit your needs, you can change the 'scopes' setting as long as your cluster will accept
 # the issued token.
 #
+#    ---
 #    openid:
-#      issuer_uri: ""
+#      authorization_endpoint: ""
 #      client_id: ""
+#      issuer_uri: ""
 #      scopes: ["profile", "email"]
 #      username_claim: "sub"
-#      authorization_endpoint: ""
 
 ##########
 #  ---

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -187,10 +187,20 @@ spec:
 # suit your needs, you can change the 'scopes' setting as long as your cluster will accept
 # the issued token.
 #
+# When users are logging in, Kiali will wait at most 5 minutes after the "Login" button is pressed
+# in Kiali and redirected to the OpenID provider. If users don't login withing 5 minutes, Kiali will
+# reject login even if the user authenticates successfully. You can change this time by adjusting
+# the 'authentication_timeout' option.
+#
+# If your OpenID provider is using a certificate signed by an unknown CA, adjust the 'insecure_skip_verify_tls'
+# to disable the certificate verification. Remember this should be for testing purposes only.
+#
 #    ---
 #    openid:
+#      authentication_timeout: 300
 #      authorization_endpoint: ""
 #      client_id: ""
+#      insecure_skip_verify_tls: false
 #      issuer_uri: ""
 #      scopes: ["profile", "email"]
 #      username_claim: "sub"

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -135,6 +135,9 @@ spec:
 #  the individual's  RBAC roles in OpenShift. Not valid for non-OpenShift environments.
 # Choose "ldap" to enable LDAP based authentication. There are additional configurations for
 #  LDAP auth strategy that are required. See below for the additional LDAP configuration section.
+# Choose "openid" to enable OpenID connect based authentication. Your cluster is required to
+#  be configured to accept the tokens issued by your IdP. There are additional required
+#  configurations for this strategy. See below for the additional OpenID configuration section.
 # When empty, its value will default to "openshift" on OpenShift and "login" on Kubernetes.
 #    ---
 #    strategy: ""
@@ -159,6 +162,38 @@ spec:
 #      ldap_use_ssl: false
 #      ldap_user_filter: "(cn=%s)"
 #      ldap_user_id_key: "cn"
+#
+#    ---
+# When "openid" strategy is chosen for authentication, you will need to fill some
+# required configurations in the following openid section. The "openid" authentication strategy
+# assumes that your Kubernetes cluster is properly configured to accept OpenID connect
+# tokens and delegates token validation to the cluster's API Server. Thus, "openid" strategy
+# won't work without the proper configuration on your Kubernetes cluster
+# (see https://kubernetes.io/docs/reference/access-authn-authz/authentication/#configuring-the-api-server).
+#
+# The "openid" strategy should NOT be used when installing Kiali in OpenShift. In this case, you
+# still should use "openshift" strategy and, in turn, setup OpenShift to use your IdP. For
+# OpenShift 4.4, you can find related docs here: https://docs.openshift.com/container-platform/4.4/authentication/identity_providers/configuring-oidc-identity-provider.html
+#
+# Kiali requires that your IdP allows the Implicit Flow grant. The 'issuer_uri' and 'client_id' attributes
+# are required values and must match your OpenId-Connect Kubernetes configuration. The 'username_claim'
+# is optional, but must match the value configured in your cluster (default value is "sub").
+#
+# You can, optionally, specify an 'authorization_endpoint' which is the URI where users will
+# be redirected to login and authorize access to Kiali. If you don't specify it, Kiali will try
+# to discover it using the 'issuer_uri'.
+#
+# By default, Kiali will ask for "openid" (forced), "profile" and "email" scopes when asking
+# for authentication to the OpenID provider. These are standard OpenID scopes. If this doesn't
+# suit your needs, you can change the 'scopes' setting as long as your cluster will accept
+# the issued token.
+#
+#    openid:
+#      issuer_uri: ""
+#      client_id: ""
+#      scopes: ["profile", "email"]
+#      username_claim: "sub"
+#      authorization_endpoint: ""
 
 ##########
 #  ---

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -43,6 +43,12 @@ kiali_defaults:
       ldap_use_ssl: false
       ldap_user_filter: "(cn=%s)"
       ldap_user_id_key: "cn"
+    openid:
+      issuer_uri: ""
+      client_id: ""
+      scopes: ["profile", "email"]
+      username_claim: "sub"
+      authorization_endpoint: ""
     strategy: ""
 
   deployment:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -49,7 +49,7 @@ kiali_defaults:
       client_id: ""
       insecure_skip_verify_tls: false
       issuer_uri: ""
-      scopes: ["profile", "email"]
+      scopes: ["openid", "profile", "email"]
       username_claim: "sub"
     strategy: ""
 
@@ -181,7 +181,9 @@ kiali_defaults:
     metrics_enabled: true
     metrics_port: 9090
     port: 20001
+    web_fqdn: ""
     web_root: ""
+    web_schema: ""
 
 # These variables are outside of the kiali_defaults. Their values will be
 # auto-detected by the role and are not meant to be set by the user.

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -44,8 +44,10 @@ kiali_defaults:
       ldap_user_filter: "(cn=%s)"
       ldap_user_id_key: "cn"
     openid:
+      authentication_timeout: 300
       authorization_endpoint: ""
       client_id: ""
+      insecure_skip_verify_tls: false
       issuer_uri: ""
       scopes: ["profile", "email"]
       username_claim: "sub"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -44,11 +44,11 @@ kiali_defaults:
       ldap_user_filter: "(cn=%s)"
       ldap_user_id_key: "cn"
     openid:
-      issuer_uri: ""
+      authorization_endpoint: ""
       client_id: ""
+      issuer_uri: ""
       scopes: ["profile", "email"]
       username_claim: "sub"
-      authorization_endpoint: ""
     strategy: ""
 
   deployment:

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -333,19 +333,26 @@
   - kiali_vars.auth.strategy != 'token'
 - name: Confirm auth strategy is valid for Kubernetes environments
   fail:
-    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'ldap', 'token' or 'anonymous'"
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'login', 'ldap', 'token', 'openid' or 'anonymous'"
   when:
   - is_k8s == True
   - kiali_vars.auth.strategy != 'login'
   - kiali_vars.auth.strategy != 'anonymous'
   - kiali_vars.auth.strategy != 'ldap'
   - kiali_vars.auth.strategy != 'token'
+  - kiali_vars.auth.strategy != 'openid'
 - name: Confirm ldap configuration when auth strategy is 'ldap'
   fail:
     msg: "Invalid configuration for LDAP! The mandatory parameters should be provided like `ldap_host', 'ldap_port', 'ldap_bind_dn', and 'ldap_base'"
   when:
   - kiali_vars.auth.strategy == "ldap"
   - kiali_vars.auth.ldap.ldap_host == "" or kiali_vars.auth.ldap.ldap_port <= 0 or kiali_vars.auth.ldap.ldap_bind_dn == "" or kiali_vars.auth.ldap.ldap_base == ""
+- name: Confirm OpenID configuration when auth strategy is 'openid'
+  fail:
+    msg: "Invalid configuration for OpenID connect! The mandatory parameters should be provided: `issuer_uri', 'client_id'. Also, the 'username_claim' cannot be set to the empty string."
+  when:
+  - kiali_vars.auth.strategy == "openid"
+  - kiali_vars.auth.openid.issuer_uri == "" or kiali_vars.auth.openid.client_id == "" or kiali_vars.auth.openid.username_claim == ""
 # Fail if ingress is disabled but auth_strategy is openshift. This is because the openshift auth strategy
 # requires OAuth Client which requires a Route. So ingress must be enabled if strategy is openshift.
 - name: Ensure Ingress is Enabled if Auth Strategy is openshift

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -343,13 +343,13 @@
   - kiali_vars.auth.strategy != 'openid'
 - name: Confirm ldap configuration when auth strategy is 'ldap'
   fail:
-    msg: "Invalid configuration for LDAP! The mandatory parameters should be provided like `ldap_host', 'ldap_port', 'ldap_bind_dn', and 'ldap_base'"
+    msg: "Invalid configuration for LDAP! The mandatory parameters should be provided like 'ldap_host', 'ldap_port', 'ldap_bind_dn', and 'ldap_base'"
   when:
   - kiali_vars.auth.strategy == "ldap"
   - kiali_vars.auth.ldap.ldap_host == "" or kiali_vars.auth.ldap.ldap_port <= 0 or kiali_vars.auth.ldap.ldap_bind_dn == "" or kiali_vars.auth.ldap.ldap_base == ""
 - name: Confirm OpenID configuration when auth strategy is 'openid'
   fail:
-    msg: "Invalid configuration for OpenID connect! The mandatory parameters should be provided: `issuer_uri', 'client_id'. Also, the 'username_claim' cannot be set to the empty string."
+    msg: "Invalid configuration for OpenID connect! The mandatory parameters should be provided: 'issuer_uri', 'client_id'. Also, the 'username_claim' cannot be set to the empty string."
   when:
   - kiali_vars.auth.strategy == "openid"
   - kiali_vars.auth.openid.issuer_uri == "" or kiali_vars.auth.openid.client_id == "" or kiali_vars.auth.openid.username_claim == ""

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -284,6 +284,14 @@
   - kiali_vars.server.web_root != "/"
   - kiali_vars.server.web_root is match(".*/$")
 
+- name: Validate web_schema configuration
+  fail:
+    msg: "Invalid server.web_schema [{{ kiali_vars.server.web_schema }}]! Must be empty, or one of either 'http' or 'https'"
+  when:
+  - kiali_vars.server.web_schema != ''
+  - kiali_vars.server.web_schema != 'https'
+  - kiali_vars.server.web_schema != 'http'
+
 - name: Set default identity cert_file based on cluster type
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'identity': {'cert_file': '/kiali-cert/tls.crt' if is_openshift else ''}}, recursive=True) }}"

--- a/roles/default/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/oauth.yaml
@@ -8,6 +8,5 @@ metadata:
     version: {{ kiali_vars.deployment.version_label }}
 redirectURIs:
   - {{ kiali_route_url }}
-  - localhost:3000
 grantMethod: auto
 allowAnyScope: true


### PR DESCRIPTION
* Add "OpenId" as new strategy
  * Documentation for OpenId auth in the example CR file
  * Add default values for OpenId auth
  * Add 'openid' as a valid strategy for Kubernetes cluster but not for OpenShift
  * Add OpenId config validations in the playbook

Additionally, remove `localhost:3000` from the valid redirectURIs for the openshift authentication.

Part of kiali/kiali#2056