### PR TITLE
Deprecate "login" strategy

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -138,7 +138,7 @@ spec:
 # Choose "openid" to enable OpenID connect based authentication. Your cluster is required to
 #  be configured to accept the tokens issued by your IdP. There are additional required
 #  configurations for this strategy. See below for the additional OpenID configuration section.
-# When empty, its value will default to "openshift" on OpenShift and "login" on Kubernetes.
+# When empty, its value will default to "openshift" on OpenShift and "token" on Kubernetes.
 #    ---
 #    strategy: ""
 #    ---

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -322,7 +322,7 @@
 
 - name: Set default auth strategy based on cluster type
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'auth': {'strategy': 'openshift' if is_openshift else 'login'}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'auth': {'strategy': 'openshift' if is_openshift else 'token'}}, recursive=True) }}"
   when:
   - kiali_vars.auth.strategy == ""
 


### PR DESCRIPTION
This is moving from "login" to "token" as the default strategy for
non-OpenShift clusters.

A message about what can be used to log in to Kiali is also added after
Kiali is deployed.

Also "openid" is added to the list of valid strategies.

Part of kiali/kiali#2862