### PR TITLE
[v1.24] Revert "Change kiali-ossm manifest to remove support to maistra crds"

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -521,6 +521,26 @@ spec:
           - list
           - patch
           - watch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
         - apiGroups: ["apps.openshift.io"]
           resources:
           - deploymentconfigs


### PR DESCRIPTION
This reverts commit a3697e5f7ad5c7f2c1821b75f68bbfe3da45b0bb.

The master PR is: https://github.com/kiali/kiali-operator/pull/159