### PR TITLE
Use new OpenShift interface for service serving certificates

### DIFF
--- a/deploy/kiali/kiali_cr_dev_servicemesh.yaml
+++ b/deploy/kiali/kiali_cr_dev_servicemesh.yaml
@@ -21,7 +21,6 @@ spec:
   external_services:
     grafana:
       auth:
-        ca_file: /kiali-configuration/service-ca.crt
         password: ${KIALI_EXTERNAL_SERVICES_PASSWORD}
         type: basic
         use_kiali_token: false
@@ -31,7 +30,6 @@ spec:
       url: https://grafana-${NAMESPACE}.${ROUTER_HOSTNAME}
     prometheus:
       auth:
-        ca_file: /kiali-configuration/service-ca.crt
         password: ${KIALI_EXTERNAL_SERVICES_PASSWORD}
         type: basic
         use_kiali_token: false
@@ -39,7 +37,6 @@ spec:
       url: https://prometheus.${NAMESPACE}.svc:9090
     tracing:
       auth:
-        ca_file: /kiali-configuration/service-ca.crt
         password: ${KIALI_EXTERNAL_SERVICES_PASSWORD}
         type: basic
         use_kiali_token: false

--- a/deploy/kiali/kiali_cr_dev_servicemesh.yaml
+++ b/deploy/kiali/kiali_cr_dev_servicemesh.yaml
@@ -21,7 +21,7 @@ spec:
   external_services:
     grafana:
       auth:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        ca_file: /kiali-configuration/service-ca.crt
         password: ${KIALI_EXTERNAL_SERVICES_PASSWORD}
         type: basic
         use_kiali_token: false
@@ -31,7 +31,7 @@ spec:
       url: https://grafana-${NAMESPACE}.${ROUTER_HOSTNAME}
     prometheus:
       auth:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        ca_file: /kiali-configuration/service-ca.crt
         password: ${KIALI_EXTERNAL_SERVICES_PASSWORD}
         type: basic
         use_kiali_token: false
@@ -39,7 +39,7 @@ spec:
       url: https://prometheus.${NAMESPACE}.svc:9090
     tracing:
       auth:
-        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        ca_file: /kiali-configuration/service-ca.crt
         password: ${KIALI_EXTERNAL_SERVICES_PASSWORD}
         type: basic
         use_kiali_token: false

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -328,24 +328,24 @@
 
 - name: Use OpenShift service CA file for Grafana
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'auth': {'ca_file': '/kiali-configuration/service-ca.crt'}}}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
   when:
   - is_openshift == True
-  - kiali_vars.external_services.grafana.auth.ca_file is not defined or kiali_vars.external_services.grafana.auth.ca_file != ''
+  - kiali_vars.external_services.grafana.auth.ca_file is not defined or kiali_vars.external_services.grafana.auth.ca_file == ''
 
 - name: Use OpenShift service CA file for Prometheus
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'auth': {'ca_file': '/kiali-configuration/service-ca.crt'}}}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
   when:
   - is_openshift == True
-  - kiali_vars.external_services.prometheus.auth.ca_file is not defined or kiali_vars.external_services.prometheus.auth.ca_file != ''
+  - kiali_vars.external_services.prometheus.auth.ca_file is not defined or kiali_vars.external_services.prometheus.auth.ca_file == ''
 
 - name: Use OpenShift service CA file for Tracing
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'auth': {'ca_file': '/kiali-configuration/service-ca.crt'}}}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
   when:
   - is_openshift == True
-  - kiali_vars.external_services.tracing.auth.ca_file is not defined or kiali_vars.external_services.tracing.auth.ca_file != ''+
+  - kiali_vars.external_services.tracing.auth.ca_file is not defined or kiali_vars.external_services.tracing.auth.ca_file == ''
 
 # Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
 - debug:

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -326,6 +326,27 @@
   when:
   - kiali_vars.auth.strategy == ""
 
+- name: Use OpenShift service CA file for Grafana
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'auth': {'ca_file': '/kiali-configuration/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.grafana.auth.ca_file is not defined or kiali_vars.external_services.grafana.auth.ca_file != ''
+
+- name: Use OpenShift service CA file for Prometheus
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'auth': {'ca_file': '/kiali-configuration/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.prometheus.auth.ca_file is not defined or kiali_vars.external_services.prometheus.auth.ca_file != ''
+
+- name: Use OpenShift service CA file for Tracing
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'auth': {'ca_file': '/kiali-configuration/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.tracing.auth.ca_file is not defined or kiali_vars.external_services.tracing.auth.ca_file != ''+
+
 # Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
 - debug:
     msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -6,6 +6,7 @@
   loop:
   - serviceaccount
   - configmap
+  - cabundle
   - "{{ 'role-viewer' if kiali_vars.deployment.view_only_mode == True else 'role' }}"
   - rolebinding
   - deployment

--- a/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
@@ -1,11 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali
+  name: kiali-cabundle
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
-data:
-  config.yaml: |
-    {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: true

--- a/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
@@ -7,4 +7,4 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
-    service.beta.openshift.io/inject-cabundle: true
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/default/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/configmap.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: true
 data:
   config.yaml: |
     {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -99,6 +99,8 @@ spec:
           mountPath: "/kiali-cert"
         - name: kiali-secret
           mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
 {% if kiali_vars.deployment.resources|length > 0 %}
         resources:
           {{ kiali_vars.deployment.resources | to_nice_yaml(indent=0) | trim | indent(10) }}
@@ -119,6 +121,9 @@ spec:
         secret:
           secretName: {{ kiali_vars.deployment.secret_name }}
           optional: true
+      - name: kiali-cabundle
+        configMap:
+          name: kiali-cabundle
 {% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
       affinity:
 {% if kiali_vars.deployment.affinity.node|length > 0 %}

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
+    service.beta.openshift.io/serving-cert-secret-name: kiali-cert-secret
     kiali.io/api-spec: https://kiali.io/api
     kiali.io/api-type: rest
 {% if kiali_vars.deployment.service_annotations|length > 0 %}

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -164,6 +164,7 @@
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='OAuthClient', resource_name='kiali-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name='kiali', api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
   - "{{ query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace)}}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali-cabundle', api_version='v1') }}"
   loop_control:
     loop_var: os_item
 

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -163,8 +163,8 @@
   with_items:
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='OAuthClient', resource_name='kiali-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name='kiali', api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace)}}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali-cabundle', api_version='v1') }}"
+  - "{{ query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace) if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali-cabundle', api_version='v1') if is_openshift == True else [] }}"
   loop_control:
     loop_var: os_item
 


### PR DESCRIPTION
OpenShift is now requiring new annotations for the service serving certificates interface. This is doing the needed changes to use the new interface.

Part of kiali/kiali#2917.