### PR TITLE
Cluster roles/bindings have no namespace - remove the superfluous namespace settings

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -633,8 +633,6 @@
   - no_longer_accessible_namespaces is defined
 
 - name: Delete Kiali cluster roles if no longer given special access to all namespaces
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_accessible_namespaces is defined
@@ -653,8 +651,6 @@
   - '"**" not in current_accessible_namespaces'
 
 - name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_view_only_mode is defined

--- a/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
@@ -4,7 +4,6 @@
     state: absent
     api_version: "{{ k8s_item.apiVersion }}"
     kind: "{{ k8s_item.kind }}"
-    namespace: "{{ role_namespace }}"
     name: "{{ k8s_item.metadata.name }}"
   register: delete_result
   until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
@@ -12,15 +11,14 @@
   delay: 10
   when:
   - is_openshift == True or is_k8s == True
-  - role_namespace is defined
   - k8s_item is defined
   - k8s_item.apiVersion is defined
   - k8s_item.kind is defined
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -94,8 +94,6 @@
 
 - name: Delete Kiali cluster roles
   ignore_errors: yes
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - is_openshift == True or is_k8s == True

--- a/roles/default/kiali-remove/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-remove/tasks/remove-clusterroles.yml
@@ -4,7 +4,6 @@
     state: absent
     api_version: "{{ k8s_item.apiVersion }}"
     kind: "{{ k8s_item.kind }}"
-    namespace: "{{ role_namespace }}"
     name: "{{ k8s_item.metadata.name }}"
   register: delete_result
   until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
@@ -12,15 +11,14 @@
   delay: 10
   when:
   - is_openshift == True or is_k8s == True
-  - role_namespace is defined
   - k8s_item is defined
   - k8s_item.apiVersion is defined
   - k8s_item.kind is defined
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/v1.0/kiali-deploy/tasks/main.yml
+++ b/roles/v1.0/kiali-deploy/tasks/main.yml
@@ -325,8 +325,6 @@
   - no_longer_accessible_namespaces is defined
 
 - name: Delete Kiali cluster roles if no longer given special access to all namespaces
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_accessible_namespaces is defined
@@ -345,8 +343,6 @@
   - '"**" not in current_accessible_namespaces'
 
 - name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_view_only_mode is defined

--- a/roles/v1.0/kiali-remove/tasks/main.yml
+++ b/roles/v1.0/kiali-remove/tasks/main.yml
@@ -98,8 +98,6 @@
 
 - name: Delete Kiali cluster roles
   ignore_errors: yes
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - is_openshift == True or is_k8s == True

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -557,8 +557,6 @@
   - no_longer_accessible_namespaces is defined
 
 - name: Delete Kiali cluster roles if no longer given special access to all namespaces
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_accessible_namespaces is defined
@@ -577,8 +575,6 @@
   - '"**" not in current_accessible_namespaces'
 
 - name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_view_only_mode is defined

--- a/roles/v1.12/kiali-remove/tasks/main.yml
+++ b/roles/v1.12/kiali-remove/tasks/main.yml
@@ -98,8 +98,6 @@
 
 - name: Delete Kiali cluster roles
   ignore_errors: yes
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - is_openshift == True or is_k8s == True


### PR DESCRIPTION
We should clean this up because (a) it doesn't make sense and (b) this may cause errors in the future.

fixes: https://github.com/kiali/kiali/issues/2941