### PR TITLE
clean up threescale from molecule tests

### DIFF
--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -78,6 +78,7 @@ If new Kiali Server resources are added or removed, you must make appropriate ch
 ## Developer Checklists When Changing Resources or Configuration
 
 Below are checklists that developers should consult when making various kinds of changes.
+When making any kind of changes, you should also make the necessary changes to the link:./molecule/[molecule tests] to ensure they still pass.
 
 #### Maintain Backward Compatibility
 

--- a/molecule/api-test/config.test.yaml
+++ b/molecule/api-test/config.test.yaml
@@ -17,7 +17,6 @@
     that:
     - api_config_json.extensions is defined
     - api_config_json.extensions.iter8 is defined
-    - api_config_json.extensions.threescale is defined
     - api_config_json.healthConfig is defined
     - api_config_json.istioAnnotations is defined
     - api_config_json.istioAnnotations.istioInjectionAnnotation is defined

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -50,7 +50,6 @@ spec:
     view_only_mode: null
 
   extensions:
-    threescale: null
     iter8: null
 
   external_services:


### PR DESCRIPTION
threescale was removed - molecule tests were previously looking for threescale things, this removes that stuff.