### PR TITLE
Assist in profiling the operator.

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,3 +7,5 @@ COPY watches.yaml ${HOME}/watches.yaml
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
+
+RUN cp /etc/ansible/ansible.cfg ${HOME}/ansible-profiler.cfg && echo "callback_whitelist = profile_tasks" >> ${HOME}/ansible-profiler.cfg

--- a/manifests/kiali-community/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
@@ -278,6 +278,8 @@ spec:
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
                   value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
                 ports:
                 - name: http-metrics
                   containerPort: 8383

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -270,6 +270,8 @@ spec:
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
                   value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
                 - name: RELATED_IMAGE_kiali_default
                   value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel7${KIALI_1_0_TAG}"
                 - name: RELATED_IMAGE_kiali_v1_0

--- a/manifests/kiali-upstream/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
@@ -278,6 +278,8 @@ spec:
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
                   value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
                 ports:
                 - name: http-metrics
                   containerPort: 8383


### PR DESCRIPTION
Set ANSIBLE_CONFIG explicitly so it's easier for an admin to change.
Create a config that turns on profiling and store in HOME/ansible-profiler.cfg.
This goes with https://github.com/kiali/kiali/issues/3469