### PR TITLE
let molecule tests empty prometheus data during testing

### DIFF
--- a/molecule/api-test/converge.yml
+++ b/molecule/api-test/converge.yml
@@ -13,6 +13,9 @@
       that:
       - kiali_configmap.auth.strategy == "anonymous"
 
+  # Start with empty Prometheus data
+  - import_tasks: ../common/purge-prometheus-data.yml
+
   - import_tasks: create-simple-mesh.yml
 
   - name: Find all API tests

--- a/molecule/common/purge-prometheus-data.yml
+++ b/molecule/common/purge-prometheus-data.yml
@@ -1,0 +1,28 @@
+- name: Purging all data from Prometheus
+  k8s:
+    state: absent
+    api_version: "{{ k8s_item.apiVersion }}"
+    kind: "{{ k8s_item.kind }}"
+    namespace: "{{ k8s_item.metadata.namespace }}"
+    name: "{{ k8s_item.metadata.name }}"
+  with_items:
+  - "{{ query('k8s', namespace=istio.control_plane_namespace, kind='Pod', label_selector='app=prometheus', api_version='v1') }}"
+  loop_control:
+    loop_var: k8s_item
+
+- name: Wait for the Prometheus pod to be back up running and that there is only one
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ istio.control_plane_namespace }}"
+    label_selectors:
+    - app=prometheus
+  register: restarted_prom_pod
+  until:
+  - restarted_prom_pod is success
+  - restarted_prom_pod.resources | length == 1
+  - restarted_prom_pod.resources[0].status is defined
+  - restarted_prom_pod.resources[0].status.phase is defined
+  - restarted_prom_pod.resources[0].status.phase == "Running"
+  retries: "{{ wait_retries }}"
+  delay: 5

--- a/molecule/metrics-test/converge.yml
+++ b/molecule/metrics-test/converge.yml
@@ -62,6 +62,9 @@
       that:
       - prometheus_query_results.json.data.result | length == 0
 
+  # Clean out any old Prometheus data
+  - import_tasks: ../common/purge-prometheus-data.yml
+
   # Turn on Kiali metrics
   - import_tasks: enable-metrics.yml
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml


### PR DESCRIPTION
I noticed a nightly run of the molecule tests failed, and it looked like it might have something to do with some old, extra data that was sitting in Prometheus. This PR allows the molecule tests to purge all data from  Prometheus so a test can start with clean/empty telemetry.