### PR TITLE
Adapt openid-test scenario to omit expires_in and access_token params

### DIFF
--- a/molecule/openid-test/converge.yml
+++ b/molecule/openid-test/converge.yml
@@ -157,8 +157,6 @@
       method: POST
       body_format: form-urlencoded
       body:
-        access_token: "{{ access_token }}"
-        expires_in: "{{ expires_in }}"
         id_token: "{{ id_token }}"
         token_type: "{{ token_type }}"
         state: "{{ state }}"


### PR DESCRIPTION
Because of kiali/kiali#2954 and kiali/kiali#2925, OpenID should work even if `access_token` and `expires_in` parameters are not sent by the IdP.

This is adapting the openid-test scenario to make sure OpenId strategy works under this cases.