### PR TITLE
molecule tests - allow dump logs on error to be turned off

### DIFF
--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -5,6 +5,9 @@
 
   # Cleanup should only ever execute when a molecule test fails - this will dump logs
 
+  - set_fact:
+      dump_logs_on_error: "{{ lookup('env', 'MOLECULE_DUMP_LOGS_ON_ERROR') | default('true', True) }}"
+
   - name: Get Kiali Operator Pod logs
     community.kubernetes.k8s_log:
       namespace: "{{ kiali.operator_namespace }}"
@@ -12,10 +15,15 @@
       - app=kiali-operator
     register: kiali_operator_logs
     ignore_errors: yes
+    when:
+    - dump_logs_on_error == True
+
   - name: Dump Kiali Operator Pod logs
     debug:
       msg: "{{ kiali_operator_logs.log_lines }}"
-    when: kiali_operator_logs is defined and kiali_operator_logs.log_lines is defined
+    when:
+    - dump_logs_on_error == True
+    - kiali_operator_logs is defined and kiali_operator_logs.log_lines is defined
 
   - name: Get Kiali Server Pod logs
     community.kubernetes.k8s_log:
@@ -24,7 +32,12 @@
       - app=kiali
     register: kiali_logs
     ignore_errors: yes
+    when:
+    - dump_logs_on_error == True
+
   - name: Dump Kiali Server Pod logs
     debug:
       msg: "{{ kiali_logs.log_lines }}"
-    when: kiali_logs is defined and kiali_logs.log_lines is defined
+    when:
+    - dump_logs_on_error == True
+    - kiali_logs is defined and kiali_logs.log_lines is defined


### PR DESCRIPTION
Sometimes it is annoying seeing all the logs dump on error (the real error sometimes scrolls off the console window and you lose it). So be able to turn that off.