### PR TITLE
log start and stop time messages as well as playbook duration time

### DIFF
--- a/playbooks/kiali-deploy.yml
+++ b/playbooks/kiali-deploy.yml
@@ -2,6 +2,13 @@
   gather_facts: no
   tasks:
 
+  - debug:
+      msg: KIALI RECONCILIATION START
+
+  - name: Playbook start time
+    set_fact:
+      playbook_time_start: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
   - name: Determine the default playbook
     include_vars:
       file: "default-playbook.yml"
@@ -41,3 +48,16 @@
   - name: Run the version-specific deploy role
     include_role:
       name: "{{ version }}/kiali-deploy"
+
+  - name: Playbook end time
+    set_fact:
+      playbook_time_end: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
+  - name: Log reconciliation processing time
+    ignore_errors: yes
+    debug:
+      msg: "Processing time: [{{ (playbook_time_end|to_datetime - playbook_time_start|to_datetime).total_seconds() | int }}] seconds"
+
+  - debug:
+      msg: KIALI RECONCILIATION IS DONE.
+

--- a/playbooks/kiali-remove.yml
+++ b/playbooks/kiali-remove.yml
@@ -1,10 +1,36 @@
 - hosts: localhost
   gather_facts: no
   tasks:
-  - name: Determine the default playbook
+
+  - ignore_errors: yes
+    debug:
+      msg: REMOVING KIALI
+
+  - ignore_errors: yes
+    name: Playbook start time
+    set_fact:
+      playbook_time_start: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
+  - ignore_errors: yes
+    name: Determine the default playbook
     include_vars:
       file: "default-playbook.yml"
       name: default_playbook
 
-  - include_role:
+  - ignore_errors: yes
+    include_role:
       name: "{{ version | default(default_playbook.playbook) }}/kiali-remove"
+
+  - ignore_errors: yes
+    name: Playbook end time
+    set_fact:
+      playbook_time_end: "{{ '%Y-%m-%d %H:%M:%S' | strftime }}"
+
+  - ignore_errors: yes
+    name: Log removal processing time
+    debug:
+      msg: "Processing time: [{{ (playbook_time_end|to_datetime - playbook_time_start|to_datetime).total_seconds() | int }}] seconds"
+
+  - ignore_errors: yes
+    debug:
+      msg: KIALI REMOVAL IS DONE.

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -1,6 +1,3 @@
-- debug:
-    msg: "KIALI RECONCILIATION START: {{ lookup('pipe','date') }}"
-
 - name: Get information about the cluster
   set_fact:
     api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
@@ -773,7 +770,3 @@
   - processed_resources.configmap is defined
   - processed_resources.configmap.changed == True
   - processed_resources.configmap.method == "patch"
-
-- name: Kiali operator has completed all processing for installation.
-  debug:
-    msg: "KIALI RECONCILIATION FINISHED: {{ lookup('pipe','date') }}"

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -5,10 +5,6 @@
 # the user will never be able to delete the Kiali CR - in fact, the delete will hang indefinitely
 # and the user will need to do an ugly hack to fix it.
 
-- ignore_errors: yes
-  debug:
-    msg: REMOVING KIALI
-
 - name: Get information about the cluster
   ignore_errors: yes
   set_fact:
@@ -166,8 +162,3 @@
   - "{{ query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace)}}"
   loop_control:
     loop_var: os_item
-
-- name: Kiali operator has completed all processing for removal.
-  ignore_errors: yes
-  debug:
-    msg: "KIALI REMOVAL IS DONE."


### PR DESCRIPTION
I was working on the reconcile loop research and realized this would be good to put in the operator now (regardless of the results of that work).

This puts the start/stop log message at the very start and stop of the full playbook (whereas before it was only at the time the main role was invoked. 

This also explicitly logs start and stop time messages (so you know when the reconciliation happened and when it finished).

Finally, at the end of the playbook, it logs the duration of time it took for the playbook to fully complete (so we can see how long each reconciliation run actually takes).
