### PR TITLE
do not deploy dashboard resources if dashboards are disabled

### DIFF
--- a/molecule/config-values-test/converge.yml
+++ b/molecule/config-values-test/converge.yml
@@ -13,6 +13,7 @@
   # This test will change some config settings to make sure things work like we expect.
   # We will add additional tasks and asserts in the future to test other config changes.
   # We load in the current kiali CR and then alter it with new config.
+  # We do this TWO times to check changing different settings.
 
   - set_fact:
       current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
@@ -21,7 +22,7 @@
     debug:
       msg: "{{ current_kiali_cr }}"
 
-  # Some sanity checks - check some default values
+  # First perform some sanity checks making sure some default values are as expected
 
   - name: Make sure the expected dashboards are installed - by default, all of them are deployed
     vars:
@@ -31,8 +32,9 @@
       - custom_dashboards | length == 20
       fail_msg: "Must have 20 custom_dashboards: {{ custom_dashboards }}"
 
-  # Make sure version label is truncated to the k8s maximum 63 chars and must start/end with alphanum char
-  - name: Set new deployment.version_label in current Kiali CR
+  # NEW CONFIG TEST #1
+
+  - name: Set new deployment.version_label to something longer than k8s maximum of 63 chars
     vars:
       new_version_label: "aaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeee12345678901234"
     set_fact:
@@ -77,3 +79,35 @@
       - custom_dashboards[0].metadata.name == 'kiali'
       fail_msg: "Must have 1 custom_dashboard: {{ custom_dashboards }}"
 
+  # NEW CONFIG TEST #2
+
+  - set_fact:
+      current_kiali_cr: "{{ lookup('k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: Disable custom dashboards entirely
+    set_fact:
+      current_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'external_services': {'custom_dashboards': {'enabled': false }}}}, recursive=True) }}"
+
+  - name: "The new Kiali CR (2) to be tested"
+    debug:
+      msg: "{{ current_kiali_cr }}"
+
+  # Deploy the new CR and wait for the CR change to take effect
+
+  - import_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ current_kiali_cr }}"
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # Assert the new config
+
+  - name: Make sure only the expected dashboards are installed
+    vars:
+      custom_dashboards: "{{ query('k8s', namespace=kiali.install_namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
+    assert:
+      that:
+      - custom_dashboards | length == 0
+      fail_msg: "Must have 0 custom_dashboards (they were disabled): {{ custom_dashboards }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -797,39 +797,48 @@
 # then adds the monitoring dashboard resources. If there are any errors here, they
 # are ignored - since the monitoring dashboards are optional, we allow the install to
 # continue even though it means the monitoring dashboards feature will be disabled.
+# If the dashboards are disabled, we still quickly check to make sure the CRD exists
+# because we may need to remove dashboards that were created previously.
 
 - name: Wait for Monitoring Dashboards CRD to be ready
   community.kubernetes.k8s_info:
     api_version: apiextensions.k8s.io/v1beta1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io
-    namespace: "{{ kiali_vars.deployment.namespace }}"
   register: monitoringdashboards_crd
   until:
-  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
-  retries: 6
+  - monitoringdashboards_crd.resources is defined
+  - monitoringdashboards_crd | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  retries: "{{ 6 if kiali_vars.external_services.custom_dashboards.enabled == True else 1 }}"
   delay: 5
   ignore_errors: yes
+
+- name: Check if the Monitoring Dashboards CRD exists and is ready
+  set_fact:
+    monitoringdashboards_crd_exists: "{{ (monitoringdashboards_crd.resources is defined) and (monitoringdashboards_crd | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True') }}"
 
 - name: Warn if Monitoring Dashboards CRD is not available
   debug:
     msg: "It does not appear you have the Monitoring Dashboard CRD created. Monitoring Dashboards will not be created."
   when:
-  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join != 'True'
-  ignore_errors: yes
+  - kiali_vars.external_services.custom_dashboards.enabled == True
+  - monitoringdashboards_crd_exists == False
 
 - name: Find all Monitoring Dashboards packaged with the operator
   find:
     paths: "{{ role_path }}/templates/dashboards"
   register: monitoring_dashboard_yamls_all_raw
+  when:
+  - monitoringdashboards_crd_exists == True
   ignore_errors: yes
+
 - set_fact:
     monitoring_dashboard_yamls_all: "{{ (monitoring_dashboard_yamls_all | default([])) + [ item.path ] }}"
   loop: "{{ monitoring_dashboard_yamls_all_raw.files }}"
   when:
+  - monitoringdashboards_crd_exists == True
   - monitoring_dashboard_yamls_all_raw is defined
   - monitoring_dashboard_yamls_all_raw.files is defined
-  ignore_errors: yes
 
 - name: Determine which Monitoring Dashboards are to be created
   find:
@@ -837,14 +846,25 @@
     patterns: "{{ kiali_vars.deployment.custom_dashboards.includes }}"
     excludes: "{{ kiali_vars.deployment.custom_dashboards.excludes }}"
   register: monitoring_dashboard_yamls_to_deploy_raw
+  when:
+  - kiali_vars.external_services.custom_dashboards.enabled == True
+  - monitoringdashboards_crd_exists == True
   ignore_errors: yes
+
 - set_fact:
     monitoring_dashboard_yamls_to_deploy: "{{ (monitoring_dashboard_yamls_to_deploy | default([])) + [ item.path ] }}"
   loop: "{{ monitoring_dashboard_yamls_to_deploy_raw.files }}"
   when:
+  - kiali_vars.external_services.custom_dashboards.enabled == True
+  - monitoringdashboards_crd_exists == True
   - monitoring_dashboard_yamls_to_deploy_raw is defined
   - monitoring_dashboard_yamls_to_deploy_raw.files is defined
-  ignore_errors: yes
+
+- name: If monitoring dashboards are disabled, indicate no dashboards are to be deployed
+  set_fact:
+    monitoring_dashboard_yamls_to_deploy: []
+  when:
+  - (kiali_vars.external_services.custom_dashboards.enabled == False) or (monitoringdashboards_crd_exists == False)
 
 - name: Remove Monitoring Dashboards that should no longer be deployed
   k8s:
@@ -853,7 +873,7 @@
     definition: "{{ lookup('template', item) }}"
   loop: "{{ (monitoring_dashboard_yamls_all | default([])) | difference(monitoring_dashboard_yamls_to_deploy | default([])) }}"
   when:
-  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  - monitoringdashboards_crd_exists == True
   ignore_errors: yes
 
 - name: Create the Monitoring Dashboards
@@ -861,10 +881,11 @@
     state: "present"
     namespace: "{{ kiali_vars.deployment.namespace }}"
     definition: "{{ lookup('template', item) }}"
-  loop: "{{ monitoring_dashboard_yamls_to_deploy | default([]) }}"
+  loop: "{{ monitoring_dashboard_yamls_to_deploy }}"
   when:
+  - monitoringdashboards_crd_exists == True
   - monitoring_dashboard_yamls_to_deploy is defined
-  - monitoringdashboards_crd | default({}) | json_query('resources[*].status.conditions[?type==`Established`].status') | flatten | join == 'True'
+  - monitoring_dashboard_yamls_to_deploy | length > 0
   ignore_errors: yes
 
 # If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart


### PR DESCRIPTION
If custom dashboards is not enabled (external_services.custom_dashboards.enabled) do not expect the MonitoringDashboards CRD to exist and do not deploy any monitoring dashboard resources.

fixes: https://github.com/kiali/kiali/issues/3285