### PR TITLE
prepare community manifest PRs script should default to a path relative to the kiali-operator repo

### DIFF
--- a/manifests/prepare-community-prs.sh
+++ b/manifests/prepare-community-prs.sh
@@ -9,7 +9,7 @@
 ################################################
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
-DEFAULT_GIT_REPO=${SCRIPT_DIR}/../../../../../../../../community-operators
+DEFAULT_GIT_REPO=${SCRIPT_DIR}/../../../community-operators
 GIT_REPO=${DEFAULT_GIT_REPO}
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
missed this when we created the separate kiali-operator repo.