### PR TITLE
be able to tell what dashboards to create

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -237,6 +237,19 @@ spec:
 #      pod: {}
 #      pod_anti: {}
 #
+# Names of the out-of-box custom monitoring dashboards that are to be installed.
+# The custom monitoring dashboards are defined in yaml files located within the operator.
+# Consult the operator templates for the custom monitoring dashboard yaml files available.
+# For example, see this for the current list of yaml files available:
+# https://github.com/kiali/kiali-operator/tree/master/roles/default/kiali-deploy/templates/dashboards
+# These settings will determine the additional metric graphs that you will see within the Kiali UI.
+# You can specify an includes and excludes list, the excludes list takes precedence.
+# Each list can have fileglob wildcard characters '*' and '?' for file matching.
+#    ---
+#    custom_dashboards:
+#      excludes: ['']
+#      includes: ['*']
+#
 # Determines which Kiali image to download and install.
 # If you set this to a specific name (i.e. you do not leave it as the default empty string),
 # you must make sure that image is supported by the operator.

--- a/dev-hosts
+++ b/dev-hosts
@@ -21,3 +21,10 @@ all:
     # can run with this empty (but it has to be defined).
 
     _kiali_io_kiali: {}
+
+    # The Operator SDK creates a "meta" variable that contains the
+    # name and namespace of the CR. Most times you can just
+    # run with these defaults
+    meta:
+      name: kiali
+      namespace: kiali-operator

--- a/molecule/accessible-namespaces-test/kiali-cr.yaml
+++ b/molecule/accessible-namespaces-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    custom_dashboards:
+      includes: []
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
+++ b/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    custom_dashboards:
+      includes: []
     namespace: {{ kiali.install_namespace }}
     # Note that we start with no affinity or tolerations or resources sections,
     # so the first time through we just pick up the defaults.

--- a/molecule/config-values-test/converge.yml
+++ b/molecule/config-values-test/converge.yml
@@ -9,17 +9,68 @@
 
   # This test will change some config settings to make sure things work like we expect.
   # We will add additional tasks and asserts in the future to test other config changes.
+  # We load in the current kiali CR and then alter it with new config.
+
+  - set_fact:
+      current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: The current Kiali CR to be used as the base of the test
+    debug:
+      msg: "{{ current_kiali_cr }}"
+
+  # Some sanity checks - check some default values
+
+  - name: Make sure the expected dashboards are installed - by default, all of them are deployed
+    vars:
+      custom_dashboards: "{{ query('k8s', namespace=kiali.install_namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
+    assert:
+      that:
+      - custom_dashboards | length == 20
+      fail_msg: "Must have 20 custom_dashboards: {{ custom_dashboards }}"
 
   # Make sure version label is truncated to the k8s maximum 63 chars and must start/end with alphanum char
-  - import_tasks: set-version-label.yml
+  - name: Set new deployment.version_label in current Kiali CR
     vars:
       new_version_label: "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee12345678901234"
+    set_fact:
+      current_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'version_label': new_version_label }}}, recursive=True) }}"
+
+  - name: Define includes and excludes for dashboards to install, ultimately only installing the kiali.yaml dashboard
+    vars:
+      custom_dashboards:
+        includes: [ 'kiali*', 'go.yaml' ]
+        excludes: [ 'go.yaml' ]
+    set_fact:
+      current_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'custom_dashboards': custom_dashboards }}}, recursive=True) }}"
+
+  - name: The new Kiali CR to be tested
+    debug:
+      msg: "{{ current_kiali_cr }}"
+
+  # Deploy the new CR and wait for the CR change to take effect
+
+  - import_tasks: ../common/set-kiali-cr.yml
+    vars:
+      new_kiali_cr: "{{ current_kiali_cr }}"
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
   - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
+
+  # Assert the new config
+
   - name: Make sure version_label was truncated properly
     assert:
       that:
       - kiali_configmap.deployment.version_label == "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee1234567890XXX"
       - "{{ kiali_deployment.resources[0].metadata.labels.version | length == 63 }}"
+
+  - name: Make sure only the expected dashboards are installed
+    vars:
+      custom_dashboards: "{{ query('k8s', namespace=kiali.install_namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
+    assert:
+      that:
+      - custom_dashboards | length == 1
+      - custom_dashboards[0].metadata.name == 'kiali'
+      fail_msg: "Must have 1 custom_dashboard: {{ custom_dashboards }}"
+

--- a/molecule/config-values-test/kiali-cr.yaml
+++ b/molecule/config-values-test/kiali-cr.yaml
@@ -3,18 +3,12 @@ kind: Kiali
 metadata:
   name: kiali
 spec:
+  # this test will try to use as many defaults as we can
   version: default
   istio_namespace: {{ istio.control_plane_namespace }}
-  auth:
-    strategy: {{ kiali.auth_strategy }}
   deployment:
-    custom_dashboards:
-      includes: []
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: NodePort
-    # the operator is only given permission to deploy Kiali in view_only_mode
-    view_only_mode: true

--- a/molecule/config-values-test/molecule.yml
+++ b/molecule/config-values-test/molecule.yml
@@ -20,14 +20,12 @@ provisioner:
     group_vars:
       all:
         kiali_operator_assets_path : "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
-        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/kiali-cr.yaml"
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/config-values-test/kiali-cr.yaml"
         cr_namespace: kiali-operator
         istio:
           control_plane_namespace: istio-system
         kiali:
           install_namespace: istio-system
-          accessible_namespaces: ["**"]
-          auth_strategy: anonymous
           operator_namespace: kiali-operator
           operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"

--- a/molecule/config-values-test/set-version-label.yml
+++ b/molecule/config-values-test/set-version-label.yml
@@ -1,7 +1,0 @@
-- name: Set new deployment.version_label in current Kiali CR
-  vars:
-    current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
-  set_fact:
-    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'version_label': new_version_label }}}, recursive=True) }}"
-
-- import_tasks: ../common/set-kiali-cr.yml

--- a/molecule/default-namespace-test/kiali-cr.yaml
+++ b/molecule/default-namespace-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    custom_dashboards:
+      includes: []
     # For this test, we do not define namespace.
     # It should default to the location where this CR lives
     # namespace:

--- a/molecule/kiali-cr.yaml
+++ b/molecule/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    custom_dashboards:
+      includes: [ 'go.yaml' ]
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/metrics-test/kiali-cr.yaml
+++ b/molecule/metrics-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    custom_dashboards:
+      includes: []
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -15,6 +15,10 @@
       - kiali_configmap.installation_tag == ""
       - kiali_configmap.additional_display_details | length == 1
       - kiali_configmap.auth.ldap.ldap_group_filter == "(cn=%s)"
+      - kiali_configmap.deployment.custom_dashboards.includes | length == 1
+      - kiali_configmap.deployment.custom_dashboards.includes[0] == '*'
+      - kiali_configmap.deployment.custom_dashboards.excludes | length == 1
+      - kiali_configmap.deployment.custom_dashboards.excludes[0] == ''
       - kiali_configmap.deployment.ingress_enabled == True
       - kiali_configmap.deployment.replicas == 1
       - kiali_configmap.deployment.secret_name == "kiali"
@@ -38,3 +42,4 @@
       - kiali_configmap.kubernetes_config.excluded_workloads | length > 0
       - kiali_configmap.login_token.signing_key | length > 0
       - kiali_configmap.server.metrics_port == 9090
+

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -27,6 +27,7 @@ spec:
       node: null
       pod: null
       pod_anti: null
+    custom_dashboards: null
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_pull_secrets: null

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -13,6 +13,8 @@ spec:
       issuer_uri: {{ openid.issuer_uri }}
       username_claim: {{ openid.username_claim }}
   deployment:
+    custom_dashboards:
+      includes: []
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/os-console-links-test/kiali-cr.yaml
+++ b/molecule/os-console-links-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    custom_dashboards:
+      includes: []
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/rolling-restart-test/kiali-cr.yaml
+++ b/molecule/rolling-restart-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    custom_dashboards:
+      includes: []
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -60,6 +60,9 @@ kiali_defaults:
       node: {}
       pod: {}
       pod_anti: {}
+    custom_dashboards:
+      excludes: ['']
+      includes: ['*']
     image_name: ""
     image_pull_policy: "IfNotPresent"
     image_pull_secrets: []

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -755,7 +755,7 @@
   when:
   - is_k8s == True
 
-# The next couple tasks wait for the Monitoring Dashboard CRD to be established, and
+# The next few tasks wait for the Monitoring Dashboard CRD to be established, and
 # then adds the monitoring dashboard resources. If there are any errors here, they
 # are ignored - since the monitoring dashboards are optional, we allow the install to
 # continue even though it means the monitoring dashboards feature will be disabled.
@@ -778,17 +778,58 @@
     msg: "It does not appear you have the Monitoring Dashboard CRD created. Monitoring Dashboards will not be created."
   when:
   - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join != 'True'
+  ignore_errors: yes
+
+- name: Find all Monitoring Dashboards packaged with the operator
+  find:
+    paths: "{{ role_path }}/templates/dashboards"
+  register: monitoring_dashboard_yamls_all_raw
+  ignore_errors: yes
+- set_fact:
+    monitoring_dashboard_yamls_all: "{{ (monitoring_dashboard_yamls_all | default([])) + [ item.path ] }}"
+  loop: "{{ monitoring_dashboard_yamls_all_raw.files }}"
+  when:
+  - monitoring_dashboard_yamls_all_raw is defined
+  - monitoring_dashboard_yamls_all_raw.files is defined
+  ignore_errors: yes
+
+- name: Determine which Monitoring Dashboards are to be created
+  find:
+    paths: "{{ role_path }}/templates/dashboards"
+    patterns: "{{ kiali_vars.deployment.custom_dashboards.includes }}"
+    excludes: "{{ kiali_vars.deployment.custom_dashboards.excludes }}"
+  register: monitoring_dashboard_yamls_to_deploy_raw
+  ignore_errors: yes
+- set_fact:
+    monitoring_dashboard_yamls_to_deploy: "{{ (monitoring_dashboard_yamls_to_deploy | default([])) + [ item.path ] }}"
+  loop: "{{ monitoring_dashboard_yamls_to_deploy_raw.files }}"
+  when:
+  - monitoring_dashboard_yamls_to_deploy_raw is defined
+  - monitoring_dashboard_yamls_to_deploy_raw.files is defined
+  ignore_errors: yes
+
+- name: Remove Monitoring Dashboards that should no longer be deployed
+  k8s:
+    state: "absent"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    definition: "{{ lookup('template', item) }}"
+  loop: "{{ (monitoring_dashboard_yamls_all | default([])) | difference(monitoring_dashboard_yamls_to_deploy | default([])) }}"
+  when:
+  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  ignore_errors: yes
 
 - name: Create the Monitoring Dashboards
   k8s:
     state: "present"
     namespace: "{{ kiali_vars.deployment.namespace }}"
     definition: "{{ lookup('template', item) }}"
-  with_fileglob:
-  - "templates/dashboards/*.yaml"
-  ignore_errors: yes
+  loop: "{{ monitoring_dashboard_yamls_to_deploy | default([]) }}"
   when:
+  - monitoring_dashboard_yamls_to_deploy is defined
   - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  ignore_errors: yes
+
+# If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
 
 - name: Force the Kiali pod to restart if necessary
   vars:


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/2989
Users probably won't want all of them, and they just cause the Kiali CR processing to be slower than need be.
The default is backward compat to previous behavior (all monitoring dashboard resources are created) but you now have the ability to not install those you do not want. e.g., in the Kiali CR:

```
deployment:
  custom_dashboards:
    includes: ['go*', 'kiali*']
```

This will install the Go and Kiali monitoring dashboards but no others.

```
deployment:
  custom_dashboards:
    includes: ['vertx*']
    excludes: ['vertx-server*']
```

This will install all the vertx dashboards except the server.