### PR TITLE
Add an OpenID molecule test

### DIFF
--- a/deploy/kiali/kiali_cr_dev.yaml
+++ b/deploy/kiali/kiali_cr_dev.yaml
@@ -9,6 +9,12 @@ spec:
   version: "${KIALI_CR_SPEC_VERSION}"
   auth:
     strategy: $AUTH_STRATEGY
+#    openid:
+#      client_id: kiali-app
+#      insecure_skip_verify_tls: true
+#      issuer_uri: "https://192-168-99-100.nip.io:32000"
+#      username_claim: email
+
   deployment:
     accessible_namespaces: [ "${ACCESSIBLE_NAMESPACES}" ]
     image_name: $KIALI_IMAGE_NAME

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -1,0 +1,22 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+spec:
+  version: default
+  istio_namespace: {{ istio.control_plane_namespace }}
+  auth:
+    strategy: openid
+    openid:
+      client_id: {{ openid.client_id }}
+      insecure_skip_verify_tls: true
+      issuer_uri: {{ openid.issuer_uri }}
+      username_claim: {{ openid.username_claim }}
+  deployment:
+    namespace: {{ kiali.install_namespace }}
+    image_name: {{ kiali.image_name }}
+    image_pull_policy: {{ kiali.image_pull_policy }}
+    image_version: {{ kiali.image_version }}
+    accessible_namespaces: {{ kiali.accessible_namespaces }}
+    service_type: NodePort
+    verbose_mode: "5"

--- a/molecule/openid-test/molecule.yml
+++ b/molecule/openid-test/molecule.yml
@@ -1,0 +1,47 @@
+---
+dependency:
+  name: galaxy
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+  inventory:
+    group_vars:
+      all:
+        kiali_operator_assets_path : "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/openid-test/kiali-cr.yaml"
+        cr_namespace: kiali-operator
+        istio:
+          control_plane_namespace: istio-system
+        openid:
+          username: admin@example.com
+          password: password
+          client_id: kiali-app
+          issuer_uri: "https://{{ lookup('env', 'MOLECULE_MINIKUBE_IP') | replace('.','-') }}.nip.io:32000"
+          username_claim: email
+        kiali:
+          install_namespace: istio-system
+          accessible_namespaces: ["**"]
+          operator_namespace: kiali-operator
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: kiali-operator
+          operator_clusterrolebindings: "- clusterrolebindings"
+          operator_clusterroles: "- clusterroles"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_pull_policy: Always
+scenario:
+  name: openid-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/molecule/openid-test/playbook.yml
+++ b/molecule/openid-test/playbook.yml
@@ -1,0 +1,181 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # Wait for Kiali to be running and accepting requests.
+  # This has the added benefit of confirming that we can access a
+  # Kiali endpoint that does not need authentication.
+  - import_tasks: ../common/wait_for_kiali_running.yml
+
+  - name: Make sure the test set the strategy to openid
+    assert:
+      that:
+      - kiali_configmap.auth.strategy == "openid"
+
+  - name: Assert that we can access Kiali console login screen that does not need authentication
+    uri:
+      url: "{{ kiali_base_url }}/console"
+      validate_certs: false
+
+  - name: Try to access Kiali api endpoint that requires authentication (should return 401)
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces"
+      status_code: 401
+      validate_certs: false
+
+  - name: Attempt login with invalid credentials
+    uri:
+      url: "{{ kiali_base_url }}/api/authenticate"
+      user: invalid
+      password: invalid
+      status_code: 401
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+
+  - name: Attempt login with good credentials but not logging in via OpenID
+    uri:
+      url: "{{ kiali_base_url }}/api/authenticate"
+      user: "{{ openid.username }}"
+      password: "{{ openid.password }}"
+      status_code: 401
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+
+  # BEGIN A SUCCESSFUL OPENID LOGIN PROCESS
+
+  - name: Get auth info from Kiali Server
+    uri:
+      url: "{{ kiali_base_url }}/api/auth/info"
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+  - name: Assert that the auth info is for openid
+    assert:
+      that:
+      - kiali_output.json.strategy == "openid"
+      - kiali_output.json.authorizationEndpoint is search("openid_redirect")
+      - kiali_output.json.sessionInfo.keys() | length == 0
+  - name: Set the auth endpoint we are being redirected to and change it to use http because an error occurs later if using https
+    set_fact:
+      auth_endpoint: "{{ kiali_output.json.authorizationEndpoint | regex_replace('^http[s]?:(.*)','http:\\1')  }}"
+
+  - name: Send request to auth endpoint
+    uri:
+      url: "{{ auth_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 302
+    register: kiali_output
+  - name: Assert that the auth endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.location is defined
+      - kiali_output.set_cookie is defined
+      - kiali_output.set_cookie is search("kiali-token-openid-nonce")
+  - set_fact:
+      auth2_endpoint: "{{ kiali_output.location }}"
+      nonce_cookie: "{{ kiali_output.set_cookie | regex_replace('.*(kiali-token-openid-nonce=[^;]+).*', '\\1') }}"
+
+  - name: Send request to auth2 endpoint which will redirect to the OpenID login screen
+    uri:
+      url: "{{ auth2_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: all
+      status_code: 200
+    register: kiali_output
+  - name: Assert that the auth2 endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.url is defined
+  - set_fact:
+      openid_login_endpoint: "{{ kiali_output.url }}"
+
+  - name: Send login post request to openid login screen endpoint
+    uri:
+      url: "{{ openid_login_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 303
+      method: POST
+      body_format: form-urlencoded
+      body:
+        login: "{{ openid.username }}"
+        password: "{{ openid.password }}"
+    register: kiali_output
+  - name: Assert that the login endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.location is defined
+  - name: There is a weird problem where the location has two '?' portions - I think its a bug. So build the URL that we know is good.
+    set_fact:
+      openid_approval_endpoint: "{{ kiali_output.url | regex_replace('auth/local','approval')  }}"
+
+  - name: Send request to OpenID approval endpoint
+    uri:
+      url: "{{ openid_approval_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 303
+    register: kiali_output
+  - name: Assert that the OpenID approval endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.location is defined
+  - set_fact:
+      final_kiali_endpoint: "{{ kiali_output.location }}"
+      access_token: "{{ kiali_output.location | regex_replace('.*access_token=([^&]+).*', '\\1') }}"
+      expires_in: "{{ kiali_output.location | regex_replace('.*expires_in=([^&]+).*', '\\1') }}"
+      id_token: "{{ kiali_output.location | regex_replace('.*id_token=([^&]+).*', '\\1') }}"
+      token_type: "{{ kiali_output.location | regex_replace('.*token_type=([^&]+).*', '\\1') }}"
+
+  - name: Send request to final Kiali endpoint with a valid session
+    uri:
+      url: "{{ final_kiali_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: all
+      status_code: 200
+    register: kiali_output
+
+  - name: With the login cookie and nonce code, make a request to the kiali auth endpoint
+    uri:
+      url: "{{ kiali_base_url }}/api/authenticate"
+      headers:
+        Cookie: "{{ nonce_cookie }}"
+      method: POST
+      body_format: form-urlencoded
+      body:
+        access_token: "{{ access_token }}"
+        expires_in: "{{ expires_in }}"
+        id_token: "{{ id_token }}"
+        token_type: "{{ token_type }}"
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+
+  - set_fact:
+      new_kiali_cookie: "{{ kiali_output.set_cookie | regex_replace('.*(kiali-token=[^;]+).*', '\\1') }}"
+
+  - name: With the updated login cookie, make a request that requires authentication (should now return 200)
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces"
+      headers:
+        Cookie: "{{ new_kiali_cookie }}"
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+  - name: Assert that we were able to get the list of namespaces
+    assert:
+      that:
+      - kiali_output.json | length > 0


### PR DESCRIPTION
Fixes: https://github.com/kiali/kiali/issues/2882
This test requires a Minikube cluster to be running and configured with an OpenID user of "admin@example.com" and password of "password" and that user has permissions to see at least one namespace.

It requires an issuer URI at the minikube IP on .nip.io domain on port 32000. e.g. https://192-168-99-100.nip.io:320000

This works if you run the hack script and grant access like this:

```
hack/k8s-minikube.sh --dex-enabled=true start
kubectl create clusterrolebinding openid-test --clusterrole=cluster-admin --user="admin@example.com"
```

You can run the test like this:

```
CLUSTER_TYPE=minikube MOLECULE_SCENARIO="openid-test" make molecule-test
```