### PR TITLE
do not create ApplicationMenu consolelinks

### DIFF
--- a/roles/default/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/console-links.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   href: {{ kiali_route_url }}{{ '/' if kiali_vars.server.web_root == '/' else (kiali_vars.server.web_root + '/') }}console/graph/namespaces?namespaces={{ namespace }}
   location: NamespaceDashboard
-  text: Open on Kiali
+  text: Kiali
   namespaceDashboard:
     namespaces:
     - {{ namespace }}

--- a/roles/default/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/console-links.yaml
@@ -1,15 +1,3 @@
-apiVersion: console.openshift.io/v1
-kind: ConsoleLink
-metadata:
-  name: kiali-app-{{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    kiali.io/home: {{ kiali_vars.deployment.namespace }}
-spec:
-  href: {{ kiali_route_url }}
-  location: ApplicationMenu
-  text: Kiali [{{ kiali_vars.deployment.namespace }}]
 {% if openshift_version is version('4.3', '>=') %}
 {% for namespace in namespaces %}
 ---


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/2861

cc @maltron - I assume we want this, even though I know the design is not fully fleshed out (i.e. we know we do not want these application menu links in the OS masthead).