### PR TITLE
Enable dependency resource watching but be able to turn off reconciliation in case of emergency

### DIFF
--- a/playbooks/kiali-deploy.yml
+++ b/playbooks/kiali-deploy.yml
@@ -51,6 +51,8 @@
   - name: Run the version-specific deploy role
     include_role:
       name: "{{ version }}/kiali-deploy"
+    when:
+    - skip_reconciliation is not defined or skip_reconciliation == False
 
   - name: Playbook end time
     set_fact:

--- a/watches.yaml
+++ b/watches.yaml
@@ -4,8 +4,8 @@
   kind: Kiali
   playbook: /opt/ansible/playbooks/kiali-deploy.yml
   reconcilePeriod: 0
-  watchDependentResources: False
-  watchClusterScopedResources: False
+  watchDependentResources: True
+  watchClusterScopedResources: True
   finalizer:
     name: finalizer.kiali
     playbook: /opt/ansible/playbooks/kiali-remove.yml


### PR DESCRIPTION
You can turn off the operator reconciliation by setting the hidden/undocumented skip_reconciliation
value to `true` in the Kiali CR.

fixes: https://github.com/kiali/kiali/issues/3324

backport PR: https://github.com/kiali/kiali-operator/pull/169