### PR TITLE
Revert "Change kiali-ossm manifest to remove support to maistra crds"

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -522,6 +522,26 @@ spec:
           - list
           - patch
           - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
         - apiGroups: ["apps.openshift.io"]
           resources:
           - deploymentconfigs


### PR DESCRIPTION
This reverts commit a3697e5f7ad5c7f2c1821b75f68bbfe3da45b0bb.

This is needed because we still want to support installing the older v1.12 which supports the older Istio installations that still has these resources. Without this revert, the operator will fail to install Kiali due to the missing permissions when running with the v1.12 role.

The backport PR: https://github.com/kiali/kiali-operator/pull/160