### PR TITLE
Remove ComponentStatus from external_services (jaeger, grafana, prom)

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -419,10 +419,7 @@ spec:
 #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
 #       and auth.token config is ignored then.
 #   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
-# component_status: Grafana info for the Istio Component Status masthead indicator. Only if it is enabled.
-#   app_label: The value of the Grafana pod(s)'s app label. The name of the app label is defined in the setting 'istio_labels.app_label_name'. It defaults to grafana.
-#   is_core: Whether the component is core for your deployment. It defaults to false.
-#   namespace: The namespace where Grafana is installed in. It defaults to the 'istio_namespace' setting.
+# core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
 # dashboards: A list of Grafana dashboards that Kiali can link to. Each item contains:
 #   name: The name of the dashboard in Grafana
 #   variables:
@@ -445,10 +442,7 @@ spec:
 #        type: "none"
 #        use_kiali_token: false
 #        username: ""
-#      component_status:
-#        app_label: "grafana"
-#        is_core: false
-#        namespace: ""
+#      core_component: false
 #      dashboards:
 #      - name: "Istio Service Dashboard"
 #        variables:
@@ -508,10 +502,6 @@ spec:
 # cache_duration: Prometheus caching duration expressed in seconds
 # cache_enabled: Enable/disable Prometheus caching used for Health services
 # cache_expiration: Prometheus caching expiration expressed in seconds
-# component_status: Prometheus info for the Istio Component Status masthead indicator. Only if it is enabled.
-#   app_label: The value of the Prometheus pod(s)'s app label. The name of the app label is defined in the setting 'istio_labels.app_label_name'. It defaults to prometheus.
-#   is_core: Whether the component is core for your deployment. It defaults to true.
-#   namespace: The namespace where Prometheus is installed in. It defaults to the 'istio_namespace' setting.
 # url: The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod.
 #      If empty, assumes it is in the istio namespace at the URL "http://prometheus.<istio_namespace>:9090"
 #    ---
@@ -527,10 +517,6 @@ spec:
 #      cache_duration: 10
 #      cache_enabled: true
 #      cache_expiration: 300
-#      component_status:
-#        app_label: "prometheus"
-#        is_core: true
-#        namespace: ""
 #      url: ""
 #
 # **Tracing-specific settings:
@@ -547,10 +533,7 @@ spec:
 #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Jaeger Query,
 #       and auth.token config is ignored then.
 #   username: Username to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
-# component_status: Jaeger info for the Istio Component Status masthead indicator. Only if it is enabled.
-#   app_label: The value of the Jaeger pod(s)'s app label. The name of the app label is defined in the setting 'istio_labels.app_label_name'. It defaults to jaeger.
-#   is_core: Whether the component is core for your deployment. It defaults to false.
-#   namespace: The namespace where Jaeger is installed in. It defaults to the 'istio_namespace' setting.
+# core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
 # enabled: When true, connections to Jaeger are enabled. "in_cluster_url" and/or "url" need to be provided.
 # in_cluster_url: Set URL for in-cluster access, which enables further integration between Kiali and Jaeger.
 #      When not provided, Kiali will only show external links using the "url" config.
@@ -570,10 +553,7 @@ spec:
 #        type: "none"
 #        use_kiali_token: false
 #        username: ""
-#      component_status:
-#        app_label: "jaeger"
-#        is_core: false
-#        namespace: ""
+#      core_component: false
 #      enabled: true
 #      in_cluster_url: ""
 #      namespace_selector: true

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -386,6 +386,7 @@ spec:
 #
 # **Custom-dashboards settings:
 # enabled: enable or disable custom dashboards, including the dashboards discovery process. Default: true.
+# is_core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
 # namespace_label: Prometheus label name used for identifying namespaces in metrics for custom dashboards.
 #   Default is "kubernetes_namespace". It is quite common to use just "namespace" as well, depending on your Prometheus configuration.
 # prometheus: please check the section below about Prometheus-specific settings: they are identical. The Prometheus
@@ -394,6 +395,7 @@ spec:
 #    ---
 #    custom_dashboards:
 #      enabled: true
+#      is_core_component: false
 #      namespace_label: "kubernetes_namespace"
 #      prometheus:
 #        auth:
@@ -419,7 +421,7 @@ spec:
 #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Grafana,
 #       and auth.token config is ignored then.
 #   username: Username to be used when making requests to Grafana, for basic authentication. User only requires viewer permissions.
-# core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
+# is_core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
 # dashboards: A list of Grafana dashboards that Kiali can link to. Each item contains:
 #   name: The name of the dashboard in Grafana
 #   variables:
@@ -442,7 +444,7 @@ spec:
 #        type: "none"
 #        use_kiali_token: false
 #        username: ""
-#      core_component: false
+#      is_core_component: false
 #      dashboards:
 #      - name: "Istio Service Dashboard"
 #        variables:
@@ -533,7 +535,7 @@ spec:
 #   use_kiali_token: When true and if auth.type is "bearer", the same OAuth token used for authentication in Kiali will be used for the API calls to Jaeger Query,
 #       and auth.token config is ignored then.
 #   username: Username to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
-# core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
+# is_core_component: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
 # enabled: When true, connections to Jaeger are enabled. "in_cluster_url" and/or "url" need to be provided.
 # in_cluster_url: Set URL for in-cluster access, which enables further integration between Kiali and Jaeger.
 #      When not provided, Kiali will only show external links using the "url" config.
@@ -553,7 +555,7 @@ spec:
 #        type: "none"
 #        use_kiali_token: false
 #        username: ""
-#      core_component: false
+#      is_core_component: false
 #      enabled: true
 #      in_cluster_url: ""
 #      namespace_selector: true

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -69,7 +69,7 @@ spec:
         type: null
         use_kiali_token: null
         username: null
-      component_status: null
+      core_component: null
       dashboards: null
       enabled: null
       in_cluster_url: null
@@ -90,7 +90,6 @@ spec:
         type: null
         use_kiali_token: null
         username: null
-      component_status: null
       url: null
 
     tracing:
@@ -102,7 +101,7 @@ spec:
         type: null
         use_kiali_token: null
         username: null
-      component_status: null
+      core_component: null
       enabled: null
       in_cluster_url: null
       namespace_selector: null

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -69,7 +69,7 @@ spec:
         type: null
         use_kiali_token: null
         username: null
-      core_component: null
+      is_core_component: null
       dashboards: null
       enabled: null
       in_cluster_url: null
@@ -101,7 +101,7 @@ spec:
         type: null
         use_kiali_token: null
         username: null
-      core_component: null
+      is_core_component: null
       enabled: null
       in_cluster_url: null
       namespace_selector: null

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -106,10 +106,7 @@ kiali_defaults:
         type: "none"
         use_kiali_token: false
         username: ""
-      component_status:
-        app_label: "grafana"
-        is_core: false
-        namespace: ""
+      core_component: false
       dashboards:
       - name: "Istio Service Dashboard"
         variables:
@@ -152,10 +149,6 @@ kiali_defaults:
       cache_duration: 7
       cache_enabled: true
       cache_expiration: 300
-      component_status:
-        app_label: "prometheus"
-        is_core: true
-        namespace: ""
       url: ""
     tracing:
       auth:
@@ -166,10 +159,7 @@ kiali_defaults:
         type: "none"
         use_kiali_token: false
         username: ""
-      component_status:
-        app_label: "jaeger"
-        is_core: false
-        namespace: ""
+      core_component: false
       enabled: true
       in_cluster_url: ""
       namespace_selector: true

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -86,6 +86,7 @@ kiali_defaults:
   external_services:
     custom_dashboards:
       enabled: true
+      is_core_component: false
       namespace_label: ""
       prometheus:
         auth:
@@ -106,7 +107,7 @@ kiali_defaults:
         type: "none"
         use_kiali_token: false
         username: ""
-      core_component: false
+      is_core_component: false
       dashboards:
       - name: "Istio Service Dashboard"
         variables:
@@ -159,7 +160,7 @@ kiali_defaults:
         type: "none"
         use_kiali_token: false
         username: ""
-      core_component: false
+      is_core_component: false
       enabled: true
       in_cluster_url: ""
       namespace_selector: true


### PR DESCRIPTION
Requires https://github.com/kiali/kiali/pull/3423

It remove the ComponentStatus from jaeger, prom and grafana. It leaves only one param for users tune the severity of the status in the masthead.