### PR TITLE
Adding permissions for fetching proxy-status

### DIFF
--- a/manifests/kiali-community/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
@@ -469,6 +469,7 @@ spec:
           - nodes
           - pods
           - pods/log
+          - pods/proxy
           - replicationcontrollers
           - services
           verbs:

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -474,6 +474,7 @@ spec:
           - nodes
           - pods
           - pods/log
+          - pods/proxy
           - replicationcontrollers
           - services
           verbs:

--- a/manifests/kiali-upstream/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
@@ -469,6 +469,7 @@ spec:
           - nodes
           - pods
           - pods/log
+          - pods/proxy
           - replicationcontrollers
           - services
           verbs:

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -15,6 +15,7 @@ rules:
   - nodes
   - pods
   - pods/log
+  - pods/proxy
   - replicationcontrollers
   - services
   verbs:

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -15,6 +15,7 @@ rules:
   - nodes
   - pods
   - pods/log
+  - pods/proxy
   - replicationcontrollers
   - services
   verbs:

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -15,6 +15,7 @@ rules:
   - nodes
   - pods
   - pods/log
+  - pods/proxy
   - replicationcontrollers
   - services
   verbs:

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -15,6 +15,7 @@ rules:
   - nodes
   - pods
   - pods/log
+  - pods/proxy
   - replicationcontrollers
   - services
   verbs:


### PR DESCRIPTION
In order to fetch the proxy status, we need to use the sub-resource `proxy` from the pods.
Needs https://github.com/kiali/kiali/pull/3126