### PR TITLE
make client id prefix configurable

### DIFF
--- a/deploy/charts/kiali-server/templates/configmap.yaml
+++ b/deploy/charts/kiali-server/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
     {{- /* Some values of the ConfigMap are generated, but might not be identical, from .Values */}}
     {{- $_ := set $cm "istio_namespace" (include "kiali-server.istio_namespace" .) }}
     {{- $_ := set $cm.auth "strategy" (include "kiali-server.auth.strategy" .) }}
+    {{- $_ := set $cm.auth.openshift "client_id_prefix" (include "kiali-server.fullname" .) }}
     {{- $_ := set $cm.identity "cert_file" (include "kiali-server.identity.cert_file" .) }}
     {{- $_ := set $cm.identity "private_key_file" (include "kiali-server.identity.private_key_file" .) }}
     {{- $_ := set $cm.login_token "signing_key" (include "kiali-server.login_token.signing_key" .) }}

--- a/deploy/charts/kiali-server/templates/oauth.yaml
+++ b/deploy/charts/kiali-server/templates/oauth.yaml
@@ -4,9 +4,7 @@
 apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
-  # Cannot use any name prefix here other than "kiali" due to https://github.com/kiali/kiali/issues/3069
-  #name: {{ include "kiali-server.fullname" . }}-{{ .Release.Namespace }}
-  name: kiali-{{ .Release.Namespace }}
+  name: {{ include "kiali-server.fullname" . }}-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}

--- a/deploy/charts/kiali-server/templates/route.yaml
+++ b/deploy/charts/kiali-server/templates/route.yaml
@@ -5,9 +5,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  # Cannot use any name here other than "kiali" due to https://github.com/kiali/kiali/issues/3069
-  #name: {{ include "kiali-server.fullname" . }}
-  name: kiali
+  name: {{ include "kiali-server.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kiali-server.labels" . | nindent 4 }}

--- a/deploy/charts/kiali-server/values.yaml
+++ b/deploy/charts/kiali-server/values.yaml
@@ -40,6 +40,8 @@ auth:
     issuer_uri: ""
     scopes: ["openid", "profile", "email"]
     username_claim: "sub"
+  openshift:
+    client_id_prefix: "kiali-server"
   strategy: ""
 
 deployment:

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -204,6 +204,12 @@ spec:
 #      issuer_uri: ""
 #      scopes: ["openid", "profile", "email"]
 #      username_claim: "sub"
+#
+# The Route resource name and OAuthClient resource name will have this value as its prefix.
+# This value normally should never change. The installer will ensure this value is set correctly.
+#    ---
+#    openshift:
+#      client_id_prefix: kiali
 
 ##########
 #  ---

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -51,6 +51,8 @@ kiali_defaults:
       issuer_uri: ""
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
+    openshift:
+      client_id_prefix: "kiali"
     strategy: ""
 
   deployment:


### PR DESCRIPTION
Do not assume the Route name is `kiali` and the OAuthClient name is prefixed with `kiali`. Let it be configurable by the installer.

This is built on top of [the kiali server helm chart PR](https://github.com/kiali/kiali-operator/pull/105)

part of fix for: https://github.com/kiali/kiali/issues/3069