### PR TITLE
update metadata for next version

### DIFF
--- a/manifests/kiali-community/1.25.0/kiali.crd.yaml
+++ b/manifests/kiali-community/1.25.0/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/kiali-community/1.25.0/kiali.monitoringdashboards.crd.yaml
+++ b/manifests/kiali-community/1.25.0/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/manifests/kiali-community/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
@@ -1,17 +1,17 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kiali-operator.v${KIALI_OPERATOR_VERSION}
+  name: kiali-operator.v1.25.0
   namespace: placeholder
   annotations:
     categories: Monitoring,Logging & Tracing
     certified: "false"
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8-operator:${KIALI_OPERATOR_VERSION}
+    containerImage: quay.io/kiali/kiali-operator:v1.25.0
     capabilities: Deep Insights
-    support: Red Hat
+    support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: ${CREATED_AT}
+    createdAt: 2020-10-09T00:00:00Z
     alm-examples: |-
       [
         {
@@ -73,9 +73,9 @@ metadata:
         }
       ]
 spec:
-  version: ${KIALI_OPERATOR_VERSION}
+  version: 1.25.0
   maturity: stable
-  replaces: kiali-operator.v${KIALI_OLD_OPERATOR_VERSION}
+  replaces: kiali-operator.v1.24.0
   displayName: Kiali Operator
   description: |-
     ## About the managed application
@@ -112,7 +112,7 @@ spec:
 
     For quick descriptions of all the settings you can configure in the Kiali
     Custom Resource (CR), see the file
-    [kiali_cr.yaml](https://github.com/kiali/kiali-operator/blob/v1.12/deploy/kiali/kiali_cr.yaml)
+    [kiali_cr.yaml](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
 
     Note that the Kiali operator can be told to restrict Kiali's access to
     specific namespaces, or can provide to Kiali cluster-wide access to all
@@ -120,11 +120,16 @@ spec:
 
     ## Prerequisites for enabling this Operator
 
-    Kiali is a companion tool for Istio. So before you install Kiali, you must have
-    already installed Istio. Note that some versions of Istio can come
-    pre-bundled with a specific version of Kiali. If you already have a
-    pre-bundled Kiali in your Istio environment and you want to
-    install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first.
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio.
+    If you already have Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the installed Kiali first.
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `token`.
+
+    If you wish to use the `openid` authentication strategy, you must have an
+    OpenID Connect available and accessible to Kiali.
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
     mediatype: image/svg+xml
@@ -133,7 +138,7 @@ spec:
   - name: Kiali Developers Google Group
     email: kiali-dev@googlegroups.com
   provider:
-    name: Red Hat
+    name: Kiali
   labels:
     name: kiali-operator
   selector:
@@ -156,9 +161,9 @@ spec:
     url: https://github.com/kiali/kiali-operator
   installModes:
   - type: OwnNamespace
-    supported: false
+    supported: true
   - type: SingleNamespace
-    supported: false
+    supported: true
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
@@ -186,11 +191,9 @@ spec:
         version: route.openshift.io/v1
       - kind: Ingress
         version: extensions/v1beta1
-      - kind: ConsoleLink
-        version: consolelinks.console.openshift.io/v1
       specDescriptors:
       - displayName: Authentication Strategy
-        description: "Determines how a user is to log into Kiali. Supported strategies include 'openshift', 'openid', 'token', and 'anonymous'."
+        description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
         path: auth.strategy
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:label'
@@ -210,7 +213,7 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
       - displayName: Web Root
-        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift); /kiali (when deployed on Kubernetes)"
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
         path: server.web_root
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:label'
@@ -245,14 +248,14 @@ spec:
                 app: kiali-operator
                 # required for the operator SDK metric service selector
                 name: kiali-operator
-                version: v${KIALI_OPERATOR_VERSION}
+                version: v1.25.0
               annotations:
                 prometheus.io/scrape: "true"
             spec:
               serviceAccountName: kiali-operator
               containers:
               - name: operator
-                image: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8-operator${KIALI_OPERATOR_TAG}
+                image: quay.io/kiali/kiali-operator:v1.25.0
                 imagePullPolicy: "IfNotPresent"
                 args:
                 - "--zap-level=info"
@@ -278,14 +281,6 @@ spec:
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
                   value: "1"
-                - name: RELATED_IMAGE_kiali_default
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_0_TAG}"
-                - name: RELATED_IMAGE_kiali_v1_0
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_0_TAG}"
-                - name: RELATED_IMAGE_kiali_v1_12
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_12_TAG}"
-                - name: RELATED_IMAGE_kiali_v1_24
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_24_TAG}"
                 ports:
                 - name: http-metrics
                   containerPort: 8383
@@ -479,8 +474,8 @@ spec:
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups: ["extensions", "apps"]
           resources:
           - deployments
@@ -489,8 +484,8 @@ spec:
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups: ["autoscaling"]
           resources:
           - horizontalpodautoscalers
@@ -505,8 +500,8 @@ spec:
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups:
           - config.istio.io
           - networking.istio.io
@@ -515,40 +510,20 @@ spec:
           - security.istio.io
           resources: ["*"]
           verbs:
-          - create
-          - delete
           - get
           - list
-          - patch
           - watch
-        - apiGroups: ["authentication.maistra.io"]
-          resources:
-          - servicemeshpolicies
-          verbs:
           - create
           - delete
-          - get
-          - list
           - patch
-          - watch
-        - apiGroups: ["rbac.maistra.io"]
-          resources:
-          - servicemeshrbacconfigs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - watch
         - apiGroups: ["apps.openshift.io"]
           resources:
           - deploymentconfigs
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups: ["project.openshift.io"]
           resources:
           - projects
@@ -569,10 +544,10 @@ spec:
           resources:
           - experiments
           verbs:
-          - create
-          - delete
           - get
           - list
-          - patch
           - watch
+          - create
+          - delete
+          - patch
         serviceAccountName: kiali-operator

--- a/manifests/kiali-community/kiali.package.yaml
+++ b/manifests/kiali-community/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.24.0
+  currentCSV: kiali-operator.v1.25.0
 - name: stable
-  currentCSV: kiali-operator.v1.24.0
+  currentCSV: kiali-operator.v1.25.0
 defaultChannel: stable

--- a/manifests/kiali-upstream/1.25.0/kiali.crd.yaml
+++ b/manifests/kiali-upstream/1.25.0/kiali.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/kiali-upstream/1.25.0/kiali.monitoringdashboards.crd.yaml
+++ b/manifests/kiali-upstream/1.25.0/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  version: v1alpha1

--- a/manifests/kiali-upstream/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.25.0/kiali.v1.25.0.clusterserviceversion.yaml
@@ -1,17 +1,17 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kiali-operator.v${KIALI_OPERATOR_VERSION}
+  name: kiali-operator.v1.25.0
   namespace: placeholder
   annotations:
     categories: Monitoring,Logging & Tracing
     certified: "false"
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8-operator:${KIALI_OPERATOR_VERSION}
+    containerImage: quay.io/kiali/kiali-operator:v1.25.0
     capabilities: Deep Insights
-    support: Red Hat
+    support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: ${CREATED_AT}
+    createdAt: 2020-10-09T00:00:00Z
     alm-examples: |-
       [
         {
@@ -24,7 +24,7 @@ metadata:
             "installation_tag": "My Kiali",
             "istio_namespace": "istio-system",
             "deployment": {
-              "namespace": "istio-system",
+              "namespace": "default",
               "verbose_mode": "4",
               "view_only_mode": false
             },
@@ -73,9 +73,9 @@ metadata:
         }
       ]
 spec:
-  version: ${KIALI_OPERATOR_VERSION}
+  version: 1.25.0
   maturity: stable
-  replaces: kiali-operator.v${KIALI_OLD_OPERATOR_VERSION}
+  replaces: kiali-operator.v1.24.0
   displayName: Kiali Operator
   description: |-
     ## About the managed application
@@ -112,7 +112,7 @@ spec:
 
     For quick descriptions of all the settings you can configure in the Kiali
     Custom Resource (CR), see the file
-    [kiali_cr.yaml](https://github.com/kiali/kiali-operator/blob/v1.12/deploy/kiali/kiali_cr.yaml)
+    [kiali_cr.yaml](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
 
     Note that the Kiali operator can be told to restrict Kiali's access to
     specific namespaces, or can provide to Kiali cluster-wide access to all
@@ -120,11 +120,16 @@ spec:
 
     ## Prerequisites for enabling this Operator
 
-    Kiali is a companion tool for Istio. So before you install Kiali, you must have
-    already installed Istio. Note that some versions of Istio can come
-    pre-bundled with a specific version of Kiali. If you already have a
-    pre-bundled Kiali in your Istio environment and you want to
-    install Kiali via the Kiali Operator, uninstall the pre-bundled Kiali first.
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio.
+    If you already have Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the installed Kiali first.
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `token`.
+
+    If you wish to use the `openid` authentication strategy, you must have an
+    OpenID Connect available and accessible to Kiali.
   icon:
   - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
     mediatype: image/svg+xml
@@ -133,7 +138,7 @@ spec:
   - name: Kiali Developers Google Group
     email: kiali-dev@googlegroups.com
   provider:
-    name: Red Hat
+    name: Kiali
   labels:
     name: kiali-operator
   selector:
@@ -156,9 +161,9 @@ spec:
     url: https://github.com/kiali/kiali-operator
   installModes:
   - type: OwnNamespace
-    supported: false
+    supported: true
   - type: SingleNamespace
-    supported: false
+    supported: true
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces
@@ -186,11 +191,9 @@ spec:
         version: route.openshift.io/v1
       - kind: Ingress
         version: extensions/v1beta1
-      - kind: ConsoleLink
-        version: consolelinks.console.openshift.io/v1
       specDescriptors:
       - displayName: Authentication Strategy
-        description: "Determines how a user is to log into Kiali. Supported strategies include 'openshift', 'openid', 'token', and 'anonymous'."
+        description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
         path: auth.strategy
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:label'
@@ -210,7 +213,7 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
       - displayName: Web Root
-        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift); /kiali (when deployed on Kubernetes)"
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
         path: server.web_root
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:label'
@@ -245,14 +248,14 @@ spec:
                 app: kiali-operator
                 # required for the operator SDK metric service selector
                 name: kiali-operator
-                version: v${KIALI_OPERATOR_VERSION}
+                version: v1.25.0
               annotations:
                 prometheus.io/scrape: "true"
             spec:
               serviceAccountName: kiali-operator
               containers:
               - name: operator
-                image: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8-operator${KIALI_OPERATOR_TAG}
+                image: quay.io/kiali/kiali-operator:v1.25.0
                 imagePullPolicy: "IfNotPresent"
                 args:
                 - "--zap-level=info"
@@ -278,14 +281,6 @@ spec:
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
                   value: "1"
-                - name: RELATED_IMAGE_kiali_default
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_0_TAG}"
-                - name: RELATED_IMAGE_kiali_v1_0
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_0_TAG}"
-                - name: RELATED_IMAGE_kiali_v1_12
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_12_TAG}"
-                - name: RELATED_IMAGE_kiali_v1_24
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_24_TAG}"
                 ports:
                 - name: http-metrics
                   containerPort: 8383
@@ -479,8 +474,8 @@ spec:
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups: ["extensions", "apps"]
           resources:
           - deployments
@@ -489,8 +484,8 @@ spec:
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups: ["autoscaling"]
           resources:
           - horizontalpodautoscalers
@@ -505,8 +500,8 @@ spec:
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups:
           - config.istio.io
           - networking.istio.io
@@ -515,40 +510,20 @@ spec:
           - security.istio.io
           resources: ["*"]
           verbs:
-          - create
-          - delete
           - get
           - list
-          - patch
           - watch
-        - apiGroups: ["authentication.maistra.io"]
-          resources:
-          - servicemeshpolicies
-          verbs:
           - create
           - delete
-          - get
-          - list
           - patch
-          - watch
-        - apiGroups: ["rbac.maistra.io"]
-          resources:
-          - servicemeshrbacconfigs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - watch
         - apiGroups: ["apps.openshift.io"]
           resources:
           - deploymentconfigs
           verbs:
           - get
           - list
-          - patch
           - watch
+          - patch
         - apiGroups: ["project.openshift.io"]
           resources:
           - projects
@@ -569,10 +544,10 @@ spec:
           resources:
           - experiments
           verbs:
-          - create
-          - delete
           - get
           - list
-          - patch
           - watch
+          - create
+          - delete
+          - patch
         serviceAccountName: kiali-operator

--- a/manifests/kiali-upstream/kiali.package.yaml
+++ b/manifests/kiali-upstream/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.24.0
+  currentCSV: kiali-operator.v1.25.0
 - name: stable
-  currentCSV: kiali-operator.v1.24.0
+  currentCSV: kiali-operator.v1.25.0
 defaultChannel: stable


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3258

This adds v1.25.0 metadata for community and upstream. We then remove these permissions that are obsolete and not needed:
```
        - apiGroups: ["authentication.maistra.io"]
          resources:
          - servicemeshpolicies
...
        - apiGroups: ["rbac.maistra.io"]
          resources:
          - servicemeshrbacconfigs
...
```

This also includes changes to kiali-ossm description and links to correct some obsolete things.