### PR TITLE
Add revision field into istio config

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -530,7 +530,7 @@ spec:
 #      istio_identity_domain: "svc.cluster.local"
 #      istio_injection_annotation: "sidecar.istio.io/inject"
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
-#      revistion: ""
+#      revision: ""
 #      url_service_version: ""
 #
 #

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -514,6 +514,7 @@ spec:
 # istio_identity_domain: The annotation used by Istio to identify domains.
 # istio_injection_annotation: The annotation used by Istio to automatically inject a specific workload
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
+# revision: The revision name of the current istio installation. It defaults to an empty string.
 # url_service_version: The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.
 #    ---
 #    istio:
@@ -529,6 +530,7 @@ spec:
 #      istio_identity_domain: "svc.cluster.local"
 #      istio_injection_annotation: "sidecar.istio.io/inject"
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
+#      revistion: ""
 #      url_service_version: ""
 #
 #

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -133,6 +133,7 @@ kiali_defaults:
       istio_identity_domain: "svc.cluster.local"
       istio_injection_annotation: "sidecar.istio.io/inject"
       istio_sidecar_annotation: "sidecar.istio.io/status"
+      revision: ""
       url_service_version: ""
     prometheus:
       auth:


### PR DESCRIPTION
Related to https://github.com/kiali/kiali/issues/3187
Requires https://github.com/kiali/kiali/pull/3193

It allows users to specify which istio revision is installed.
The default value is an empty string ("") because Istio 1.7 plain installation goes without revision.