### PR TITLE
document the fact molecule tests can't run if SELinux is enabled.

### DIFF
--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -85,6 +85,8 @@ NOTE: Remember to maintain backward compatiblity for all supported versions. Do 
 
 ### Run Molecule Tests
 
+WARNING: This may not work if you have SELinux enabled. If you get permission errors, disable SELinux via `setenforce 0` and try again.
+
 When making any kind of change, you should also make the necessary changes to the link:./molecule/[Molecule tests] to ensure they still pass. You can easily run the Molecule tests on your local box using Minikube by running the link:https://github.com/kiali/kiali/blob/master/hack/ci-minikube-molecule-tests.sh[ci-minikube-molecule-tests.sh] hack script. If you want to run just a few or one Molecule test rather than the whole suite, you can run something like this (omit `CLUSTER_TYPE` if running the test on OpenShift; you can omit `MINIKUBE_PROFILE` if your profile is the default of `minikube`).
 
 ```


### PR DESCRIPTION
It's possible the combination of SELinux and podman 2.x is causing the problem. At the moment, I believe disabling SELinux will work around the problem.