### PR TITLE
Remove resources properly when no deployment.namespace is in the CR

### DIFF
--- a/molecule/default-namespace-test/playbook.yml
+++ b/molecule/default-namespace-test/playbook.yml
@@ -6,3 +6,39 @@
   tasks:
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
+
+  - name: Get some Kiali resources that we know should have been created
+    set_fact:
+      doomed_cm: "{{ query('k8s', kind='ConfigMap', resource_name='kiali', namespace=cr_namespace, api_version='v1') }}"
+      doomed_rb: "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+      doomed_role: "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+
+  - assert:
+      that:
+      - doomed_cm | length == 1
+      - doomed_rb | length == 1
+      - doomed_role | length == 1
+
+  # Remove the CR and make sure Kiali gets cleaned up
+  # This shows that when the CR does not have deployment.namespace that the remove role still works
+  - name: Remove the Kiali CR so we can see the operator purge the doomed resources
+    k8s:
+      state: absent
+      api_version: kiali.io/v1alpha1
+      kind: Kiali
+      namespace: "{{ cr_namespace }}"
+      name: "{{ custom_resource.metadata.name }}"
+      wait: yes
+      wait_timeout: 600
+
+  - name: Get some Kiali resources that we know were created but should now be deleted
+    set_fact:
+      doomed_cm: "{{ query('k8s', kind='ConfigMap', resource_name='kiali', namespace=cr_namespace, api_version='v1') }}"
+      doomed_rb: "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+      doomed_role: "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+
+  - assert:
+      that:
+      - doomed_cm | length == 0
+      - doomed_rb | length == 0
+      - doomed_role | length == 0

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -12,6 +12,7 @@
       namespace: "{{ cr_namespace }}"
       name: "{{ custom_resource.metadata.name }}"
       wait: yes
+      wait_timeout: 600
 
   - name: Produce Files with Correct Parameters
     shell: " {{ item }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -633,8 +633,6 @@
   - no_longer_accessible_namespaces is defined
 
 - name: Delete Kiali cluster roles if no longer given special access to all namespaces
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_accessible_namespaces is defined
@@ -653,8 +651,6 @@
   - '"**" not in current_accessible_namespaces'
 
 - name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_view_only_mode is defined

--- a/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
@@ -4,7 +4,6 @@
     state: absent
     api_version: "{{ k8s_item.apiVersion }}"
     kind: "{{ k8s_item.kind }}"
-    namespace: "{{ role_namespace }}"
     name: "{{ k8s_item.metadata.name }}"
   register: delete_result
   until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
@@ -12,15 +11,14 @@
   delay: 10
   when:
   - is_openshift == True or is_k8s == True
-  - role_namespace is defined
   - k8s_item is defined
   - k8s_item.apiVersion is defined
   - k8s_item.kind is defined
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/default/kiali-remove/defaults/main.yml
+++ b/roles/default/kiali-remove/defaults/main.yml
@@ -1,7 +1,6 @@
 kiali_defaults:
   deployment:
     accessible_namespaces: []
-    namespace: "istio-system"
 
 # Will be auto-detected, but for debugging purposes you can force one of these to true
 is_k8s: false

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -94,8 +94,6 @@
 
 - name: Delete Kiali cluster roles
   ignore_errors: yes
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - is_openshift == True or is_k8s == True

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -38,6 +38,14 @@
     msg: "{{ msg.split('\n') }}"
   tags: test
 
+- name: Set default deployment namespace to the same namespace where the CR lives
+  vars:
+    current_cr: "{{ _kiali_io_kiali }}"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
+
 # When the Operator installed Kiali, the configmap has accessible_namespaces set.
 # There are no regexes in the configmap; they are all full namespace names.
 # NOTE: there is a special value of accessible_namespaces of two asterisks ("**")

--- a/roles/default/kiali-remove/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-remove/tasks/remove-clusterroles.yml
@@ -4,7 +4,6 @@
     state: absent
     api_version: "{{ k8s_item.apiVersion }}"
     kind: "{{ k8s_item.kind }}"
-    namespace: "{{ role_namespace }}"
     name: "{{ k8s_item.metadata.name }}"
   register: delete_result
   until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
@@ -12,15 +11,14 @@
   delay: 10
   when:
   - is_openshift == True or is_k8s == True
-  - role_namespace is defined
   - k8s_item is defined
   - k8s_item.apiVersion is defined
   - k8s_item.kind is defined
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=role_namespace, kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/v1.0/kiali-deploy/tasks/main.yml
+++ b/roles/v1.0/kiali-deploy/tasks/main.yml
@@ -325,8 +325,6 @@
   - no_longer_accessible_namespaces is defined
 
 - name: Delete Kiali cluster roles if no longer given special access to all namespaces
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_accessible_namespaces is defined
@@ -345,8 +343,6 @@
   - '"**" not in current_accessible_namespaces'
 
 - name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_view_only_mode is defined

--- a/roles/v1.0/kiali-remove/tasks/main.yml
+++ b/roles/v1.0/kiali-remove/tasks/main.yml
@@ -98,8 +98,6 @@
 
 - name: Delete Kiali cluster roles
   ignore_errors: yes
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - is_openshift == True or is_k8s == True

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -557,8 +557,6 @@
   - no_longer_accessible_namespaces is defined
 
 - name: Delete Kiali cluster roles if no longer given special access to all namespaces
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_accessible_namespaces is defined
@@ -577,8 +575,6 @@
   - '"**" not in current_accessible_namespaces'
 
 - name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - current_view_only_mode is defined

--- a/roles/v1.12/kiali-remove/tasks/main.yml
+++ b/roles/v1.12/kiali-remove/tasks/main.yml
@@ -98,8 +98,6 @@
 
 - name: Delete Kiali cluster roles
   ignore_errors: yes
-  vars:
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
   include_tasks: remove-clusterroles.yml
   when:
   - is_openshift == True or is_k8s == True


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/2942

This PR includes some molecule testing to confirm it is working.

This should be merged after this PR: https://github.com/kiali/kiali-operator/pull/59