### PR TITLE
sort the list of accessible namespaces (#135)

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -481,7 +481,7 @@
 
 - name: Set deployment.accessible_namespaces to a list of full namespace names
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'accessible_namespaces': all_accessible_namespaces}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'accessible_namespaces': all_accessible_namespaces | sort }}, recursive=True) }}"
 
 - name: Listing of all accessible namespaces (includes regex matches)
   debug:


### PR DESCRIPTION
Backporting in case we need this (for OSSM it shouldn't be needed, but its such an annoying issue I'm backporting this just in case)
(cherry picked from commit 474cf4b1a1fd86501242fbe071d0503dbab5d5bc)