### PR TITLE
add new supported version of v1.24

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -286,6 +286,8 @@ spec:
                   value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_0_TAG}"
                 - name: RELATED_IMAGE_kiali_v1_12
                   value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_12_TAG}"
+                - name: RELATED_IMAGE_kiali_v1_24
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_24_TAG}"
                 ports:
                 - name: http-metrics
                   containerPort: 8383

--- a/playbooks/default-supported-images.yml
+++ b/playbooks/default-supported-images.yml
@@ -1,3 +1,4 @@
 default: {"image_name": "quay.io/kiali/kiali", "image_version": "lastrelease"}
 v1.0: {"image_name": "quay.io/kiali/kiali", "image_version": "v1.0"}
 v1.12: {"image_name": "quay.io/kiali/kiali", "image_version": "v1.12"}
+v1.24: {"image_name": "quay.io/kiali/kiali", "image_version": "v1.24"}

--- a/roles/v1.24/kiali-deploy/defaults/main.yml
+++ b/roles/v1.24/kiali-deploy/defaults/main.yml
@@ -1,0 +1,225 @@
+# Defaults for all user-facing Kiali settings. These are documented in kiali_cr.yaml.
+#
+# Note that these are under the main dictionary group "kiali_defaults".
+# The actual vars used by the role are found in the vars/ directory.
+# These defaults (the dictionaries under "kiali_defaults") are merged into the vars such that the values
+# below (e.g. deployment, server, etc.) are merged in rather than completely replaced by user-supplied values.
+#
+# If new groups are added to these defaults, you must remember to add the merge code to vars/main.yml.
+
+kiali_defaults:
+  installation_tag: ""
+  istio_component_namespaces: {}
+  istio_namespace: ""
+  version: "default"
+
+  additional_display_details:
+  - title: "API Documentation"
+    annotation: "kiali.io/api-spec"
+    icon_annotation: "kiali.io/api-type"
+
+  api:
+    namespaces:
+      exclude:
+      - "istio-operator"
+      - "kube.*"
+      - "openshift.*"
+      - "ibm.*"
+      - "kiali-operator"
+      #label_selector:
+
+  auth:
+    openid:
+      api_proxy: ""
+      api_proxy_ca_data: ""
+      authentication_timeout: 300
+      authorization_endpoint: ""
+      client_id: ""
+      insecure_skip_verify_tls: false
+      issuer_uri: ""
+      scopes: ["openid", "profile", "email"]
+      username_claim: "sub"
+    openshift:
+      client_id_prefix: "kiali"
+    strategy: ""
+
+  deployment:
+    accessible_namespaces: ["^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"]
+    #additional_service_yaml:
+    affinity:
+      node: {}
+      pod: {}
+      pod_anti: {}
+    custom_dashboards:
+      excludes: ['']
+      includes: ['*']
+    image_name: ""
+    image_pull_policy: "IfNotPresent"
+    image_pull_secrets: []
+    image_version: ""
+    ingress_enabled: true
+    namespace: ""
+    node_selector: {}
+    #override_ingress_yaml:
+    pod_annotations: {}
+    priority_class_name: ""
+    replicas: 1
+    resources: {}
+    secret_name: "kiali"
+    service_annotations: {}
+    #service_type: "NodePort"
+    tolerations: []
+    verbose_mode: "3"
+    version_label: ""
+    view_only_mode: false
+
+  extensions:
+    threescale:
+      adapter_name: "threescale"
+      adapter_port: "3333"
+      adapter_service: "threescale-istio-adapter"
+      enabled: false
+      template_name: "threescale-authorization"
+    iter_8:
+      enabled: false
+
+  external_services:
+    custom_dashboards:
+      namespace_label: ""
+      prometheus:
+        auth:
+          ca_file: ""
+          insecure_skip_verify: false
+          password: ""
+          token: ""
+          type: "none"
+          use_kiali_token: false
+          username: ""
+        url: ""
+    grafana:
+      auth:
+        ca_file: ""
+        component_status:
+          app_label: "grafana"
+          is_core: false
+        insecure_skip_verify: false
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      dashboards:
+      - name: "Istio Service Dashboard"
+        variables:
+          namespace: "var-namespace"
+          service: "var-service"
+      - name: "Istio Workload Dashboard"
+        variables:
+          namespace: "var-namespace"
+          workload: "var-workload"
+      enabled: true
+      in_cluster_url: ""
+      url: ""
+    istio:
+      component_status:
+        enabled: true
+        components:
+        - app_label: "istiod"
+          is_core: true
+        - app_label: "istio-ingressgateway"
+          is_core: true
+        - app_label: "istio-egressgateway"
+          is_core: false
+      istio_identity_domain: "svc.cluster.local"
+      istio_injection_annotation: "sidecar.istio.io/inject"
+      istio_sidecar_annotation: "sidecar.istio.io/status"
+      url_service_version: ""
+    prometheus:
+      auth:
+        ca_file: ""
+        insecure_skip_verify: false
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      component_status:
+        app_label: "prometheus"
+        is_core: true
+      url: ""
+    tracing:
+      auth:
+        ca_file: ""
+        insecure_skip_verify: false
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      component_status:
+        app_label: "jaeger"
+        is_core: false
+      enabled: true
+      in_cluster_url: ""
+      namespace_selector: true
+      url: ""
+      whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
+
+  identity: {}
+    #cert_file:
+    #private_key_file:
+
+  istio_labels:
+    app_label_name: "app"
+    injection_label_name: "istio-injection"
+    version_label_name: "version"
+
+  kiali_feature_flags:
+    istio_injection_action: true
+
+  kubernetes_config:
+    burst: 200
+    cache_duration: 300
+    cache_enabled: true
+    cache_istio_types:
+    - "DestinationRule"
+    - "Gateway"
+    - "ServiceEntry"
+    - "VirtualService"
+    - "Sidecar"
+    - "PeerAuthentication"
+    - "RequestAuthentication"
+    - "AuthorizationPolicy"
+
+    cache_namespaces:
+    - ".*"
+    cache_token_namespace_duration: 10
+    excluded_workloads:
+    - "CronJob"
+    - "DeploymentConfig"
+    - "Job"
+    - "ReplicationController"
+    qps: 175
+
+  login_token:
+    expiration_seconds: 86400
+    signing_key: ""
+
+  server:
+    address: ""
+    audit_log: true
+    cors_allow_all: false
+    gzip_enabled: true
+    metrics_enabled: true
+    metrics_port: 9090
+    port: 20001
+    web_fqdn: ""
+    web_root: ""
+    web_schema: ""
+
+# These variables are outside of the kiali_defaults. Their values will be
+# auto-detected by the role and are not meant to be set by the user.
+# However, for debugging purposes you can change these.
+
+is_k8s: false
+is_openshift: false

--- a/roles/v1.24/kiali-deploy/filter_plugins/stripnone.py
+++ b/roles/v1.24/kiali-deploy/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/roles/v1.24/kiali-deploy/meta/main.yml
+++ b/roles/v1.24/kiali-deploy/meta/main.yml
@@ -1,0 +1,25 @@
+galaxy_info:
+  author: Kiali
+  description: Installs the Kiali console and its API server. See https://www.kiali.io
+  license: Apache 2.0
+  min_ansible_version: 2.7.9
+  galaxy_tags:
+  - service-mesh
+  - observability
+  - monitoring
+  - cloud
+  - openshift
+  - kubernetes
+  - maistra
+  - istio
+  # NOTE: This aren't valid platforms for Galaxy - but they are more useful for our purposes
+  platforms:
+  - name: Kubernetes
+    versions:
+    - 1.14
+    - 1.16
+  - name: OpenShift
+    versions:
+    - 4.2
+    - 4.3
+dependencies: []

--- a/roles/v1.24/kiali-deploy/tasks/create-namespace-label.yml
+++ b/roles/v1.24/kiali-deploy/tasks/create-namespace-label.yml
@@ -1,0 +1,30 @@
+- debug:
+    msg: "Create namespace label [{{ the_namespace_label_name }}={{ the_namespace_label_value }}] on namespace [{{ the_namespace }}]"
+
+- set_fact:
+    the_namespace_raw: {}
+    the_labeled_namespace: {}
+
+- name: "Get namespace [{{ the_namespace }}] that is to be labeled"
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ the_namespace }}"
+    namespace: "{{ the_namespace }}"
+  register: the_namespace_raw
+
+- set_fact:
+    the_labeled_namespace: "{{ the_namespace_raw['resources'][0] | combine({'metadata': {'labels': { the_namespace_label_name: the_namespace_label_value }}}, recursive=True) }}"
+  when:
+  - the_namespace_raw['resources'] is defined
+  - the_namespace_raw['resources'][0] is defined
+
+- fail:
+    msg: "Failed to create the label to namespace [{{ the_namespace }}]"
+  when:
+  - the_labeled_namespace.metadata is not defined
+
+- name: "Saving label to namespace [{{ the_namespace }}]"
+  k8s:
+    state: "present"
+    definition: "{{ the_labeled_namespace }}"

--- a/roles/v1.24/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/v1.24/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -1,0 +1,51 @@
+- name: Create Kiali objects on Kubernetes
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_cluster: "kubernetes"
+    role_namespace: "{{ kiali_vars.deployment.namespace }}"
+  loop:
+  - serviceaccount
+  - configmap
+  - "{{ 'role-viewer' if kiali_vars.deployment.view_only_mode == True else 'role' }}"
+  - rolebinding
+  - deployment
+  - service
+  loop_control:
+    loop_var: process_resource_item
+  when:
+  - is_k8s == True
+
+- name: Create Ingress on Kubernetes if enabled
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_cluster: "kubernetes"
+    role_namespace: "{{ kiali_vars.deployment.namespace }}"
+  loop:
+  - ingress
+  loop_control:
+    loop_var: process_resource_item
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.ingress_enabled == True
+
+- name: Delete Ingress on Kubernetes if disabled
+  k8s:
+    state: absent
+    api_version: "extensions/v1beta1"
+    kind: "Ingress"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "kiali"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.ingress_enabled == False
+
+- name: Create additional Kiali roles on Kubernetes
+  include_tasks: process-additional-roles.yml
+  vars:
+    process_resource_cluster: "kubernetes"
+  loop: "{{ kiali_vars.deployment.accessible_namespaces }}"
+  loop_control:
+    loop_var: role_namespace
+  when:
+  - is_k8s == True
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'

--- a/roles/v1.24/kiali-deploy/tasks/main.yml
+++ b/roles/v1.24/kiali-deploy/tasks/main.yml
@@ -1,0 +1,833 @@
+- name: Get information about the cluster
+  set_fact:
+    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+- name: Determine the cluster type
+  set_fact:
+    is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+# Indicate what kind of cluster we are in (OpenShift or Kubernetes).
+- debug:
+    msg: "CLUSTER TYPE: is_openshift={{ is_openshift }}; is_k8s={{ is_k8s }}"
+- fail:
+    msg: "Cannot determine what type of cluster we are in"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+- name: Determine the Kubernetes version
+  set_fact:
+    k8s_version: "{{ lookup('k8s', cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
+  ignore_errors: yes
+
+- name: Determine the OpenShift version
+  vars:
+    kube_apiserver_cluster_op_raw: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
+    ri_query: "status.versions[?name == 'raw-internal'].version"
+  set_fact:
+    openshift_version: "{{ kube_apiserver_cluster_op_raw | json_query(ri_query) | join }}"
+  when:
+  - is_openshift == True
+
+- name: Determine the Istio implementation
+  set_fact:
+    is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
+
+- name: Get information about the operator
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+    name: "{{ lookup('env', 'POD_NAME') }}"
+  register: operator_pod_raw
+  ignore_errors: yes
+- name: Determine the version of the operator based on the version label
+  set_fact:
+    operator_version: "{{ operator_pod_raw.resources[0].metadata.labels.version }}"
+  when:
+  - operator_pod_raw is defined
+  - operator_pod_raw.resources[0] is defined
+  - operator_pod_raw.resources[0].metadata is defined
+  - operator_pod_raw.resources[0].metadata.labels is defined
+  - operator_pod_raw.resources[0].metadata.labels.version is defined
+- set_fact:
+    operator_version: "unknown"
+  when:
+  - operator_version is not defined
+- debug:
+    msg: "OPERATOR VERSION: [{{ operator_version }}]"
+
+# Because we are passing through some yaml directly to Kubernetes resources, we have to retain the camelCase keys.
+# All CR parameters are converted to snake_case, but the original yaml is found in the special _kiali_io_kiali param.
+# We need to copy that original yaml into our vars where appropriate to keep the camelCase.
+
+- name: Get the original CR as-is for the camelCase keys
+  set_fact:
+    current_cr: "{{ _kiali_io_kiali }}"
+
+- name: Replace snake_case with camelCase in deployment.affinity.node
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment']['affinity'].pop('node') %}
+      {{ kiali_vars | combine({'deployment': {'affinity': {'node': current_cr.spec.deployment.affinity.node }}}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.affinity is defined
+  - kiali_vars.deployment.affinity.node is defined
+  - kiali_vars.deployment.affinity.node | length > 0
+
+- name: Replace snake_case with camelCase in deployment.affinity.pod
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment']['affinity'].pop('pod') %}
+      {{ kiali_vars | combine({'deployment': {'affinity': {'pod': current_cr.spec.deployment.affinity.pod }}}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.affinity is defined
+  - kiali_vars.deployment.affinity.pod is defined
+  - kiali_vars.deployment.affinity.pod | length > 0
+
+- name: Replace snake_case with camelCase in deployment.affinity.pod_anti
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment']['affinity'].pop('pod_anti') %}
+      {{ kiali_vars | combine({'deployment': {'affinity': {'pod_anti': current_cr.spec.deployment.affinity.pod_anti }}}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.affinity is defined
+  - kiali_vars.deployment.affinity.pod_anti is defined
+  - kiali_vars.deployment.affinity.pod_anti | length > 0
+
+- name: Replace snake_case with camelCase in deployment.tolerations
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('tolerations') %}
+      {{ kiali_vars | combine({'deployment': {'tolerations': current_cr.spec.deployment.tolerations }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.tolerations is defined
+  - kiali_vars.deployment.tolerations | length > 0
+
+- name: Replace snake_case with camelCase in deployment.additional_service_yaml
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('additional_service_yaml') %}
+      {{ kiali_vars | combine({'deployment': {'additional_service_yaml': current_cr.spec.deployment.additional_service_yaml }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.additional_service_yaml is defined
+  - kiali_vars.deployment.additional_service_yaml | length > 0
+
+- name: Replace snake_case with camelCase in deployment.resources
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('resources') %}
+      {{ kiali_vars | combine({'deployment': {'resources': current_cr.spec.deployment.resources }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.resources is defined
+  - kiali_vars.deployment.resources | length > 0
+
+- name: Replace snake_case with camelCase in deployment.override_ingress_yaml
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('override_ingress_yaml') %}
+      {{ kiali_vars | combine({'deployment': {'override_ingress_yaml': current_cr.spec.deployment.override_ingress_yaml }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.override_ingress_yaml is defined
+  - kiali_vars.deployment.override_ingress_yaml | length > 0
+
+- name: Replace snake_case with camelCase in deployment.pod_annotations
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('pod_annotations') %}
+      {{ kiali_vars | combine({'deployment': {'pod_annotations': current_cr.spec.deployment.pod_annotations }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.pod_annotations is defined
+  - kiali_vars.deployment.pod_annotations | length > 0
+
+- name: Replace snake_case with camelCase in deployment.service_annotations
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('service_annotations') %}
+      {{ kiali_vars | combine({'deployment': {'service_annotations': current_cr.spec.deployment.service_annotations }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.service_annotations is defined
+  - kiali_vars.deployment.service_annotations | length > 0
+
+- name: Print some debug information
+  vars:
+    msg: |
+        Kiali Variables:
+        --------------------------------
+        {{ kiali_vars | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+  tags: test
+
+# We do not want to blindly default to istio-system for some namespaces. If the istio_namespace is not
+# provided, assume it is the same namespace where Kiali is being deployed. Set the other istio namespace
+# values accordingly.
+# We determine the default Istio namespace var first, and the rest will use it for their default as appropriate.
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
+
+- name: Set default istio namespace
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'istio_namespace': kiali_vars.deployment.namespace}, recursive=True) }}"
+  when:
+  - kiali_vars.istio_namespace == ""
+
+- name: "Set default istio component namespace: grafana"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'grafana': kiali_vars.istio_namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.istio_component_namespaces.grafana is not defined or kiali_vars.istio_component_namespaces.grafana == ""
+
+- name: "Set default istio component namespace: tracing"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'tracing': kiali_vars.istio_namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.istio_component_namespaces.tracing is not defined or kiali_vars.istio_component_namespaces.tracing == ""
+
+- name: "Set default istio component namespace: pilot - needed for Istio 1.5 and earlier"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'pilot': kiali_vars.istio_namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.istio_component_namespaces.pilot is not defined or kiali_vars.istio_component_namespaces.pilot == ""
+
+- name: "Set default istio component namespace: istiod - needed for Istio 1.6 and later"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'istiod': kiali_vars.istio_namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.istio_component_namespaces.istiod is not defined or kiali_vars.istio_component_namespaces.istiod == ""
+
+- name: "Set default istio component namespace: prometheus"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'prometheus': kiali_vars.istio_namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.istio_component_namespaces.prometheus is not defined or kiali_vars.istio_component_namespaces.prometheus == ""
+
+- name: Set default Grafana in_cluster_url
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'in_cluster_url': 'http://grafana.' + kiali_vars.istio_component_namespaces.grafana + ':3000'}}}, recursive=True) }}"
+  when:
+    kiali_vars.external_services.grafana.in_cluster_url == ""
+
+- name: Set default Tracing in_cluster_url for Maistra
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'in_cluster_url': 'http://tracing.' + kiali_vars.istio_component_namespaces.tracing + ':16686'}}}, recursive=True) }}"
+  when:
+    kiali_vars.external_services.tracing.in_cluster_url == "" and is_maistra
+
+- name: Set default Tracing in_cluster_url
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'in_cluster_url': 'http://tracing.' + kiali_vars.istio_component_namespaces.tracing + '/jaeger'}}}, recursive=True) }}"
+  when:
+    kiali_vars.external_services.tracing.in_cluster_url == "" and is_maistra == False
+
+- name: Check for the existence of istiod version endpoint
+  uri:
+    url: "http://istiod.{{ kiali_vars.istio_component_namespaces.istiod }}:15014/version"
+  register: istiod_version_url_results_raw
+  until: istiod_version_url_results_raw.status == 200
+  retries: 5
+  delay: 1
+  ignore_errors: yes
+  when:
+  - kiali_vars.external_services.istio.url_service_version == ""
+
+- name: Set default Istio service that provides version info (istiod for Istio 1.6 and later)
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'url_service_version': 'http://istiod.' + kiali_vars.istio_component_namespaces.istiod + ':15014/version'}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.istio.url_service_version == ""
+  - istiod_version_url_results_raw.status == 200
+
+- name: Fallback to Istio pilot service that provides version info (for Istio 1.5 and earlier)
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'url_service_version': 'http://istio-pilot.' + kiali_vars.istio_component_namespaces.pilot + ':8080/version'}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.istio.url_service_version == ""
+
+- name: Set default Prometheus URL
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'url': 'http://prometheus.' + kiali_vars.istio_component_namespaces.prometheus + ':9090'}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.prometheus.url == ""
+
+# Determine some more defaults.
+
+- name: Set default web root based on cluster type
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'server': {'web_root': '/' if is_openshift else '/kiali'}}, recursive=True) }}"
+  when:
+  - kiali_vars.server.web_root == ""
+- name: Make sure web root never ends with a slash
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'server': {'web_root': kiali_vars.server.web_root | regex_replace('\\/$', '')}}, recursive=True) }}"
+  when:
+  - kiali_vars.server.web_root != "/"
+  - kiali_vars.server.web_root is match(".*/$")
+
+- name: Validate web_schema configuration
+  fail:
+    msg: "Invalid server.web_schema [{{ kiali_vars.server.web_schema }}]! Must be empty, or one of either 'http' or 'https'"
+  when:
+  - kiali_vars.server.web_schema != ''
+  - kiali_vars.server.web_schema != 'https'
+  - kiali_vars.server.web_schema != 'http'
+
+- name: Set default identity cert_file based on cluster type
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'identity': {'cert_file': '/kiali-cert/tls.crt' if is_openshift else ''}}, recursive=True) }}"
+  when:
+  - kiali_vars.identity.cert_file is not defined
+- name: Set default identity private_key_file based on cluster type
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'identity': {'private_key_file': '/kiali-cert/tls.key' if is_openshift else ''}}, recursive=True) }}"
+  when:
+  - kiali_vars.identity.private_key_file is not defined
+
+- name: Default the image name to a known supported image.
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_name': supported_kiali_images[kiali_vars.version].image_name}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_name == ""
+- name: Default the image version to a known supported image.
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': ('latest' if operator_version == 'master' else operator_version) if supported_kiali_images[kiali_vars.version].image_version == 'operator_version' else supported_kiali_images[kiali_vars.version].image_version}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_version == ""
+
+- name: If image version is latest then we will want to always pull
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_pull_policy': 'Always'}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_version == "latest"
+
+- name: Set default auth strategy based on cluster type
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'auth': {'strategy': 'openshift' if is_openshift else 'token'}}, recursive=True) }}"
+  when:
+  - kiali_vars.auth.strategy == ""
+
+- name: Use OpenShift service CA file for Grafana
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.grafana.auth.ca_file is not defined or kiali_vars.external_services.grafana.auth.ca_file == ''
+
+- name: Use OpenShift service CA file for Prometheus
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.prometheus.auth.ca_file is not defined or kiali_vars.external_services.prometheus.auth.ca_file == ''
+
+- name: Use OpenShift service CA file for Tracing
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.tracing.auth.ca_file is not defined or kiali_vars.external_services.tracing.auth.ca_file == ''
+
+# Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
+- debug:
+    msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"
+- name: Confirm auth strategy is valid for OpenShift environments
+  fail:
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'openshift', 'token' or 'anonymous'"
+  when:
+  - is_openshift == True
+  - kiali_vars.auth.strategy != 'anonymous'
+  - kiali_vars.auth.strategy != 'openshift'
+  - kiali_vars.auth.strategy != 'token'
+- name: Confirm auth strategy is valid for Kubernetes environments
+  fail:
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'token', 'openid' or 'anonymous'"
+  when:
+  - is_k8s == True
+  - kiali_vars.auth.strategy != 'anonymous'
+  - kiali_vars.auth.strategy != 'token'
+  - kiali_vars.auth.strategy != 'openid'
+- name: Confirm OpenID configuration when auth strategy is 'openid'
+  fail:
+    msg: "Invalid configuration for OpenID connect! The mandatory parameters should be provided: 'issuer_uri', 'client_id'. Also, the 'username_claim' cannot be set to the empty string."
+  when:
+  - kiali_vars.auth.strategy == "openid"
+  - kiali_vars.auth.openid.issuer_uri == "" or kiali_vars.auth.openid.client_id == "" or kiali_vars.auth.openid.username_claim == ""
+# Fail if ingress is disabled but auth_strategy is openshift. This is because the openshift auth strategy
+# requires OAuth Client which requires a Route. So ingress must be enabled if strategy is openshift.
+- name: Ensure Ingress is Enabled if Auth Strategy is openshift
+  fail:
+    msg: "The auth.strategy is 'openshift' which requires a Route, but deployment.ingress_enabled is false. Aborting."
+  when:
+  - kiali_vars.auth.strategy == "openshift"
+  - kiali_vars.deployment.ingress_enabled == False
+
+- name: Confirm the cluster can access github.com when it needs to determine the last release of Kiali
+  uri:
+    url: https://api.github.com/repos/kiali/kiali-operator/releases
+  when:
+  - kiali_vars.deployment.image_version == "lastrelease"
+- name: Determine image version when last release is to be installed
+  shell: echo -n $(curl -s https://api.github.com/repos/kiali/kiali-operator/releases 2> /dev/null | grep "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//' | grep -v "snapshot" | sort -t "." -k 1.2g,1 -k 2g,2 -k 3g | tail -n 1)
+  register: github_lastrelease
+  when:
+  - kiali_vars.deployment.image_version == "lastrelease"
+- set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': github_lastrelease.stdout}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_version == "lastrelease"
+
+- name: Determine image version when it explicitly was configured as the operator_version
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': 'latest' if operator_version == 'master' else operator_version}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_version == "operator_version"
+
+- fail:
+    msg: "Could not determine what the image version should be. Set deployment.image_version to a valid value"
+  when:
+  - kiali_vars.deployment.image_version == "" or kiali_vars.deployment.image_version == "unknown"
+
+- name: Determine version_label based on image_version
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': 'master' if kiali_vars.deployment.image_version == 'latest' else kiali_vars.deployment.image_version}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.version_label == ""
+
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure the label is valid.
+- name: Trim version_label when appropriate
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label[:60] + 'XXX' }}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.version_label | length > 63
+
+# Indicate which Kiali image we are going to use.
+- debug:
+    msg: "IMAGE_NAME={{ kiali_vars.deployment.image_name }}; IMAGE VERSION={{ kiali_vars.deployment.image_version }}; VERSION LABEL={{ kiali_vars.deployment.version_label }}"
+
+# Determine the accessible namespaces. The user may have specified names using regex expressions.
+# We need to get a list of all namespaces and match them to the regex expressions.
+# Note that we replace kiali_vars.deployment.accessible_namespaces with the full list of actual namespace names
+# with regex expressions removed because when the CR changes, we need to know what namespaces were granted roles in
+# case we need to revoke those roles (to do this, we need to know the exact names of the namespaces).
+# This must be done before the next step which is figuring out what namespaces are no longer accessible and revoking their roles.
+# If the user did not specify Kiali's own namespace in accessible_namespaces, it will be added to the list automatically.
+# NOTE: there is a special value of accessible_namespaces - two asterisks ("**") means Kiali is to be given access to all
+# namespaces via a single cluster role (as opposed to individual roles in each accessible namespace).
+
+- name: Determine the Role and RoleBinding kinds that the operator will create and that the role templates will use
+  set_fact:
+    role_kind: "{{ 'ClusterRole' if '**' in kiali_vars.deployment.accessible_namespaces else 'Role' }}"
+    role_binding_kind: "{{ 'ClusterRoleBinding' if '**' in kiali_vars.deployment.accessible_namespaces else 'RoleBinding' }}"
+
+- name: Determine if the operator can support accessible_namespaces=**
+  vars:
+    role_json: "{{ lookup('k8s', api_version='rbac.authorization.k8s.io/v1', kind='ClusterRole', resource_name='kiali-operator') | default({}) }}"
+    query_cr: "rules[?apiGroups.contains(@, 'rbac.authorization.k8s.io')].resources.contains(@, 'clusterroles')"
+    query_crb: "rules[?apiGroups.contains(@, 'rbac.authorization.k8s.io')].resources.contains(@, 'clusterrolebindings')"
+  fail:
+    msg: "The operator cannot support deployment.accessible_namespaces set to '**' because it does not have permissions to create clusterroles or clusterrolebindings"
+  when:
+  - '"**" in kiali_vars.deployment.accessible_namespaces'
+  - (role_json | json_query(query_cr) != [true]) or (role_json | json_query(query_crb) != [true])
+
+- name: Find all namespaces (this is limited to what the operator has permission to see)
+  set_fact:
+    all_namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
+  when:
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+
+- name: Determine all accessible namespaces, expanding regex expressions to matched namespaces
+  set_fact:
+    all_accessible_namespaces: "{{ ((all_accessible_namespaces | default([ kiali_vars.deployment.namespace, kiali_vars.istio_namespace ])) + [ item.1 | regex_search(item.0) ]) | unique }}"
+  loop: "{{ kiali_vars.deployment.accessible_namespaces | product(all_namespaces) | list }}"
+  when:
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+  - item.1 | regex_search(item.0)
+
+- name: If Kiali has not been granted access to any namespaces, use the deployment namespace and the control plane namespace
+  set_fact:
+    all_accessible_namespaces: "{{ [ kiali_vars.deployment.namespace, kiali_vars.istio_namespace ] | unique }}"
+  when:
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+  - all_accessible_namespaces is not defined or all_accessible_namespaces | length == 0
+
+- fail:
+    msg: "Kiali has not been granted access to its own namespace of [{{ kiali_vars.deployment.namespace }}]. This is explicitly required. Check the deployment.accessible_namespaces setting."
+  when:
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+  - kiali_vars.deployment.namespace not in all_accessible_namespaces
+- fail:
+    msg: "Kiali has not been granted access to the control plane namespace [{{ kiali_vars.istio_namespace }}]. This is explicitly required. Check the deployment.accessible_namespaces setting."
+  when:
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+  - kiali_vars.istio_namespace not in all_accessible_namespaces
+
+- name: If accessible namespaces list has the special all-namespaces indicator, remove all other namespaces from the list
+  set_fact:
+    all_accessible_namespaces: ["**"]
+  when:
+  - '"**" in kiali_vars.deployment.accessible_namespaces'
+
+- name: Set deployment.accessible_namespaces to a list of full namespace names
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'accessible_namespaces': all_accessible_namespaces}}, recursive=True) }}"
+
+- name: Listing of all accessible namespaces (includes regex matches)
+  debug:
+    msg: "{{ kiali_vars.deployment.accessible_namespaces }}"
+
+- name: When accessible namespaces are specified, ensure label selector is set
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'api': {'namespaces': {'label_selector': ('kiali.io/member-of=' + kiali_vars.deployment.namespace)}}}, recursive=True) }}"
+  when:
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+  - kiali_vars.api.namespaces.label_selector is not defined
+
+- name: Make sure label selector is in the valid format name=value
+  fail:
+    msg: "The api.namespaces.label_selector is not valid [{{ kiali_vars.api.namespaces.label_selector }}] - it must be in the form of 'name=value' following Kubernetes syntax rules for label names and values."
+  when:
+  - kiali_vars.api.namespaces.label_selector is defined
+  # this regex is not 100% accurate, but we want to at least catch obvious errors
+  - kiali_vars.api.namespaces.label_selector is not regex('^[a-zA-Z0-9/_.-]+=[a-zA-Z0-9_.-]+$')
+
+# If the signing key is empty string, we need to ensure a signing key secret exists - if it does not generate one.
+
+- name: Get information about any existing signing key secret if we need to know if it exists or not
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: kiali-signing-key
+  register: signing_key_secret_raw
+  when:
+  - kiali_vars.login_token.signing_key == ""
+
+- name: Create secret to store a random signing key if a secret does not already exist and we need one
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+        name: kiali-signing-key
+        labels:
+          app: kiali
+          version: "{{ kiali_vars.deployment.version_label }}"
+      type: Opaque
+      data:
+        key: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') | b64encode }}"
+  when:
+  - kiali_vars.login_token.signing_key == ""
+  - signing_key_secret_raw is defined
+  - signing_key_secret_raw.resources is defined
+  - signing_key_secret_raw.resources | length == 0
+
+- name: Point signing key to the generated secret
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'login_token': {'signing_key': 'secret:kiali-signing-key:key'}}, recursive=True) }}"
+  when:
+  - kiali_vars.login_token.signing_key == ""
+
+# Prepare any additional environment variables that need to be defined in the deployment
+
+- set_fact:
+    kiali_deployment_environment_variables: {}
+
+- name: Prepare environment variable for prometheus password
+  set_fact:
+    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'PROMETHEUS_PASSWORD': {'secret_name': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+  when:
+  - kiali_vars.external_services.prometheus.auth.password | regex_search('secret:.+:.+')
+
+- name: Prepare environment variable for prometheus token
+  set_fact:
+    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'PROMETHEUS_TOKEN': {'secret_name': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+  when:
+  - kiali_vars.external_services.prometheus.auth.token | regex_search('secret:.+:.+')
+
+- name: Prepare environment variable for tracing password
+  set_fact:
+    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_PASSWORD': {'secret_name': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+  when:
+  - kiali_vars.external_services.tracing.auth.password | regex_search('secret:.+:.+')
+
+- name: Prepare environment variable for tracing token
+  set_fact:
+    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_TOKEN': {'secret_name': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+  when:
+  - kiali_vars.external_services.tracing.auth.token | regex_search('secret:.+:.+')
+
+- name: Prepare environment variable for grafana password
+  set_fact:
+    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_PASSWORD': {'secret_name': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+  when:
+  - kiali_vars.external_services.grafana.auth.password | regex_search('secret:.+:.+')
+
+- name: Prepare environment variable for grafana token
+  set_fact:
+    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_TOKEN': {'secret_name': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+  when:
+  - kiali_vars.external_services.grafana.auth.token | regex_search('secret:.+:.+')
+
+- name: Prepare environment variable for login token signing key
+  set_fact:
+    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'LOGIN_TOKEN_SIGNING_KEY': {'secret_name': kiali_vars.login_token.signing_key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.login_token.signing_key | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+  when:
+  - kiali_vars.login_token.signing_key | regex_search('secret:.+:.+')
+
+# The following few tasks read the current Kiali configmap (if one exists) in order to figure out what
+# namespaces are no longer accessible. Those namespaces will have their Kiali roles removed.
+# They will also have the Kiali labels removed.
+
+- name: Find current configmap, if it exists
+  set_fact:
+    current_configmap: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+
+- name: Find some current configuration settings
+  set_fact:
+    current_accessible_namespaces: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.accessible_namespaces') }}"
+    current_label_selector: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('api.namespaces.label_selector') }}"
+    current_view_only_mode: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.view_only_mode') }}"
+    current_image_name: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_name') }}"
+    current_image_version: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_version') }}"
+  when:
+  - current_configmap is defined
+  - current_configmap.data is defined
+  - current_configmap.data['config.yaml'] is defined
+
+# Because we need to remove the labels that were created before, we must not allow the user to change
+# the label_selector. So if the current accessible_namespaces is not ** but the label_select is being changed,
+# we need to abort since we won't know what the old labels were. If current accessible_namespaces is ** then
+# we know we didn't create labels before so we can allow label_selector to change.
+- name: Do not allow user to change label selector
+  fail:
+    msg: "The api.namespaces.label_selector cannot be changed to a different value. It was [{{ current_label_selector }}] but is now configured to be [{{ kiali_vars.api.namespaces.label_selector }}]. In order to install Kiali with a different label selector than what was used before, please uninstall Kiali first."
+  when:
+  - current_accessible_namespaces is defined
+  - '"**" not in current_accessible_namespaces'
+  - current_label_selector is defined
+  - kiali_vars.api.namespaces.label_selector is defined
+  - current_label_selector != kiali_vars.api.namespaces.label_selector
+
+- name: Determine the namespaces that were previously accessible but are now inaccessible
+  set_fact:
+    no_longer_accessible_namespaces: "{{ current_accessible_namespaces | difference(kiali_vars.deployment.accessible_namespaces) }}"
+  when:
+  - current_accessible_namespaces is defined
+  - '"**" not in current_accessible_namespaces'
+
+- name: Delete all additional Kiali roles from namespaces that Kiali no longer has access to
+  include_tasks: remove-roles.yml
+  loop: "{{ no_longer_accessible_namespaces }}"
+  loop_control:
+    loop_var: role_namespace
+  when:
+  - no_longer_accessible_namespaces is defined
+
+- name: Delete Kiali cluster roles if no longer given special access to all namespaces
+  include_tasks: remove-clusterroles.yml
+  when:
+  - current_accessible_namespaces is defined
+  - '"**" in current_accessible_namespaces'
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+
+- name: Delete all Kiali roles from namespaces if view_only_mode is changing since role bindings are immutable
+  include_tasks: remove-roles.yml
+  loop: "{{ kiali_vars.deployment.accessible_namespaces }}"
+  loop_control:
+    loop_var: role_namespace
+  when:
+  - current_view_only_mode is defined
+  - current_view_only_mode != kiali_vars.deployment.view_only_mode
+  - current_accessible_namespaces is defined
+  - '"**" not in current_accessible_namespaces'
+
+- name: Delete Kiali cluster roles if view_only_mode is changing since role bindings are immutable
+  include_tasks: remove-clusterroles.yml
+  when:
+  - current_view_only_mode is defined
+  - current_view_only_mode != kiali_vars.deployment.view_only_mode
+  - current_accessible_namespaces is defined
+  - '"**" in current_accessible_namespaces'
+
+- name: Remove Kiali label from namespaces that Kiali no longer has access to
+  include_tasks: remove-namespace-label.yml
+  vars:
+    the_namespace_label_name: "{{ current_label_selector | regex_replace('^(.*)=.*$', '\\1') }}"
+  loop: "{{ no_longer_accessible_namespaces }}"
+  loop_control:
+    loop_var: the_namespace
+  when:
+  - no_longer_accessible_namespaces is defined
+  - current_label_selector is defined
+
+- name: Create namespace labels on all accessible namespaces
+  include_tasks: create-namespace-label.yml
+  vars:
+    # everything to the left of the = is the label name; to the right is the label value
+    the_namespace_label_name: "{{ kiali_vars.api.namespaces.label_selector | regex_replace('^(.*)=.*$', '\\1') }}"
+    the_namespace_label_value: "{{ kiali_vars.api.namespaces.label_selector | regex_replace('^.*=(.*)$', '\\1') }}"
+  loop: "{{ kiali_vars.deployment.accessible_namespaces }}"
+  loop_control:
+    loop_var: the_namespace
+  when:
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+
+- name: Delete Kiali deployment if image is changing - this uninstalled any old version of Kiali that might be running
+  k8s:
+    state: absent
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: kiali
+  when:
+  - is_openshift == True or is_k8s == True
+  - current_image_name is defined and current_image_version is defined
+  - (current_image_name != kiali_vars.deployment.image_name) or (current_image_version != kiali_vars.deployment.image_version)
+
+# Get the deployment's custom annotation we set that tells us when we last updated the Deployment.
+# We need this to ensure the Deployment we update retains this same timestamp unless changes are made
+# that requires a pod restart - in which case we update this timestamp.
+- name: Find current deployment, if it exists
+  set_fact:
+    current_deployment: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+
+- name: Get current deployment last-updated annotation timestamp from existing deployment
+  set_fact:
+    current_deployment_last_updated: "{{ current_deployment.spec.template.metadata.annotations['operator.kiali.io/last-updated'] if current_deployment.spec.template.metadata.annotations['operator.kiali.io/last-updated'] is defined else lookup('pipe','date') }}"
+    deployment_is_new: false
+  when:
+  - current_deployment is defined
+  - current_deployment.spec is defined
+  - current_deployment.spec.template is defined
+  - current_deployment.spec.template.metadata is defined
+  - current_deployment.spec.template.metadata.annotations is defined
+
+- name: Set current deployment last-updated annotation timestamp for new deployments
+  set_fact:
+    current_deployment_last_updated: "{{ lookup('pipe','date') }}"
+    deployment_is_new: true
+  when:
+  - current_deployment_last_updated is not defined
+
+# Now deploy all resources for the specific cluster environment
+
+- name: Execute for OpenShift environment
+  include: openshift/os-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
+  when:
+  - is_openshift == True
+
+- name: Execute for Kubernetes environment
+  include: kubernetes/k8s-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
+  when:
+  - is_k8s == True
+
+# The next few tasks wait for the Monitoring Dashboard CRD to be established, and
+# then adds the monitoring dashboard resources. If there are any errors here, they
+# are ignored - since the monitoring dashboards are optional, we allow the install to
+# continue even though it means the monitoring dashboards feature will be disabled.
+
+- name: Wait for Monitoring Dashboards CRD to be ready
+  community.kubernetes.k8s_info:
+    api_version: apiextensions.k8s.io/v1beta1
+    kind: CustomResourceDefinition
+    name: monitoringdashboards.monitoring.kiali.io
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+  register: monitoringdashboards_crd
+  until:
+  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  retries: 6
+  delay: 5
+  ignore_errors: yes
+
+- name: Warn if Monitoring Dashboards CRD is not available
+  debug:
+    msg: "It does not appear you have the Monitoring Dashboard CRD created. Monitoring Dashboards will not be created."
+  when:
+  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join != 'True'
+  ignore_errors: yes
+
+- name: Find all Monitoring Dashboards packaged with the operator
+  find:
+    paths: "{{ role_path }}/templates/dashboards"
+  register: monitoring_dashboard_yamls_all_raw
+  ignore_errors: yes
+- set_fact:
+    monitoring_dashboard_yamls_all: "{{ (monitoring_dashboard_yamls_all | default([])) + [ item.path ] }}"
+  loop: "{{ monitoring_dashboard_yamls_all_raw.files }}"
+  when:
+  - monitoring_dashboard_yamls_all_raw is defined
+  - monitoring_dashboard_yamls_all_raw.files is defined
+  ignore_errors: yes
+
+- name: Determine which Monitoring Dashboards are to be created
+  find:
+    paths: "{{ role_path }}/templates/dashboards"
+    patterns: "{{ kiali_vars.deployment.custom_dashboards.includes }}"
+    excludes: "{{ kiali_vars.deployment.custom_dashboards.excludes }}"
+  register: monitoring_dashboard_yamls_to_deploy_raw
+  ignore_errors: yes
+- set_fact:
+    monitoring_dashboard_yamls_to_deploy: "{{ (monitoring_dashboard_yamls_to_deploy | default([])) + [ item.path ] }}"
+  loop: "{{ monitoring_dashboard_yamls_to_deploy_raw.files }}"
+  when:
+  - monitoring_dashboard_yamls_to_deploy_raw is defined
+  - monitoring_dashboard_yamls_to_deploy_raw.files is defined
+  ignore_errors: yes
+
+- name: Remove Monitoring Dashboards that should no longer be deployed
+  k8s:
+    state: "absent"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    definition: "{{ lookup('template', item) }}"
+  loop: "{{ (monitoring_dashboard_yamls_all | default([])) | difference(monitoring_dashboard_yamls_to_deploy | default([])) }}"
+  when:
+  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  ignore_errors: yes
+
+- name: Create the Monitoring Dashboards
+  k8s:
+    state: "present"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    definition: "{{ lookup('template', item) }}"
+  loop: "{{ monitoring_dashboard_yamls_to_deploy | default([]) }}"
+  when:
+  - monitoring_dashboard_yamls_to_deploy is defined
+  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  ignore_errors: yes
+
+# If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
+
+- name: Force the Kiali pod to restart if necessary
+  vars:
+    updated_deployment: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+  k8s:
+    state: "present"
+    definition: "{{ updated_deployment }}"
+  when:
+  - deployment_is_new == False
+  - processed_resources.configmap is defined
+  - processed_resources.configmap.changed == True
+  - processed_resources.configmap.method == "patch"
+
+- include_tasks: update-status.yml
+  vars:
+    status_vars:
+      accessibleNamespaces: "{{ kiali_vars.deployment.accessible_namespaces }}"

--- a/roles/v1.24/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/v1.24/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -1,0 +1,48 @@
+# All of this is ultimately to obtain the kiali_route_url
+
+# Give some time for the route to come up
+
+- name: Detect Kiali route on OpenShift
+  community.kubernetes.k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: kiali
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+  register: kiali_route_raw
+  until:
+  - kiali_route_raw['resources'] is defined
+  - kiali_route_raw['resources'][0] is defined
+  - kiali_route_raw['resources'][0]['status'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] is defined
+  retries: 30
+  delay: 10
+  when:
+  - is_openshift == True
+
+- name: Set Kiali TLS Termination from OpenShift route
+  set_fact:
+    kiali_route_tls_termination: "{{ kiali_route_raw['resources'][0]['spec']['tls']['termination'] }}"
+  when:
+  - is_openshift == True
+
+- name: Detect HTTP Kiali OpenShift route protocol
+  set_fact:
+    kiali_route_protocol: "http"
+  when:
+  - is_openshift == True
+  - kiali_route_tls_termination == ""
+
+- name: Detect HTTPS Kiali OpenShift route protocol
+  set_fact:
+    kiali_route_protocol: "https"
+  when:
+  - is_openshift == True
+  - kiali_route_tls_termination != ""
+
+- name: Create URL for Kiali OpenShift route
+  set_fact:
+    kiali_route_url: "{{ kiali_route_protocol }}://{{ kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] }}"
+  when:
+  - is_openshift == True

--- a/roles/v1.24/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/v1.24/kiali-deploy/tasks/openshift/os-main.yml
@@ -1,0 +1,86 @@
+- name: Create Kiali objects on OpenShift
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_cluster: "openshift"
+    role_namespace: "{{ kiali_vars.deployment.namespace }}"
+  loop:
+  - serviceaccount
+  - configmap
+  - cabundle
+  - "{{ 'role-viewer' if kiali_vars.deployment.view_only_mode == True else 'role' }}"
+  - rolebinding
+  - deployment
+  - service
+  loop_control:
+    loop_var: process_resource_item
+  when:
+  - is_openshift == True
+
+- name: Create Route on OpenShift if enabled
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_cluster: "openshift"
+    role_namespace: "{{ kiali_vars.deployment.namespace }}"
+  loop:
+  - route
+  loop_control:
+    loop_var: process_resource_item
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.ingress_enabled == True
+
+- name: Delete Route on OpenShift if disabled
+  k8s:
+    state: absent
+    api_version: "route.openshift.io/v1"
+    kind: "Route"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "kiali"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.ingress_enabled == False
+
+- name: Create additional Kiali roles on OpenShift
+  include_tasks: process-additional-roles.yml
+  vars:
+    process_resource_cluster: "openshift"
+  loop: "{{ kiali_vars.deployment.accessible_namespaces }}"
+  loop_control:
+    loop_var: role_namespace
+  when:
+  - is_openshift == True
+  - '"**" not in kiali_vars.deployment.accessible_namespaces'
+
+- name: Get the Kiali Route URL
+  include: openshift/os-get-kiali-route-url.yml
+  when:
+  - is_openshift == True
+
+- name: Process OpenShift OAuth client
+  k8s:
+    definition: "{{ lookup('template', 'templates/openshift/oauth.yaml') }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.auth.strategy == "openshift"
+
+- name: Delete all ConsoleLinks for namespaces that are no longer accessible
+  k8s:
+    state: absent
+    api_version: console.openshift.io/v1
+    kind: ConsoleLink
+    name: "kiali-namespace-{{ inaccessible_namespace }}"
+  loop: "{{ no_longer_accessible_namespaces }}"
+  loop_control:
+    loop_var: inaccessible_namespace
+  when:
+  - is_openshift == True
+  - no_longer_accessible_namespaces is defined
+
+- name: Process OpenShift Console Links
+  k8s:
+    definition: "{{ lookup('template', 'templates/openshift/console-links.yaml') }}"
+  vars:
+    # When accessible_namespaces=**, the kiali.io/member-of label is not set, but maistra.io/member-of are always present
+    namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace', label_selector=('maistra.io/member-of=' + kiali_vars.istio_namespace)) | default({}) | json_query('[].metadata.name') if '**' in all_accessible_namespaces else all_accessible_namespaces }}"
+  when:
+  - is_openshift == True

--- a/roles/v1.24/kiali-deploy/tasks/process-additional-roles.yml
+++ b/roles/v1.24/kiali-deploy/tasks/process-additional-roles.yml
@@ -1,0 +1,16 @@
+# Create the roles needed to access a given namespace.
+# If the namespace does not exist, this task will be skipped.
+- name: "Create additional Kiali roles in [{{ process_resource_cluster }}] namespace [{{ role_namespace }}]"
+  vars:
+    role_namespace_obj: "{{ lookup('k8s', namespace=role_namespace, kind='Namespace', resource_name=role_namespace, api_version='v1') }}"
+  include_tasks: process-resource.yml
+  loop:
+  - "{{ 'role-viewer' if kiali_vars.deployment.view_only_mode == True else 'role' }}"
+  - rolebinding
+  loop_control:
+    loop_var: process_resource_item
+  when:
+  - role_namespace_obj is defined
+  - role_namespace_obj.metadata is defined
+  - role_namespace_obj.metadata.name is defined
+  - role_namespace_obj.metadata.name == role_namespace

--- a/roles/v1.24/kiali-deploy/tasks/process-resource.yml
+++ b/roles/v1.24/kiali-deploy/tasks/process-resource.yml
@@ -1,0 +1,15 @@
+- name: "Create resource [{{ process_resource_item }}] on [{{ process_resource_cluster }}]"
+  k8s:
+    state: "present"
+    definition: "{{ lookup('template', 'templates/' + process_resource_cluster + '/' + process_resource_item + '.yaml') }}"
+  register: process_resource_result
+  until:
+  - process_resource_result.error is not defined
+  - process_resource_result.result is defined
+  - process_resource_result.result.metadata is defined
+  retries: 6
+  delay: 10
+
+# Store the results of the processed resource so they can be examined later (e.g. to know if something changed or stayed the same)
+- set_fact:
+    processed_resources: "{{ processed_resources | default({}) | combine( { process_resource_item: { 'changed': process_resource_result.changed, 'method': process_resource_result.method } } ) }}"

--- a/roles/v1.24/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/v1.24/kiali-deploy/tasks/remove-clusterroles.yml
@@ -1,0 +1,24 @@
+- name: Delete unused Kiali cluster roles
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True or is_k8s == True
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  loop_control:
+    loop_var: k8s_item

--- a/roles/v1.24/kiali-deploy/tasks/remove-namespace-label.yml
+++ b/roles/v1.24/kiali-deploy/tasks/remove-namespace-label.yml
@@ -1,0 +1,33 @@
+- debug:
+    msg: "Remove namespace label [{{ the_namespace_label_name }}] from namespace [{{ the_namespace }}]"
+
+- set_fact:
+    the_namespace_raw: {}
+    the_labeled_namespace: {}
+    the_namespace_label_value: null
+
+- name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ the_namespace }}"
+    namespace: "{{ the_namespace }}"
+  register: the_namespace_raw
+
+- set_fact:
+    the_labeled_namespace: "{{ the_namespace_raw['resources'][0] | combine({'metadata': {'labels': { the_namespace_label_name: the_namespace_label_value }}}, recursive=True) }}"
+  when:
+  - the_namespace_raw['resources'] is defined
+  - the_namespace_raw['resources'][0] is defined
+
+- debug:
+    msg: "Failed to remove the label from namespace [{{ the_namespace }}]. This usually happens if the namespace has been deleted."
+  when:
+  - the_labeled_namespace.metadata is not defined
+
+- name: "Saving the label removal from namespace [{{ the_namespace }}]"
+  k8s:
+    state: "present"
+    definition: "{{ the_labeled_namespace }}"
+  when:
+  - the_labeled_namespace.metadata is defined

--- a/roles/v1.24/kiali-deploy/tasks/remove-roles.yml
+++ b/roles/v1.24/kiali-deploy/tasks/remove-roles.yml
@@ -1,0 +1,26 @@
+- name: Delete unused Kiali roles from previously accessible namespaces
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    namespace: "{{ role_namespace }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True or is_k8s == True
+  - role_namespace is defined
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', namespace=role_namespace, kind='RoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=role_namespace, kind='Role', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=role_namespace, kind='Role', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  loop_control:
+    loop_var: k8s_item

--- a/roles/v1.24/kiali-deploy/tasks/update-status.yml
+++ b/roles/v1.24/kiali-deploy/tasks/update-status.yml
@@ -1,0 +1,7 @@
+- operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars }}"
+  ignore_errors: yes

--- a/roles/v1.24/kiali-deploy/templates/dashboards/envoy.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/envoy.yaml
@@ -1,0 +1,49 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: envoy
+spec:
+  title: Envoy Metrics
+#  discoverOn: "envoy_server_uptime"
+  items:
+  - chart:
+      name: "Pods uptime"
+      spans: 4
+      metricName: "envoy_server_uptime"
+      dataType: "raw"
+  - chart:
+      name: "Allocated memory"
+      unit: "bytes"
+      spans: 4
+      metricName: "envoy_server_memory_allocated"
+      dataType: "raw"
+      min: 0
+  - chart:
+      name: "Heap size"
+      unit: "bytes"
+      spans: 4
+      metricName: "envoy_server_memory_heap_size"
+      dataType: "raw"
+      min: 0
+  - chart:
+      name: "Upstream active connections"
+      spans: 6
+      metricName: "envoy_cluster_upstream_cx_active"
+      dataType: "raw"
+  - chart:
+      name: "Upstream total requests"
+      spans: 6
+      metricName: "envoy_cluster_upstream_rq_total"
+      unit: "rps"
+      dataType: "rate"
+  - chart:
+      name: "Downstream active connections"
+      spans: 6
+      metricName: "envoy_listener_downstream_cx_active"
+      dataType: "raw"
+  - chart:
+      name: "Downstream HTTP requests"
+      spans: 6
+      metricName: "envoy_listener_http_downstream_rq"
+      unit: "rps"
+      dataType: "rate"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/go.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/go.yaml
@@ -1,0 +1,60 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: go
+spec:
+  title: Go Metrics
+  runtime: Go
+  discoverOn: "go_info"
+  items:
+  - chart:
+      name: "CPU ratio"
+      spans: 6
+      metricName: "process_cpu_seconds_total"
+      dataType: "rate"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
+  - chart:
+      name: "RSS Memory"
+      unit: "bytes"
+      spans: 6
+      metricName: "process_resident_memory_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
+  - chart:
+      name: "Goroutines"
+      spans: 6
+      metricName: "go_goroutines"
+      dataType: "raw"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
+  - chart:
+      name: "Heap allocation rate"
+      unit: "bytes/s"
+      spans: 6
+      metricName: "go_memstats_alloc_bytes_total"
+      dataType: "rate"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
+  - chart:
+      name: "GC rate"
+      spans: 6
+      metricName: "go_gc_duration_seconds_count"
+      dataType: "rate"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"
+  - chart:
+      name: "Next GC"
+      unit: "bytes"
+      spans: 6
+      metricName: "go_memstats_next_gc_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "pod_name"
+        displayName: "Pod"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/kiali.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/kiali.yaml
@@ -1,0 +1,37 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: kiali
+spec:
+  title: Kiali Internal Metrics
+  items:
+  - chart:
+      name: "API processing duration"
+      unit: "seconds"
+      spans: 6
+      metricName: "kiali_api_processing_duration_seconds"
+      dataType: "histogram"
+      aggregations:
+      - label: "route"
+        displayName: "Route"
+  - chart:
+      name: "Functions processing duration"
+      unit: "seconds"
+      spans: 6
+      metricName: "kiali_go_function_processing_duration_seconds"
+      dataType: "histogram"
+      aggregations:
+      - label: "function"
+        displayName: "Function"
+      - label: "package"
+        displayName: "Package"
+  - chart:
+      name: "Failures"
+      spans: 12
+      metricName: "kiali_go_function_failures_total"
+      dataType: "raw"
+      aggregations:
+      - label: "function"
+        displayName: "Function"
+      - label: "package"
+        displayName: "Package"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
@@ -1,0 +1,36 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: micrometer-1.0.6-jvm-pool
+spec:
+  runtime: JVM
+  title: JVM Pool Metrics
+  discoverOn: "jvm_buffer_total_capacity_bytes"
+  items:
+  - chart:
+      name: "Pool buffer memory used"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_buffer_memory_used_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "id"
+        displayName: "Pool"
+  - chart:
+      name: "Pool buffer capacity"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_buffer_total_capacity_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "id"
+        displayName: "Pool"
+  - chart:
+      name: "Pool buffer count"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_buffer_count"
+      dataType: "raw"
+      aggregations:
+      - label: "id"
+        displayName: "Pool"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm.yaml
@@ -1,0 +1,58 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: micrometer-1.0.6-jvm
+spec:
+  runtime: JVM
+  title: JVM Metrics
+  discoverOn: "jvm_threads_live"
+  items:
+  - chart:
+      name: "Total live threads"
+      spans: 4
+      metricName: "jvm_threads_live"
+      dataType: "raw"
+  - chart:
+      name: "Daemon threads"
+      spans: 4
+      metricName: "jvm_threads_daemon"
+      dataType: "raw"
+  - chart:
+      name: "Loaded classes"
+      spans: 4
+      metricName: "jvm_classes_loaded"
+      dataType: "raw"
+
+  - chart:
+      name: "Memory used"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_memory_used_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "area"
+        displayName: "Area"
+      - label: "id"
+        displayName: "Space"
+  - chart:
+      name: "Memory commited"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_memory_committed_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "area"
+        displayName: "Area"
+      - label: "id"
+        displayName: "Space"
+  - chart:
+      name: "Memory max"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_memory_max_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "area"
+        displayName: "Area"
+      - label: "id"
+        displayName: "Space"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/micrometer-1.1-jvm.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/micrometer-1.1-jvm.yaml
@@ -1,0 +1,61 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: micrometer-1.1-jvm
+spec:
+  runtime: JVM
+  title: JVM Metrics
+  discoverOn: "jvm_threads_live_threads"
+  items:
+  - chart:
+      name: "Memory used"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_memory_used_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "area"
+        displayName: "Area"
+      - label: "id"
+        displayName: "Space"
+  - chart:
+      name: "Memory commited"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_memory_committed_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "area"
+        displayName: "Area"
+      - label: "id"
+        displayName: "Space"
+  - chart:
+      name: "Memory max"
+      unit: "bytes"
+      spans: 4
+      metricName: "jvm_memory_max_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "area"
+        displayName: "Area"
+      - label: "id"
+        displayName: "Space"
+
+  - chart:
+      name: "Total live threads"
+      spans: 4
+      metricName: "jvm_threads_live_threads"
+      dataType: "raw"
+  - chart:
+      name: "Daemon threads"
+      spans: 4
+      metricName: "jvm_threads_daemon_threads"
+      dataType: "raw"
+  - chart:
+      name: "Threads states"
+      spans: 4
+      metricName: "jvm_threads_states_threads"
+      dataType: "raw"
+      aggregations:
+      - label: "state"
+        displayName: "State"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/microprofile-1.1.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/microprofile-1.1.yaml
@@ -1,0 +1,52 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: microprofile-1.1
+spec:
+  title: MicroProfile Metrics
+  runtime: MicroProfile
+  discoverOn: "base:thread_count"
+  items:
+  - chart:
+      name: "Current loaded classes"
+      spans: 6
+      metricName: "base:classloader_current_loaded_class_count"
+      dataType: "raw"
+  - chart:
+      name: "Unloaded classes"
+      spans: 6
+      metricName: "base:classloader_total_unloaded_class_count"
+      dataType: "raw"
+  - chart:
+      name: "Thread count"
+      spans: 4
+      metricName: "base:thread_count"
+      dataType: "raw"
+  - chart:
+      name: "Thread max count"
+      spans: 4
+      metricName: "base:thread_max_count"
+      dataType: "raw"
+  - chart:
+      name: "Thread daemon count"
+      spans: 4
+      metricName: "base:thread_daemon_count"
+      dataType: "raw"
+  - chart:
+      name: "Committed heap"
+      unit: "bytes"
+      spans: 4
+      metricName: "base:memory_committed_heap_bytes"
+      dataType: "raw"
+  - chart:
+      name: "Max heap"
+      unit: "bytes"
+      spans: 4
+      metricName: "base:memory_max_heap_bytes"
+      dataType: "raw"
+  - chart:
+      name: "Used heap"
+      unit: "bytes"
+      spans: 4
+      metricName: "base:memory_used_heap_bytes"
+      dataType: "raw"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/microprofile-x.y.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/microprofile-x.y.yaml
@@ -1,0 +1,31 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: microprofile-x.y
+spec:
+  title: MicroProfile Metrics
+  runtime: MicroProfile
+  discoverOn: "base:gc_complete_scavenger_count"
+  items:
+  - chart:
+      name: "Young GC time"
+      unit: "seconds"
+      spans: 3
+      metricName: "base:gc_young_generation_scavenger_time_seconds"
+      dataType: "raw"
+  - chart:
+      name: "Young GC count"
+      spans: 3
+      metricName: "base:gc_young_generation_scavenger_count"
+      dataType: "raw"
+  - chart:
+      name: "Total GC time"
+      unit: "seconds"
+      spans: 3
+      metricName: "base:gc_complete_scavenger_time_seconds"
+      dataType: "raw"
+  - chart:
+      name: "Total GC count"
+      spans: 3
+      metricName: "base:gc_complete_scavenger_count"
+      dataType: "raw"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/nodejs.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/nodejs.yaml
@@ -1,0 +1,52 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: nodejs
+spec:
+  runtime: Node.js
+  title: Node.js Metrics
+  discoverOn: "nodejs_active_handles_total"
+  items:
+  - chart:
+      name: "Active handles"
+      spans: 4
+      metricName: "nodejs_active_handles_total"
+      dataType: "raw"
+  - chart:
+      name: "Active requests"
+      spans: 4
+      metricName: "nodejs_active_requests_total"
+      dataType: "raw"
+  - chart:
+      name: "Event loop lag"
+      unit: "seconds"
+      spans: 4
+      metricName: "nodejs_eventloop_lag_seconds"
+      dataType: "raw"
+  - chart:
+      name: "Total heap size"
+      unit: "bytes"
+      spans: 12
+      metricName: "nodejs_heap_space_size_total_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "space"
+        displayName: "Space"
+  - chart:
+      name: "Used heap size"
+      unit: "bytes"
+      spans: 6
+      metricName: "nodejs_heap_space_size_used_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "space"
+        displayName: "Space"
+  - chart:
+      name: "Available heap size"
+      unit: "bytes"
+      spans: 6
+      metricName: "nodejs_heap_space_size_available_bytes"
+      dataType: "raw"
+      aggregations:
+      - label: "space"
+        displayName: "Space"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/quarkus.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/quarkus.yaml
@@ -1,0 +1,26 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: quarkus
+spec:
+  title: Quarkus Metrics
+  runtime: Quarkus
+  items:
+  - chart:
+      name: "Thread count"
+      spans: 4
+      metricName: "vendor:thread_count"
+      dataType: "raw"
+  - chart:
+      name: "Used heap"
+      unit: "bytes"
+      spans: 4
+      metricName: "vendor:memory_heap_usage_bytes"
+      dataType: "raw"
+  - chart:
+      name: "Used non-heap"
+      unit: "bytes"
+      spans: 4
+      metricName: "vendor:memory_non_heap_usage_bytes"
+      dataType: "raw"
+  - include: "microprofile-x.y"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/springboot-jvm-pool.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/springboot-jvm-pool.yaml
@@ -1,0 +1,9 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: springboot-jvm-pool
+spec:
+  runtime: Spring Boot
+  title: JVM Pool Metrics
+  items:
+  - include: "micrometer-1.0.6-jvm-pool"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/springboot-jvm.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/springboot-jvm.yaml
@@ -1,0 +1,9 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: springboot-jvm
+spec:
+  runtime: Spring Boot
+  title: JVM Metrics
+  items:
+  - include: "micrometer-1.0.6-jvm"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/springboot-tomcat.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/springboot-tomcat.yaml
@@ -1,0 +1,9 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: springboot-tomcat
+spec:
+  runtime: Spring Boot
+  title: Tomcat Metrics
+  items:
+  - include: "tomcat"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/thorntail.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/thorntail.yaml
@@ -1,0 +1,15 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: thorntail
+spec:
+  runtime: Thorntail
+  title: Thorntail Metrics
+  discoverOn: "vendor:loaded_modules"
+  items:
+  - include: "microprofile-1.1"
+  - chart:
+      name: "Loaded modules"
+      spans: 6
+      metricName: "vendor:loaded_modules"
+      dataType: "raw"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/tomcat.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/tomcat.yaml
@@ -1,0 +1,60 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: tomcat
+spec:
+  runtime: Tomcat
+  title: Tomcat Metrics
+  discoverOn: "tomcat_sessions_created_total"
+  items:
+  - chart:
+      name: "Sessions created"
+      spans: 4
+      metricName: "tomcat_sessions_created_total"
+      dataType: "raw"
+  - chart:
+      name: "Active sessions"
+      spans: 4
+      metricName: "tomcat_sessions_active_current"
+      dataType: "raw"
+  - chart:
+      name: "Sessions rejected"
+      spans: 4
+      metricName: "tomcat_sessions_rejected_total"
+      dataType: "raw"
+
+  - chart:
+      name: "Bytes sent"
+      unit: "bitrate"
+      spans: 6
+      metricName: "tomcat_global_sent_bytes_total"
+      dataType: "rate"
+      aggregations:
+      - label: "name"
+        displayName: "Name"
+  - chart:
+      name: "Bytes received"
+      unit: "bitrate"
+      spans: 6
+      metricName: "tomcat_global_received_bytes_total"
+      dataType: "rate"
+      aggregations:
+      - label: "name"
+        displayName: "Name"
+
+  - chart:
+      name: "Global errors"
+      spans: 6
+      metricName: "tomcat_global_error_total"
+      dataType: "raw"
+      aggregations:
+      - label: "name"
+        displayName: "Name"
+  - chart:
+      name: "Servlet errors"
+      spans: 6
+      metricName: "tomcat_servlet_error_total"
+      dataType: "raw"
+      aggregations:
+      - label: "name"
+        displayName: "Name"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/vertx-client.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/vertx-client.yaml
@@ -1,0 +1,53 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: vertx-client
+spec:
+  runtime: Vert.x
+  title: Vert.x Client Metrics
+  discoverOn: "vertx_http_client_connections"
+  items:
+  - chart:
+      name: "Client response time"
+      unit: "seconds"
+      spans: 6
+      metricName: "vertx_http_client_responseTime_seconds"
+      dataType: "histogram"
+      aggregations:
+      - label: "path"
+        displayName: "Path"
+      - label: "method"
+        displayName: "Method"
+  - chart:
+      name: "Client request count rate"
+      unit: "ops"
+      spans: 6
+      metricName: "vertx_http_client_requestCount_total"
+      dataType: "rate"
+      aggregations:
+      - label: "path"
+        displayName: "Path"
+      - label: "method"
+        displayName: "Method"
+  - chart:
+      name: "Client active connections"
+      spans: 6
+      metricName: "vertx_http_client_connections"
+      dataType: "raw"
+  - chart:
+      name: "Client active websockets"
+      spans: 6
+      metricName: "vertx_http_client_wsConnections"
+      dataType: "raw"
+  - chart:
+      name: "Client bytes sent"
+      unit: "bytes"
+      spans: 6
+      metricName: "vertx_http_client_bytesSent"
+      dataType: "histogram"
+  - chart:
+      name: "Client bytes received"
+      unit: "bytes"
+      spans: 6
+      metricName: "vertx_http_client_bytesReceived"
+      dataType: "histogram"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/vertx-eventbus.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/vertx-eventbus.yaml
@@ -1,0 +1,52 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: vertx-eventbus
+spec:
+  runtime: Vert.x
+  title: Vert.x Eventbus Metrics
+  discoverOn: "vertx_eventbus_handlers"
+  items:
+  - chart:
+      name: "Event bus handlers"
+      spans: 6
+      metricName: "vertx_eventbus_handlers"
+      dataType: "raw"
+      aggregations:
+      - label: "address"
+        displayName: "Eventbus address"
+  - chart:
+      name: "Event bus pending messages"
+      spans: 6
+      metricName: "vertx_eventbus_pending"
+      dataType: "raw"
+      aggregations:
+      - label: "address"
+        displayName: "Eventbus address"
+  - chart:
+      name: "Event bus processing time"
+      unit: "seconds"
+      spans: 6
+      metricName: "vertx_eventbus_processingTime_seconds"
+      dataType: "histogram"
+      aggregations:
+      - label: "address"
+        displayName: "Eventbus address"
+  - chart:
+      name: "Event bus bytes read"
+      unit: "bytes"
+      spans: 6
+      metricName: "vertx_eventbus_bytesRead"
+      dataType: "histogram"
+      aggregations:
+      - label: "address"
+        displayName: "Eventbus address"
+  - chart:
+      name: "Event bus bytes written"
+      unit: "bytes"
+      spans: 6
+      metricName: "vertx_eventbus_bytesWritten"
+      dataType: "histogram"
+      aggregations:
+      - label: "address"
+        displayName: "Eventbus address"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/vertx-jvm.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/vertx-jvm.yaml
@@ -1,0 +1,9 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: vertx-jvm
+spec:
+  runtime: Vert.x
+  title: JVM Metrics
+  items:
+  - include: "micrometer-1.1-jvm"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/vertx-pool.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/vertx-pool.yaml
@@ -1,0 +1,61 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: vertx-pool
+spec:
+  runtime: Vert.x
+  title: Vert.x Pools Metrics
+  discoverOn: "vertx_pool_ratio"
+  items:
+  - chart:
+      name: "Usage duration"
+      unit: "seconds"
+      spans: 6
+      metricName: "vertx_pool_usage_seconds"
+      dataType: "histogram"
+      aggregations:
+      - label: "pool_name"
+        displayName: "Name"
+      - label: "pool_type"
+        displayName: "Type"
+  - chart:
+      name: "Usage ratio"
+      spans: 6
+      metricName: "vertx_pool_ratio"
+      dataType: "raw"
+      aggregations:
+      - label: "pool_name"
+        displayName: "Name"
+      - label: "pool_type"
+        displayName: "Type"
+  - chart:
+      name: "Queue size"
+      spans: 6
+      metricName: "vertx_pool_queue_size"
+      dataType: "raw"
+      aggregations:
+      - label: "pool_name"
+        displayName: "Name"
+      - label: "pool_type"
+        displayName: "Type"
+  - chart:
+      name: "Time in queue"
+      unit: "seconds"
+      spans: 6
+      metricName: "vertx_pool_queue_delay_seconds"
+      dataType: "histogram"
+      aggregations:
+      - label: "pool_name"
+        displayName: "Name"
+      - label: "pool_type"
+        displayName: "Type"
+  - chart:
+      name: "Resources used"
+      spans: 6
+      metricName: "vertx_pool_inUse"
+      dataType: "raw"
+      aggregations:
+      - label: "pool_name"
+        displayName: "Name"
+      - label: "pool_type"
+        displayName: "Type"

--- a/roles/v1.24/kiali-deploy/templates/dashboards/vertx-server.yaml
+++ b/roles/v1.24/kiali-deploy/templates/dashboards/vertx-server.yaml
@@ -1,0 +1,55 @@
+apiVersion: "monitoring.kiali.io/v1alpha1"
+kind: MonitoringDashboard
+metadata:
+  name: vertx-server
+spec:
+  runtime: Vert.x
+  title: Vert.x Server Metrics
+  discoverOn: "vertx_http_server_connections"
+  items:
+  - chart:
+      name: "Server response time"
+      unit: "seconds"
+      spans: 6
+      metricName: "vertx_http_server_responseTime_seconds"
+      dataType: "histogram"
+      aggregations:
+      - label: "path"
+        displayName: "Path"
+      - label: "method"
+        displayName: "Method"
+  - chart:
+      name: "Server request count rate"
+      unit: "ops"
+      spans: 6
+      metricName: "vertx_http_server_requestCount_total"
+      dataType: "rate"
+      aggregations:
+      - label: "code"
+        displayName: "Error code"
+      - label: "path"
+        displayName: "Path"
+      - label: "method"
+        displayName: "Method"
+  - chart:
+      name: "Server active connections"
+      spans: 6
+      metricName: "vertx_http_server_connections"
+      dataType: "raw"
+  - chart:
+      name: "Server active websockets"
+      spans: 6
+      metricName: "vertx_http_server_wsConnections"
+      dataType: "raw"
+  - chart:
+      name: "Server bytes sent"
+      unit: "bytes"
+      spans: 6
+      metricName: "vertx_http_server_bytesSent"
+      dataType: "histogram"
+  - chart:
+      name: "Server bytes received"
+      unit: "bytes"
+      spans: 6
+      metricName: "vertx_http_server_bytesReceived"
+      dataType: "histogram"

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+data:
+  config.yaml: |
+    {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -1,0 +1,156 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    kiali.io/api-spec: https://kiali.io/api
+    kiali.io/api-type: rest
+spec:
+  replicas: {{ kiali_vars.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: kiali
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      name: kiali
+      labels:
+        app: kiali
+        version: {{ kiali_vars.deployment.version_label }}
+      annotations:
+{% if kiali_vars.server.metrics_enabled == True %}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ kiali_vars.server.metrics_port }}"
+{% else %}
+        prometheus.io/scrape: "false"
+        prometheus.io/port: null
+{% endif %}
+        kiali.io/runtimes: go,kiali
+        operator.kiali.io/last-updated: "{{ deployment_last_updated }}"
+{% if kiali_vars.deployment.pod_annotations|length > 0 %}
+        {{ kiali_vars.deployment.pod_annotations | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+    spec:
+      serviceAccount: kiali-service-account
+{% if kiali_vars.deployment.priority_class_name != "" %}
+      priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
+{% endif %}
+{% if kiali_vars.deployment.image_pull_secrets | default([]) | length > 0 %}
+      imagePullSecrets:
+{% for n in kiali_vars.deployment.image_pull_secrets %}
+      - name: {{ n }}
+{% endfor %}
+{% endif %}
+      containers:
+      - image: {{ kiali_vars.deployment.image_name }}:{{ kiali_vars.deployment.image_version }}
+        imagePullPolicy: {{ kiali_vars.deployment.image_pull_policy }}
+        name: kiali
+        command:
+        - "/opt/kiali/kiali"
+        - "-config"
+        - "/kiali-configuration/config.yaml"
+        - "-v"
+        - "{{ kiali_vars.deployment.verbose_mode }}"
+        ports:
+          - name: api-port
+            containerPort: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.metrics_enabled == True %}
+          - name: http-metrics
+            containerPort: {{ kiali_vars.server.metrics_port }}
+{% endif %}
+        readinessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        livenessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        env:
+        - name: ACTIVE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+{% for env in kiali_deployment_environment_variables %}
+        - name: {{ env }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ kiali_deployment_environment_variables[env].secret_name }}
+              key: {{ kiali_deployment_environment_variables[env].secret_key }}
+{% endfor %}
+        volumeMounts:
+        - name: kiali-configuration
+          mountPath: "/kiali-configuration"
+        - name: kiali-cert
+          mountPath: "/kiali-cert"
+        - name: kiali-secret
+          mountPath: "/kiali-secret"
+{% if kiali_vars.deployment.resources|length > 0 %}
+        resources:
+          {{ kiali_vars.deployment.resources | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        resources: null
+{% endif %}
+      volumes:
+      - name: kiali-configuration
+        configMap:
+          name: kiali
+      - name: kiali-cert
+        secret:
+          secretName: istio.kiali-service-account
+{% if kiali_vars.identity.cert_file == "" %}
+          optional: true
+{% endif %}
+      - name: kiali-secret
+        secret:
+          secretName: {{ kiali_vars.deployment.secret_name }}
+          optional: true
+{% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+      affinity:
+{% if kiali_vars.deployment.affinity.node|length > 0 %}
+        nodeAffinity:
+          {{ kiali_vars.deployment.affinity.node | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        nodeAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod|length > 0 %}
+        podAffinity:
+          {{ kiali_vars.deployment.affinity.pod | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+        podAntiAffinity:
+          {{ kiali_vars.deployment.affinity.pod_anti | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAntiAffinity: null
+{% endif %}
+{% else %}
+      affinity: null
+{% endif %}
+{% if kiali_vars.deployment.tolerations|length > 0 %}
+      tolerations:
+      {{ kiali_vars.deployment.tolerations | to_nice_yaml(indent=0) | trim | indent(6) }}
+{% else %}
+      tolerations: null
+{% endif %}
+{% if kiali_vars.deployment.node_selector|length > 0 %}
+      nodeSelector:
+        {{ kiali_vars.deployment.node_selector | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% else %}
+      nodeSelector: null
+{% endif %}

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
+  annotations:
+    # For ingress-nginx versions older than 0.20.0
+    # (see: https://github.com/kubernetes/ingress-nginx/issues/3416#issuecomment-438247948)
+    nginx.ingress.kubernetes.io/secure-backends: "{{ 'false' if kiali_vars.identity.cert_file == "" else 'true' }}"
+    # For ingress-nginx versions 0.20.0 and later
+    nginx.ingress.kubernetes.io/backend-protocol: "{{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}"
+{% endif %}
+spec:
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.spec is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
+  rules:
+  - http:
+      paths:
+      - path: {{ kiali_vars.server.web_root }}
+        backend:
+          serviceName: kiali
+          servicePort: {{ kiali_vars.server.port }}
+{% endif %}

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -1,0 +1,70 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: kiali-viewer
+  namespace: {{ role_namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  - rbac.istio.io
+  - security.istio.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+  - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - get
+  - list

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/role.yaml
@@ -1,0 +1,80 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: kiali
+  namespace: {{ role_namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - config.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  - rbac.istio.io
+  - security.istio.io
+  resources: ["*"]
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+  - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_binding_kind }}
+metadata:
+  name: kiali
+  namespace: {{ role_namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ role_kind }}
+  name: {{ 'kiali-viewer' if kiali_vars.deployment.view_only_mode == True else 'kiali' }}
+subjects:
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: {{ kiali_vars.deployment.namespace }}

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/service.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    kiali.io/api-spec: https://kiali.io/api
+    kiali.io/api-type: rest
+{% if kiali_vars.deployment.service_annotations|length > 0 %}
+    {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% endif %}
+spec:
+{% if kiali_vars.deployment.service_type is defined %}
+  type: {{ kiali_vars.deployment.service_type }}
+{% endif %}
+  ports:
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
+    protocol: TCP
+    port: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.metrics_enabled == True %}
+  - name: http-metrics
+    protocol: TCP
+    port: {{ kiali_vars.server.metrics_port }}
+{% endif %}
+  selector:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/v1.24/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/v1.24/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kiali-service-account
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}

--- a/roles/v1.24/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/cabundle.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali-cabundle
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v1.24/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+data:
+  config.yaml: |
+    {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}

--- a/roles/v1.24/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/console-links.yaml
@@ -1,0 +1,20 @@
+{% if openshift_version is version('4.3', '>=') %}
+{% for namespace in namespaces %}
+---
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: kiali-namespace-{{ namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+    kiali.io/home: {{ kiali_vars.deployment.namespace }}
+spec:
+  href: {{ kiali_route_url }}{{ '/' if kiali_vars.server.web_root == '/' else (kiali_vars.server.web_root + '/') }}console/graph/namespaces?namespaces={{ namespace }}
+  location: NamespaceDashboard
+  text: Kiali
+  namespaceDashboard:
+    namespaces:
+    - {{ namespace }}
+{% endfor %}
+{% endif %}

--- a/roles/v1.24/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/deployment.yaml
@@ -1,0 +1,161 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    kiali.io/api-spec: https://kiali.io/api
+    kiali.io/api-type: rest
+spec:
+  replicas: {{ kiali_vars.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: kiali
+  template:
+    metadata:
+      name: kiali
+      labels:
+        app: kiali
+        version: {{ kiali_vars.deployment.version_label }}
+      annotations:
+{% if kiali_vars.server.metrics_enabled == True %}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ kiali_vars.server.metrics_port }}"
+{% else %}
+        prometheus.io/scrape: "false"
+        prometheus.io/port: null
+{% endif %}
+        kiali.io/runtimes: go,kiali
+        operator.kiali.io/last-updated: "{{ deployment_last_updated }}"
+{% if kiali_vars.deployment.pod_annotations|length > 0 %}
+        {{ kiali_vars.deployment.pod_annotations | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+    strategy:
+      rollingUpdate:
+        maxSurge: 1
+        maxAvailable: 1
+      type: RollingUpdate
+    spec:
+      serviceAccount: kiali-service-account
+{% if kiali_vars.deployment.priority_class_name != "" %}
+      priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
+{% endif %}
+{% if kiali_vars.deployment.image_pull_secrets | default([]) | length > 0 %}
+      imagePullSecrets:
+{% for n in kiali_vars.deployment.image_pull_secrets %}
+      - name: {{ n }}
+{% endfor %}
+{% endif %}
+      containers:
+      - image: {{ kiali_vars.deployment.image_name }}:{{ kiali_vars.deployment.image_version }}
+        imagePullPolicy: {{ kiali_vars.deployment.image_pull_policy }}
+        name: kiali
+        command:
+        - "/opt/kiali/kiali"
+        - "-config"
+        - "/kiali-configuration/config.yaml"
+        - "-v"
+        - "{{ kiali_vars.deployment.verbose_mode }}"
+        ports:
+          - name: api-port
+            containerPort: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.metrics_enabled == True %}
+          - name: http-metrics
+            containerPort: {{ kiali_vars.server.metrics_port }}
+{% endif %}
+        readinessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        livenessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        env:
+        - name: ACTIVE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+{% for env in kiali_deployment_environment_variables %}
+        - name: {{ env }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ kiali_deployment_environment_variables[env].secret_name }}
+              key: {{ kiali_deployment_environment_variables[env].secret_key }}
+{% endfor %}
+        volumeMounts:
+        - name: kiali-configuration
+          mountPath: "/kiali-configuration"
+        - name: kiali-cert
+          mountPath: "/kiali-cert"
+        - name: kiali-secret
+          mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
+{% if kiali_vars.deployment.resources|length > 0 %}
+        resources:
+          {{ kiali_vars.deployment.resources | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        resources: null
+{% endif %}
+      volumes:
+      - name: kiali-configuration
+        configMap:
+          name: kiali
+      - name: kiali-cert
+        secret:
+          secretName: kiali-cert-secret
+{% if kiali_vars.identity.cert_file == "" %}
+          optional: true
+{% endif %}
+      - name: kiali-secret
+        secret:
+          secretName: {{ kiali_vars.deployment.secret_name }}
+          optional: true
+      - name: kiali-cabundle
+        configMap:
+          name: kiali-cabundle
+{% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+      affinity:
+{% if kiali_vars.deployment.affinity.node|length > 0 %}
+        nodeAffinity:
+          {{ kiali_vars.deployment.affinity.node | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        nodeAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod|length > 0 %}
+        podAffinity:
+          {{ kiali_vars.deployment.affinity.pod | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+        podAntiAffinity:
+          {{ kiali_vars.deployment.affinity.pod_anti | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAntiAffinity: null
+{% endif %}
+{% else %}
+      affinity: null
+{% endif %}
+{% if kiali_vars.deployment.tolerations|length > 0 %}
+      tolerations:
+      {{ kiali_vars.deployment.tolerations | to_nice_yaml(indent=0) | trim | indent(6) }}
+{% else %}
+      tolerations: null
+{% endif %}
+{% if kiali_vars.deployment.node_selector|length > 0 %}
+      nodeSelector:
+        {{ kiali_vars.deployment.node_selector | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% else %}
+      nodeSelector: null
+{% endif %}

--- a/roles/v1.24/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/oauth.yaml
@@ -1,0 +1,11 @@
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: kiali-{{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+redirectURIs:
+  - {{ kiali_route_url }}
+grantMethod: auto
+allowAnyScope: true

--- a/roles/v1.24/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -1,0 +1,101 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: kiali-viewer
+  namespace: {{ role_namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  - rbac.istio.io
+  - security.istio.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["authentication.maistra.io"]
+  resources:
+  - servicemeshpolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["rbac.maistra.io"]
+  resources:
+  - servicemeshrbacconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+  - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - get
+  - list

--- a/roles/v1.24/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/role.yaml
@@ -1,0 +1,118 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: kiali
+  namespace: {{ role_namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - namespaces
+  - nodes
+  - pods
+  - pods/log
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - config.istio.io
+  - networking.istio.io
+  - authentication.istio.io
+  - rbac.istio.io
+  - security.istio.io
+  resources: ["*"]
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["authentication.maistra.io"]
+  resources:
+  - servicemeshpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["rbac.maistra.io"]
+  resources:
+  - servicemeshrbacconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["monitoring.kiali.io"]
+  resources:
+  - monitoringdashboards
+  verbs:
+  - get
+  - list
+- apiGroups: ["iter8.tools"]
+  resources:
+  - experiments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch

--- a/roles/v1.24/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_binding_kind }}
+metadata:
+  name: kiali
+  namespace: {{ role_namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ role_kind }}
+  name: {{ 'kiali-viewer' if kiali_vars.deployment.view_only_mode == True else 'kiali' }}
+subjects:
+- kind: ServiceAccount
+  name: kiali-service-account
+  namespace: {{ kiali_vars.deployment.namespace }}

--- a/roles/v1.24/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/route.yaml
@@ -1,0 +1,23 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}
+spec:
+{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.spec is defined %}
+  {{ kiali_vars.deployment.override_ingress_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    targetPort: {{ kiali_vars.server.port }}
+    name: kiali
+{% endif %}

--- a/roles/v1.24/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/service.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: kiali-cert-secret
+    kiali.io/api-spec: https://kiali.io/api
+    kiali.io/api-type: rest
+{% if kiali_vars.deployment.service_annotations|length > 0 %}
+    {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% endif %}
+spec:
+{% if kiali_vars.deployment.service_type is defined %}
+  type: {{ kiali_vars.deployment.service_type }}
+{% endif %}
+  ports:
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
+    protocol: TCP
+    port: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.metrics_enabled == True %}
+  - name: http-metrics
+    protocol: TCP
+    port: {{ kiali_vars.server.metrics_port }}
+{% endif %}
+  selector:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/v1.24/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/v1.24/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kiali-service-account
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}

--- a/roles/v1.24/kiali-deploy/vars/main.yml
+++ b/roles/v1.24/kiali-deploy/vars/main.yml
@@ -1,0 +1,104 @@
+# These are the actual variables used by the role. You will notice it is
+# one big dictionary (key="kiali_vars") whose child dictionaries mimic those
+# as defined in defaults/main.yml.
+# The child dictionaries below will have values that are a combination of the default values
+# (as found in defaults/main.yaml) and user-supplied values.
+# Without this magic, a user supplying only one key/value pair in a child dictionary will
+# clear out (make undefined) all the rest of the key/value pairs in that child dictionary.
+# This is not what we want. We want the rest of the dictionary to keep the defaults,
+# thus allowing the user to override only a subset of key/values in a dictionary.
+#
+# I found this trick at https://groups.google.com/forum/#!topic/Ansible-project/pGbRYZyqxZ4
+# I tweeked that solution a little bit because I did not want to require the user to supply
+# everything under a main "kiali_vars" dictionary.
+
+kiali_vars:
+  installation_tag: "{{ installation_tag | default(kiali_defaults.installation_tag) }}"
+  istio_component_namespaces: "{{ istio_component_namespaces | default(kiali_defaults.istio_component_namespaces) }}"
+  istio_namespace: "{{ istio_namespace | default(kiali_defaults.istio_namespace) }}"
+  version: "{{ version | default(kiali_defaults.version) }}"
+
+  additional_display_details: |
+    {%- if additional_display_details is defined and additional_display_details is iterable -%}
+    {{ additional_display_details }}
+    {%- else -%}
+    {{ kiali_defaults.additional_display_details }}
+    {%- endif -%}
+
+  api: |
+    {%- if api is defined and api is iterable -%}
+    {{ kiali_defaults.api | combine((api | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.api }}
+    {%- endif -%}
+
+  auth: |
+    {%- if auth is defined and auth is iterable -%}
+    {{ kiali_defaults.auth | combine((auth | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.auth }}
+    {%- endif -%}
+
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ kiali_defaults.deployment | combine((deployment | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.deployment }}
+    {%- endif -%}
+
+  extensions: |
+    {%- if extensions is defined and extensions is iterable -%}
+    {{ kiali_defaults.extensions | combine((extensions | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.extensions }}
+    {%- endif -%}
+
+  external_services: |
+    {%- if external_services is defined and external_services is iterable -%}
+    {{ kiali_defaults.external_services | combine((external_services | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.external_services }}
+    {%- endif -%}
+
+  identity: |
+    {%- if identity is defined and identity is iterable -%}
+    {{ kiali_defaults.identity | combine((identity | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.identity }}
+    {%- endif -%}
+
+  istio_labels: |
+    {%- if istio_labels is defined and istio_labels is iterable -%}
+    {{ kiali_defaults.istio_labels | combine((istio_labels | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.istio_labels }}
+    {%- endif -%}
+
+  kiali_feature_flags: |
+    {%- if kiali_feature_flags is defined and kiali_feature_flags is iterable -%}
+    {{ kiali_defaults.kiali_feature_flags | combine((kiali_feature_flags | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.kiali_feature_flags }}
+    {%- endif -%}
+
+  kubernetes_config: |
+    {%- if kubernetes_config is defined and kubernetes_config is iterable -%}
+    {{ kiali_defaults.kubernetes_config | combine((kubernetes_config | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.kubernetes_config }}
+    {%- endif -%}
+
+  login_token: |
+    {%- if login_token is defined and login_token is iterable -%}
+    {{ kiali_defaults.login_token | combine((login_token | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.login_token }}
+    {%- endif -%}
+
+  server: |
+    {%- if server is defined and server is iterable -%}
+    {{ kiali_defaults.server | combine((server | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.server }}
+    {%- endif -%}
+

--- a/roles/v1.24/kiali-remove/defaults/main.yml
+++ b/roles/v1.24/kiali-remove/defaults/main.yml
@@ -1,0 +1,7 @@
+kiali_defaults:
+  deployment:
+    accessible_namespaces: []
+
+# Will be auto-detected, but for debugging purposes you can force one of these to true
+is_k8s: false
+is_openshift: false

--- a/roles/v1.24/kiali-remove/tasks/main.yml
+++ b/roles/v1.24/kiali-remove/tasks/main.yml
@@ -1,0 +1,171 @@
+# These tasks remove all Kiali resources such that no remnants of Kiali will remain.
+#
+# Note that we ignore_errors everywhere - we do not want these tasks to ever abort with a failure.
+# This is because these are run within a finalizer and if a failure aborts any task here
+# the user will never be able to delete the Kiali CR - in fact, the delete will hang indefinitely
+# and the user will need to do an ugly hack to fix it.
+
+- name: Get information about the cluster
+  ignore_errors: yes
+  set_fact:
+    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+- name: Determine the cluster type
+  ignore_errors: yes
+  set_fact:
+    is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+# Indicate what kind of cluster we are in (OpenShift or Kubernetes).
+- ignore_errors: yes
+  debug:
+    msg: "CLUSTER TYPE: is_openshift={{ is_openshift }}; is_k8s={{ is_k8s }}"
+
+- name: Print some debug information
+  ignore_errors: yes
+  vars:
+    msg: |
+        Kiali Variables:
+        --------------------------------
+        {{ kiali_vars | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+  tags: test
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  vars:
+    current_cr: "{{ _kiali_io_kiali }}"
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
+
+# When the Operator installed Kiali, the configmap has accessible_namespaces set.
+# There are no regexes in the configmap; they are all full namespace names.
+# NOTE: there is a special value of accessible_namespaces of two asterisks ("**")
+# which indicates Kiali is given access to all namespaces via a single cluster role
+# not individual roles in each accessible namespace.
+
+- name: Find current configmap, if it exists
+  ignore_errors: yes
+  set_fact:
+    current_configmap: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+- name: Find currently accessible namespaces
+  ignore_errors: yes
+  set_fact:
+    current_accessible_namespaces: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.accessible_namespaces') }}"
+  when:
+  - current_configmap is defined
+  - current_configmap.data is defined
+  - current_configmap.data['config.yaml'] is defined
+
+- name: Delete all additional Kiali roles in current accessible namespaces
+  ignore_errors: yes
+  include_tasks: remove-roles.yml
+  when:
+  - is_openshift == True or is_k8s == True
+  - current_accessible_namespaces is defined
+  - '"**" not in current_accessible_namespaces'
+  loop: "{{ current_accessible_namespaces }}"
+  loop_control:
+    loop_var: role_namespace
+
+- name: Find currently configured label selector
+  ignore_errors: yes
+  set_fact:
+    current_label_selector: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('api.namespaces.label_selector') }}"
+  when:
+  - current_configmap is defined
+  - current_configmap.data is defined
+  - current_configmap.data['config.yaml'] is defined
+
+- name: Remove Kiali label from namespaces found in current accessible namespaces
+  ignore_errors: yes
+  include_tasks: remove-namespace-label.yml
+  vars:
+    # everything to the left of the = is the name of the label we want to remove
+    the_namespace_label_name: "{{ current_label_selector | regex_replace('^(.*)=.*$', '\\1') }}"
+  when:
+  - is_openshift == True or is_k8s == True
+  - current_accessible_namespaces is defined
+  - '"**" not in current_accessible_namespaces'
+  - current_label_selector is defined
+  loop: "{{ current_accessible_namespaces }}"
+  loop_control:
+    loop_var: the_namespace
+
+- name: Delete Kiali cluster roles
+  ignore_errors: yes
+  include_tasks: remove-clusterroles.yml
+  when:
+  - is_openshift == True or is_k8s == True
+  - current_accessible_namespaces is defined
+  - '"**" in current_accessible_namespaces'
+
+- name: Delete Kiali resources
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True or is_k8s == True
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name='kiali', api_version='extensions/v1beta1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name='kiali', api_version='apps/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name='kiali', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name='kiali', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name='kiali', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name='kiali-service-account', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
+  loop_control:
+    loop_var: k8s_item
+
+- name: Delete OpenShift-specific Kiali resources
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ os_item.apiVersion }}"
+    kind: "{{ os_item.kind }}"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ os_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result is defined
+  retries: 10
+  delay: 2
+  when:
+  - is_openshift == True
+  - os_item is defined
+  - os_item.apiVersion is defined
+  - os_item.kind is defined
+  - os_item.metadata is defined
+  - os_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', kind='OAuthClient', resource_name='kiali-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name='kiali', api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace) if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali-cabundle', api_version='v1') if is_openshift == True else [] }}"
+  loop_control:
+    loop_var: os_item

--- a/roles/v1.24/kiali-remove/tasks/remove-clusterroles.yml
+++ b/roles/v1.24/kiali-remove/tasks/remove-clusterroles.yml
@@ -1,0 +1,24 @@
+- name: "Delete Kiali cluster roles"
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True or is_k8s == True
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  loop_control:
+    loop_var: k8s_item

--- a/roles/v1.24/kiali-remove/tasks/remove-namespace-label.yml
+++ b/roles/v1.24/kiali-remove/tasks/remove-namespace-label.yml
@@ -1,0 +1,40 @@
+- ignore_errors: yes
+  debug:
+    msg: "Remove namespace label [{{ the_namespace_label_name }}] from namespace [{{ the_namespace }}]"
+
+- ignore_errors: yes
+  set_fact:
+    the_namespace_raw: {}
+    the_labeled_namespace: {}
+    the_namespace_label_value: null
+
+- name: "Get namespace [{{ the_namespace }}] whose label is to be removed"
+  ignore_errors: yes
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Namespace
+    name: "{{ the_namespace }}"
+    namespace: "{{ the_namespace }}"
+  register: the_namespace_raw
+
+- name: Set the namespace label to a value that will enable it to be deleted
+  ignore_errors: yes
+  set_fact:
+    the_labeled_namespace: "{{ the_namespace_raw['resources'][0] | combine({'metadata': {'labels': { the_namespace_label_name: the_namespace_label_value }}}, recursive=True) }}"
+  when:
+  - the_namespace_raw['resources'] is defined
+  - the_namespace_raw['resources'][0] is defined
+
+- ignore_errors: yes
+  debug:
+    msg: "Failed to remove the label from namespace [{{ the_namespace }}]. This usually happens if the namespace has been deleted."
+  when:
+  - the_labeled_namespace.metadata is not defined
+
+- name: "Saving the label removal from namespace [{{ the_namespace }}]"
+  ignore_errors: yes
+  k8s:
+    state: "present"
+    definition: "{{ the_labeled_namespace }}"
+  when:
+  - the_labeled_namespace.metadata is defined

--- a/roles/v1.24/kiali-remove/tasks/remove-roles.yml
+++ b/roles/v1.24/kiali-remove/tasks/remove-roles.yml
@@ -1,0 +1,26 @@
+- name: "Delete additional Kiali roles in accessible namespaces"
+  ignore_errors: yes
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    namespace: "{{ role_namespace }}"
+    name: "{{ k8s_item.metadata.name }}"
+  register: delete_result
+  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True or is_k8s == True
+  - role_namespace is defined
+  - k8s_item is defined
+  - k8s_item.apiVersion is defined
+  - k8s_item.kind is defined
+  - k8s_item.metadata is defined
+  - k8s_item.metadata.name is defined
+  with_items:
+  - "{{ query('k8s', namespace=role_namespace, kind='RoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=role_namespace, kind='Role', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=role_namespace, kind='Role', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  loop_control:
+    loop_var: k8s_item

--- a/roles/v1.24/kiali-remove/vars/main.yml
+++ b/roles/v1.24/kiali-remove/vars/main.yml
@@ -1,0 +1,7 @@
+kiali_vars:
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ kiali_defaults.deployment | combine(deployment, recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.deployment }}
+    {%- endif -%}


### PR DESCRIPTION
this forks the "default" role and names the new copy "v1.24"

fixes: https://github.com/kiali/kiali/issues/3213

Once merged, people need to backport changes made to default role into the v1.24 role (if you want that feature to be in 1.24).