### PR TITLE
change what the status.accessibleNamespaces field looks like in Kiali CR

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -854,7 +854,11 @@
   - processed_resources.configmap.changed == True
   - processed_resources.configmap.method == "patch"
 
+# Can't just populate with the list of namespaces - see https://github.com/operator-framework/operator-sdk-ansible-util/issues/12
+# So instead - if the list of namespaces is manageable, store them in a comma-separate list.
+# Otherwise, we'll just log the count. The purpose of this accessibleNamespaces status field is
+# just to inform the user how many namespaces the operator processed.
 - include_tasks: update-status.yml
   vars:
     status_vars:
-      accessibleNamespaces: "{{ kiali_vars.deployment.accessible_namespaces }}"
+      accessibleNamespaces: "{{ ('Number of accessible namespaces (including control plane namespace): ' + (kiali_vars.deployment.accessible_namespaces | length | string)) if (kiali_vars.deployment.accessible_namespaces | length > 20) else (kiali_vars.deployment.accessible_namespaces | join(',')) }}"


### PR DESCRIPTION
Due to bug in ansible task k8s_status, we can't just log the list of namespaces. Use string instead of list for the value type.

fixes: https://github.com/kiali/kiali/issues/3485

If accessible namespaces is less than or equal to 20 namespaces, this will be what the status field looks like:

```
accessibleNamespaces: anamespace,default,istio-system
```

If accessible namespaces is greater than 20 namespaces, this will be what the status field looks like:

```
  accessibleNamespaces: 'Number of accessible namespaces (including control plane
    namespace): 43'
```