### PR TITLE
increase retries in molecule tests

### DIFF
--- a/molecule/common/prepare-prometheus.yml
+++ b/molecule/common/prepare-prometheus.yml
@@ -12,8 +12,8 @@
   - prometheus_route_raw['resources'][0]['status']['ingress'] is defined
   - prometheus_route_raw['resources'][0]['status']['ingress'][0] is defined
   - prometheus_route_raw['resources'][0]['status']['ingress'][0]['host'] is defined
-  retries: 10
-  delay: 6
+  retries: 60
+  delay: 5
   when:
   - is_openshift == True
 
@@ -56,8 +56,8 @@
 - name: Wait for Prometheus Ingress to start on the k8s cluster
   uri:
     url: "{{ prometheus_url }}//query?query=up"
-  retries: 20
-  delay: 6
+  retries: 60
+  delay: 5
   when:
   - is_k8s == True
 

--- a/molecule/common/wait_for_kiali_cr_changes.yml
+++ b/molecule/common/wait_for_kiali_cr_changes.yml
@@ -7,5 +7,5 @@
   register: kiali_cr_list
   until:
   - kiali_cr_list | default({}) | json_query('resources[*].status.conditions[?reason==`Successful`].status') | flatten | join == 'True'
-  retries: 60
+  retries: 120
   delay: 5

--- a/molecule/common/wait_for_kiali_running.yml
+++ b/molecule/common/wait_for_kiali_running.yml
@@ -7,7 +7,7 @@
     - app = kiali
   register: kiali_pod
   until: kiali_pod.resources | length == 1 and kiali_pod.resources[0].status.phase is defined and kiali_pod.resources[0].status.phase == "Running"
-  retries: 60
+  retries: 120
   delay: 5
 
 - name: Wait for Kiali to be running and accepting requests
@@ -21,5 +21,5 @@
   - _kiali_output.json is defined
   - _kiali_output.json.status is defined
   - _kiali_output.json.status['Kiali state'] == "running"
-  retries: 60
+  retries: 120
   delay: 5

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -63,5 +63,5 @@
       - app = kiali
     register: kiali_deployment
     until: kiali_deployment.resources |length == 1 and kiali_deployment.resources[0].status.availableReplicas is defined and kiali_deployment.resources[0].status.availableReplicas == 1
-    retries: 60
+    retries: 120
     delay: 5


### PR DESCRIPTION
If running these molecule tests against slow clusters (like CRC on a laptop) we need to wait longer for things to complete