### PR TITLE
Fix molecule tests for NetworkPolicy creation when deploying dev builds inside a Maistra environment

### DIFF
--- a/molecule/api-test/create-simple-mesh.yml
+++ b/molecule/api-test/create-simple-mesh.yml
@@ -9,6 +9,23 @@
         labels:
           istio-injection: enabled
 
+- name: Create Maistra SMM to add simple-mesh to the mesh
+  k8s:
+    state: present
+    definition:
+      apiVersion: maistra.io/v1
+      kind: ServiceMeshMember
+      metadata:
+        name: default
+        namespace: "{{ simple_mesh_namespace }}"
+      spec:
+        controlPlaneRef:
+          namespace: "{{ istio.control_plane_namespace }}"
+          name: full
+  when:
+  - is_openshift == True
+  - is_maistra == True
+
 - name: Create NAD so CNI works, only if on OpenShift
   k8s:
     state: present
@@ -39,6 +56,8 @@
             app: simple-server
         template:
           metadata:
+            annotations:
+              sidecar.istio.io/inject: "true"
             labels:
               app: simple-server
               version: v99
@@ -93,6 +112,8 @@
             app: simple-client
         template:
           metadata:
+            annotations:
+              sidecar.istio.io/inject: "true"
             labels:
               app: simple-client
               version: v99

--- a/molecule/api-test/create-simple-mesh.yml
+++ b/molecule/api-test/create-simple-mesh.yml
@@ -45,7 +45,7 @@
           spec:
             containers:
             - name: simple-server
-              image: docker.io/alpine:latest
+              image: quay.io/jmazzitelli/alpine:latest
               command:
               - "/bin/sh"
               args:
@@ -99,7 +99,7 @@
           spec:
             containers:
             - name: simple-client
-              image: docker.io/alpine:latest
+              image: quay.io/jmazzitelli/alpine:latest
               command:
               - "/bin/sh"
               args:

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -2,6 +2,14 @@
   hosts: localhost
   connection: local
   tasks:
+
+  - name: Get information about the cluster
+    set_fact:
+      api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+  - name: Determine the Istio implementation
+    set_fact:
+      is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
+
   - name: Remove Kiali CR
     vars:
       custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
@@ -40,6 +48,12 @@
     - doomed_list | json_query("resources[*]") | length == 0
     retries: "{{ wait_retries }}"
     delay: 5
+
+  - name: Delete any NetworkPolicy that was created
+    import_tasks: process-network-policy.yml
+    vars:
+      network_policy_state: "absent"
+      network_policy_namespace: "{{ kiali.install_namespace }}"
 
   - name: Uninstall Operator via Helm
     command:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -2,6 +2,14 @@
   hosts: localhost
   connection: local
   tasks:
+
+  - name: Get information about the cluster
+    set_fact:
+      api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+  - name: Determine the Istio implementation
+    set_fact:
+      is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
+
   - name: See if we have Service Mesh htpasswd secret for accessing external services like Prometheus
     k8s_info:
       api_version: v1
@@ -9,6 +17,8 @@
       namespace: "{{ istio.control_plane_namespace }}"
       name: htpasswd
     register: ossm_secret_htpasswd_raw
+    when:
+    - is_maistra == True
 
   - name: Define url and auth for Prometheus for Service Mesh
     set_fact:
@@ -76,6 +86,12 @@
       api_version: v1
       kind: Namespace
       name: "{{ cr_namespace }}"
+
+  - name: Create any NetworkPolicy needed to access the Kiali UI
+    import_tasks: process-network-policy.yml
+    vars:
+      network_policy_state: "present"
+      network_policy_namespace: "{{ kiali.install_namespace }}"
 
   - name: Create Kiali CR based solely on the template
     k8s:

--- a/molecule/default/process-network-policy.yml
+++ b/molecule/default/process-network-policy.yml
@@ -1,0 +1,19 @@
+- name: "Process NetworkPolicy needed to access the Kiali UI when in Maistra environment [state={{ network_policy_state }}]"
+  k8s:
+    state: "{{ network_policy_state }}"
+    definition:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
+      metadata:
+        name: kiali-network-policy-molecule
+        namespace: "{{ network_policy_namespace }}"
+        labels:
+          app.kubernetes.io/name: kiali
+      spec:
+        podSelector:
+          matchLabels:
+            app.kubernetes.io/name: kiali
+        policyTypes: ["Ingress"]
+        ingress: [{}]
+  when:
+  - is_maistra == True

--- a/molecule/metrics-test/converge.yml
+++ b/molecule/metrics-test/converge.yml
@@ -18,36 +18,45 @@
   - set_fact:
       test_start_time: "{{ ansible_date_time.iso8601 }}"
 
+  - set_fact:
+      prom_namespace_label: "{{ 'namespace' if is_maistra == True else 'kubernetes_namespace' }}"
+
   # Operator metrics are always enabled - make sure we have them
-  # NOTE: Service Mesh/Maistra does NOT collect these metrics, so ignore test failures for those tests
+  # NOTE: Service Mesh/Maistra does NOT collect these metrics, so do not test when running in Maistra env.
 
   # an operator http-metric
   - import_tasks: ../common/query-prometheus.yml
     vars:
       prometheus_request:
-        query: "workqueue_work_duration_seconds_count{app=\\\"kiali-operator\\\",kubernetes_namespace=\\\"{{ kiali.operator_namespace }}\\\"}"
+        query: "workqueue_work_duration_seconds_count{app=\\\"kiali-operator\\\",{{ prom_namespace_label }}=\\\"{{ kiali.operator_namespace }}\\\"}"
         time: "{{ test_start_time}}"
+    when:
+    - is_maistra != True
   - assert:
       that:
       - prometheus_query_results.json.data.result | length > 0
-    ignore_errors: "{{ 'yes' if is_maistra == True else 'no' }}"
+    when:
+    - is_maistra != True
 
   # an operator cr-metric
   - import_tasks: ../common/query-prometheus.yml
     vars:
       prometheus_request:
-        query: "kiali_info{app=\\\"kiali-operator\\\",kubernetes_namespace=\\\"{{ kiali.operator_namespace }}\\\"}"
+        query: "kiali_info{app=\\\"kiali-operator\\\",{{ prom_namespace_label }}=\\\"{{ kiali.operator_namespace }}\\\"}"
         time: "{{ test_start_time}}"
+    when:
+    - is_maistra != True
   - assert:
       that:
       - prometheus_query_results.json.data.result | length > 0
-    ignore_errors: "{{ 'yes' if is_maistra == True else 'no' }}"
+    when:
+    - is_maistra != True
 
   # The test is initialized with Kiali metrics turned off so there should not be any yet
   - import_tasks: ../common/query-prometheus.yml
     vars:
       prometheus_request:
-        query: "kiali_api_processing_duration_seconds_count{app=\\\"kiali\\\",kubernetes_namespace=\\\"{{ kiali.install_namespace }}\\\"}"
+        query: "kiali_api_processing_duration_seconds_count{app=\\\"kiali\\\",{{ prom_namespace_label }}=\\\"{{ kiali.install_namespace }}\\\"}"
         time: "{{ test_start_time}}"
   - assert:
       that:
@@ -72,7 +81,7 @@
   - import_tasks: ../common/query-prometheus.yml
     vars:
       prometheus_request:
-        query: "kiali_api_processing_duration_seconds_count{app=\\\"kiali\\\",kubernetes_namespace=\\\"{{ kiali.install_namespace }}\\\"}"
+        query: "kiali_api_processing_duration_seconds_count{app=\\\"kiali\\\",{{ prom_namespace_label }}=\\\"{{ kiali.install_namespace }}\\\"}"
         time: ""
   - assert:
       that:


### PR DESCRIPTION
When the molecule tests create a Kiali deployment (which is done outside of Maistra/OLM), the Maistra NetworkPolicy forbids access to that Kiali deployment. So we need to create our own NetworkPolicy to enable access to our dev deployments.

fixes: https://github.com/kiali/kiali/issues/3433