### PR TITLE
bump to molecule 3.0.6

### DIFF
--- a/molecule/docker/Dockerfile
+++ b/molecule/docker/Dockerfile
@@ -1,7 +1,4 @@
-FROM quay.io/ansible/molecule:3.0.4
+FROM quay.io/ansible/molecule:3.0.6
 RUN apk add gettext gcc libc-dev
 RUN pip install openshift junit-xml jmespath docker kubernetes
 RUN ansible-galaxy collection install community.kubernetes
-
-# fixes https://github.com/ansible-community/molecule/pull/2690 - take this out when we move to 3.0.5
-RUN mkdir -p /usr/share/ansible && ln -s /root/.ansible/collections /usr/share/ansible/collections


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/2987