### PR TITLE
Add namespace field in each istio component health

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -458,6 +458,7 @@ spec:
 #   component_status: Grafana info for the Istio Component Status masthead indicator. Only if it is enabled.
 #       app_label: The value of the Grafana pod(s)'s app label. The name of the app label is defined in the setting 'istio_labels.app_label_name'. It defaults to grafana.
 #       is_core: Whether the component is core for your deployment. It defaults to false.
+#       namespace: The namespace where the grafana is installed in. It defaults to the 'istio_namespace' setting.
 #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Grafana over https.
 #   password: Password to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions. May refer to a secret - see note above.
 #   token: Token / API key to access Grafana, for token-based authentication. It only requires viewer permissions. May refer to a secret - see note above.
@@ -511,6 +512,7 @@ spec:
 #   components: A list of components that Kiali will check its statuses.
 #     app_label: Istio component pod app label.
 #     is_core: Whether the component is core for your deployment.
+#     namespace: The namespace where the component is installed in. It defaults to the 'istio_namespace' setting.
 # config_map_name: The name of the istio control plane config map. It defaults to `istio`.
 # istio_identity_domain: The annotation used by Istio to identify domains.
 # istio_injection_annotation: The annotation used by Istio to automatically inject a specific workload
@@ -541,6 +543,7 @@ spec:
 #   component_status: Prometheus info for the Istio Component Status masthead indicator. Only if it is enabled.
 #       app_label: The value of the Prometheus pod(s)'s app label. The name of the app label is defined in the setting 'istio_labels.app_label_name'. It defaults to prometheus.
 #       is_core: Whether the component is core for your deployment. It defaults to true.
+#       namespace: The namespace where Prometheus is installed in. It defaults to the 'istio_namespace' setting.
 #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Prometheus over https.
 #   password: Password to be used when making requests to Prometheus, for basic authentication. May refer to a secret - see note above.
 #   token: Token / API key to access Prometheus, for token-based authentication. May refer to a secret - see note above.
@@ -573,6 +576,7 @@ spec:
 #   component_status: Jaeger info for the Istio Component Status masthead indicator. Only if it is enabled.
 #       app_label: The value of the Jaeger pod(s)'s app label. The name of the app label is defined in the setting 'istio_labels.app_label_name'. It defaults to jaeger.
 #       is_core: Whether the component is core for your deployment. It defaults to false.
+#       namespace: The namespace where Jaeger is installed in. It defaults to the 'istio_namespace' setting.
 #   ca_file: The certificate authority file to use when accessing Jaeger using https. An empty string means no extra
 #       certificate authority file is used. Default is an empty string.
 #   insecure_skip_verify: Set true to skip verifying certificate validity when Kiali contacts Jaeger over https.

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -102,6 +102,7 @@ kiali_defaults:
         component_status:
           app_label: "grafana"
           is_core: false
+          namespace: ""
         insecure_skip_verify: false
         password: ""
         token: ""
@@ -126,10 +127,13 @@ kiali_defaults:
         components:
         - app_label: "istiod"
           is_core: true
+          namespace: ""
         - app_label: "istio-ingressgateway"
           is_core: true
+          namespace: ""
         - app_label: "istio-egressgateway"
           is_core: false
+          namespace: ""
       config_map_name: "istio"
       istio_identity_domain: "svc.cluster.local"
       istio_injection_annotation: "sidecar.istio.io/inject"
@@ -147,6 +151,7 @@ kiali_defaults:
       component_status:
         app_label: "prometheus"
         is_core: true
+        namespace: ""
       url: ""
     tracing:
       auth:
@@ -160,6 +165,7 @@ kiali_defaults:
       component_status:
         app_label: "jaeger"
         is_core: false
+        namespace: ""
       enabled: true
       in_cluster_url: ""
       namespace_selector: true


### PR DESCRIPTION
Requires https://github.com/kiali/kiali/pull/3211

It allows users to specify the namespace of each istio component. It defaults to the `istio_namespace`. This way the user doesn't have to specify each namespace for each component.