### PR TITLE
[v1.12 / v1.0] Use new OpenShift interface for service serving certificates

### DIFF
--- a/roles/v1.0/kiali-deploy/tasks/main.yml
+++ b/roles/v1.0/kiali-deploy/tasks/main.yml
@@ -124,6 +124,27 @@
   when:
   - kiali_vars.auth.strategy == ""
 
+- name: Use OpenShift service CA file for Grafana
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.grafana.auth.ca_file is not defined or kiali_vars.external_services.grafana.auth.ca_file == ''
+
+- name: Use OpenShift service CA file for Prometheus
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.prometheus.auth.ca_file is not defined or kiali_vars.external_services.prometheus.auth.ca_file == ''
+
+- name: Use OpenShift service CA file for Tracing
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.tracing.auth.ca_file is not defined or kiali_vars.external_services.tracing.auth.ca_file == ''
+
 # Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
 - debug:
     msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"

--- a/roles/v1.0/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/v1.0/kiali-deploy/tasks/openshift/os-main.yml
@@ -6,6 +6,7 @@
   loop:
   - serviceaccount
   - configmap
+  - cabundle
   - role
   - role-viewer
   - rolebinding

--- a/roles/v1.0/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v1.0/kiali-deploy/templates/openshift/cabundle.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali-cabundle
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v1.0/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.0/kiali-deploy/templates/openshift/deployment.yaml
@@ -74,6 +74,8 @@ spec:
           mountPath: "/kiali-cert"
         - name: kiali-secret
           mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
       volumes:
       - name: kiali-configuration
         configMap:
@@ -85,3 +87,6 @@ spec:
         secret:
           secretName: {{ kiali_vars.deployment.secret_name }}
           optional: true
+      - name: kiali-cabundle
+        configMap:
+          name: kiali-cabundle

--- a/roles/v1.0/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.0/kiali-deploy/templates/openshift/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
+    service.beta.openshift.io/serving-cert-secret-name: kiali-cert-secret
 spec:
   type: {{ kiali_vars.deployment.service_type }}
   ports:

--- a/roles/v1.0/kiali-remove/tasks/main.yml
+++ b/roles/v1.0/kiali-remove/tasks/main.yml
@@ -163,6 +163,7 @@
   with_items:
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='OAuthClient', resource_name='kiali-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name='kiali', api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali-cabundle', api_version='v1') if is_openshift == True else [] }}"
   loop_control:
     loop_var: os_item
 

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -285,6 +285,27 @@
   when:
   - kiali_vars.auth.strategy == ""
 
+- name: Use OpenShift service CA file for Grafana
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.grafana.auth.ca_file is not defined or kiali_vars.external_services.grafana.auth.ca_file == ''
+
+- name: Use OpenShift service CA file for Prometheus
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'prometheus': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.prometheus.auth.ca_file is not defined or kiali_vars.external_services.prometheus.auth.ca_file == ''
+
+- name: Use OpenShift service CA file for Tracing
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'auth': {'ca_file': '/kiali-cabundle/service-ca.crt'}}}}, recursive=True) }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.external_services.tracing.auth.ca_file is not defined or kiali_vars.external_services.tracing.auth.ca_file == ''
+
 # Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
 - debug:
     msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"

--- a/roles/v1.12/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/openshift/os-main.yml
@@ -6,6 +6,7 @@
   loop:
   - serviceaccount
   - configmap
+  - cabundle
   - "{{ 'role-viewer' if kiali_vars.deployment.view_only_mode == True else 'role' }}"
   - rolebinding
   - deployment

--- a/roles/v1.12/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v1.12/kiali-deploy/templates/openshift/cabundle.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali-cabundle
+  namespace: {{ kiali_vars.deployment.namespace }}
+  labels:
+    app: kiali
+    version: {{ kiali_vars.deployment.version_label }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v1.12/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.12/kiali-deploy/templates/openshift/deployment.yaml
@@ -87,6 +87,8 @@ spec:
           mountPath: "/kiali-cert"
         - name: kiali-secret
           mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
 {% if kiali_vars.deployment.resources|length > 0 %}
         resources:
           {{ kiali_vars.deployment.resources | to_nice_yaml(indent=0) | trim | indent(10) }}
@@ -107,6 +109,9 @@ spec:
         secret:
           secretName: {{ kiali_vars.deployment.secret_name }}
           optional: true
+      - name: kiali-cabundle
+        configMap:
+          name: kiali-cabundle
 {% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
       affinity:
 {% if kiali_vars.deployment.affinity.node|length > 0 %}

--- a/roles/v1.12/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.12/kiali-deploy/templates/openshift/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: kiali-cert-secret
+    service.beta.openshift.io/serving-cert-secret-name: kiali-cert-secret
 spec:
 {% if kiali_vars.deployment.service_type is defined %}
   type: {{ kiali_vars.deployment.service_type }}

--- a/roles/v1.12/kiali-remove/tasks/main.yml
+++ b/roles/v1.12/kiali-remove/tasks/main.yml
@@ -163,7 +163,8 @@
   with_items:
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='OAuthClient', resource_name='kiali-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name='kiali', api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace)}}"
+  - "{{ query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace) if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali-cabundle', api_version='v1') if is_openshift == True else [] }}"
   loop_control:
     loop_var: os_item
 


### PR DESCRIPTION
oOpS! So, I did the changes for Kiali v1.0 and v1.12 to move away from the deprecated serving certificate, but I only fixed the `master` branch and never backported to the branch that currently goes downstream.

This is the backport of #63, to move away from the deprecated OS serving certificates interface.
Required for [MAISTRA-1719](https://issues.redhat.com/browse/MAISTRA-1719)