### PR TITLE
k8s kind "extensions/v1beta1 Ingress" is deprecated in favor of "networking.k8s.io/v1beta1 Ingress"

### DIFF
--- a/manifests/kiali-community/1.26.0/kiali.v1.26.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.26.0/kiali.v1.26.0.clusterserviceversion.yaml
@@ -190,7 +190,7 @@ spec:
       - kind: Route
         version: route.openshift.io/v1
       - kind: Ingress
-        version: extensions/v1beta1
+        version: networking.k8s.io/v1beta1
       specDescriptors:
       - displayName: Authentication Strategy
         description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
@@ -392,7 +392,7 @@ spec:
           - get
           - list
           - watch
-        - apiGroups: ["extensions"]
+        - apiGroups: ["networking.k8s.io"]
           resources:
           - ingresses
           verbs:

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -185,7 +185,7 @@ spec:
       - kind: Route
         version: route.openshift.io/v1
       - kind: Ingress
-        version: extensions/v1beta1
+        version: networking.k8s.io/v1beta1
       - kind: ConsoleLink
         version: consolelinks.console.openshift.io/v1
       specDescriptors:
@@ -397,7 +397,7 @@ spec:
           - get
           - list
           - watch
-        - apiGroups: ["extensions"]
+        - apiGroups: ["networking.k8s.io"]
           resources:
           - ingresses
           verbs:

--- a/manifests/kiali-upstream/1.26.0/kiali.v1.26.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.26.0/kiali.v1.26.0.clusterserviceversion.yaml
@@ -190,7 +190,7 @@ spec:
       - kind: Route
         version: route.openshift.io/v1
       - kind: Ingress
-        version: extensions/v1beta1
+        version: networking.k8s.io/v1beta1
       specDescriptors:
       - displayName: Authentication Strategy
         description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
@@ -392,7 +392,7 @@ spec:
           - get
           - list
           - watch
-        - apiGroups: ["extensions"]
+        - apiGroups: ["networking.k8s.io"]
           resources:
           - ingresses
           verbs:

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -31,7 +31,7 @@
 - name: Delete Ingress on Kubernetes if disabled
   k8s:
     state: absent
-    api_version: "extensions/v1beta1"
+    api_version: "networking.k8s.io/v1beta1"
     kind: "Ingress"
     namespace: "{{ kiali_vars.deployment.namespace }}"
     name: "kiali"

--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: kiali

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -128,7 +128,7 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name='kiali', api_version='extensions/v1beta1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name='kiali', api_version='networking.k8s.io/v1beta1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name='kiali', api_version='apps/v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name='kiali', api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name='kiali', api_version='v1') }}"


### PR DESCRIPTION
This was reported against the helm chart - but we need to do this in the operator, too.
See https://github.com/kiali/kiali/issues/3343