### PR TITLE
enable dependent resource watching

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,3 +3,7 @@ FROM quay.io/operator-framework/ansible-operator:v0.17.0
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
 COPY watches.yaml ${HOME}/watches.yaml
+
+COPY requirements.yml ${HOME}/requirements.yml
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
+ && chmod -R ug+rwx ${HOME}/.ansible

--- a/deploy/deploy-kiali-operator.sh
+++ b/deploy/deploy-kiali-operator.sh
@@ -120,8 +120,15 @@
 #    Default: "false"
 #
 # OPERATOR_WATCH_NAMESPACE
-#    The namespace in which the operator looks for the Kiali CR.
-#    Default: The configured OPERATOR_NAMESPACE
+#    The namespace in which the operator looks for a Kiali CR. When a Kiali CR is touched (i.e. created,
+#    modified, or deleted) in a watched namespace, the operator will perform all necessary tasks in order
+#    to deploy Kiali with the configuration specified in the Kiali CR (this is called "reconciling").
+#    If specified as "**" (or, alternatively, literally two double-quotes "") then the operator will
+#    watch all namespaces. Note that if you specify a specific watch namespace, and a user changes
+#    some of the Kiali resources that exist outside of that watched namespace (e.g. deletes or modifies
+#    the Kiali Deployment) the operator will be unable to reconcile those changes (e.g. it will not
+#    be able to redeploy the Deployment resource) unless and until the Kiali CR is touched again.
+#    Default: ""
 #
 # -----------
 # Environment variables that affect Kiali installation:
@@ -428,8 +435,15 @@ Valid options for the operator installation:
       operator will be unable to do so.
       Default: "false"
   -own|--operator-watch-namespace
-      The namespace in which the operator looks for the Kiali CR.
-      Default: The configured operator namespace (-on)
+      The namespace in which the operator looks for a Kiali CR. When a Kiali CR is touched (i.e. created,
+      modified, or deleted) in a watched namespace, the operator will perform all necessary tasks in order
+      to deploy Kiali with the configuration specified in the Kiali CR (this is called "reconciling").
+      If specified as "**" (or, alternatively, literally two double-quotes "") then the operator will
+      watch all namespaces. Note that if you specify a specific watch namespace, and a user changes
+      some of the Kiali resources that exist outside of that watched namespace (e.g. deletes or modifies
+      the Kiali Deployment) the operator will be unable to reconcile those changes (e.g. it will not
+      be able to redeploy the Deployment resource) unless and until the Kiali CR is touched again.
+      Default: ""
 
 Valid options for Kiali installation (if Kiali is to be installed):
   -an|--accessible-namespaces
@@ -569,7 +583,7 @@ export OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kiali-operator}"
 export OPERATOR_SKIP_WAIT="${OPERATOR_SKIP_WAIT:-false}"
 export OPERATOR_VERSION_LABEL="${OPERATOR_VERSION_LABEL:-$OPERATOR_IMAGE_VERSION}"
 export OPERATOR_VIEW_ONLY_MODE="${OPERATOR_VIEW_ONLY_MODE:-false}"
-export OPERATOR_WATCH_NAMESPACE="${OPERATOR_WATCH_NAMESPACE:-$OPERATOR_NAMESPACE}"
+export OPERATOR_WATCH_NAMESPACE="${OPERATOR_WATCH_NAMESPACE:-\"\"}"
 export OPERATOR_ROLE_CLUSTERROLEBINDINGS="# The operator does not have permission to manage cluster role bindings"
 export OPERATOR_ROLE_CLUSTERROLES="# The operator does not have permission to manage cluster roles"
 export OPERATOR_ROLE_CREATE="# The operator does not have permission to create"

--- a/deploy/merge-operator-yaml.sh
+++ b/deploy/merge-operator-yaml.sh
@@ -90,8 +90,8 @@ $0 [option...]
       The value of this label is determined by this setting.
       Default: The value given for the operator image version
   -own|--operator-watch-namespace
-      The namespace in which the operator looks for the Kiali CR.
-      Default: The configured operator namespace (-on)
+      The namespace in which the operator looks for the Kiali CR. If '""' then watch all namespaces.
+      Default: ""
 
 HELPMSG
       exit 1
@@ -109,7 +109,7 @@ export OPERATOR_IMAGE_NAME="${OPERATOR_IMAGE_NAME:-quay.io/kiali/kiali-operator}
 export OPERATOR_IMAGE_VERSION="${OPERATOR_IMAGE_VERSION:-latest}"
 export OPERATOR_IMAGE_PULL_POLICY="${OPERATOR_IMAGE_PULL_POLICY:-IfNotPresent}"
 export OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kiali-operator}"
-export OPERATOR_WATCH_NAMESPACE="${OPERATOR_WATCH_NAMESPACE:-${OPERATOR_NAMESPACE}}"
+export OPERATOR_WATCH_NAMESPACE="${OPERATOR_WATCH_NAMESPACE:-\"\"}"
 
 # If version label is not specified, set it to image version; but if
 # image version is "latest" the version label will be set to "master".

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+- community.kubernetes
+- operator_sdk.util

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -801,3 +801,8 @@
   - processed_resources.configmap is defined
   - processed_resources.configmap.changed == True
   - processed_resources.configmap.method == "patch"
+
+- include_tasks: update-status.yml
+  vars:
+    status_vars:
+      accessibleNamespaces: "{{ kiali_vars.deployment.accessible_namespaces }}"

--- a/roles/default/kiali-deploy/tasks/update-status.yml
+++ b/roles/default/kiali-deploy/tasks/update-status.yml
@@ -1,0 +1,7 @@
+- operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars }}"
+  ignore_errors: yes

--- a/watches.yaml
+++ b/watches.yaml
@@ -4,7 +4,8 @@
   kind: Kiali
   playbook: /opt/ansible/playbooks/kiali-deploy.yml
   reconcilePeriod: 0
-  watchDependentResources: False
+  watchDependentResources: True
+  watchClusterScopedResources: True
   finalizer:
     name: finalizer.kiali
     playbook: /opt/ansible/playbooks/kiali-remove.yml


### PR DESCRIPTION
the main fix for https://github.com/kiali/kiali/issues/2889

This enables dependent resource watching - if any resource the operator creates is later touched by a user (e.g. modified or deleted) then the operator's playbook will immediately be triggered again, presumably to "undo" any unauthorized modifications to Kiali. For example, if someone deletes Kiali's ConfigMap, this will ensure the operator will re-create it again.

Here's the thought process for why this method was chosen: https://github.com/kiali/kiali/issues/2889#issuecomment-655699840

There is an associated backend change that needs to be merged also - see https://github.com/kiali/kiali/pull/2976