### PR TITLE
[Proxy-config] Add PortForward permissions at pod level

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -466,6 +466,7 @@ spec:
 #     is_core: Whether the component is core for your deployment.
 #     namespace: The namespace where the component is installed in. It defaults to the 'istio_namespace' setting.
 # config_map_name: The name of the istio control plane config map. It defaults to `istio`.
+# envoy_admin_local_port: The port which kiali will open to fetch envoy config data information.
 # istio_identity_domain: The annotation used by Istio to identify domains.
 # istio_injection_annotation: The annotation used by Istio to automatically inject a specific workload
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
@@ -482,6 +483,7 @@ spec:
 #        - app_label: istio-egressgateway
 #          is_core: false
 #      config_map_name: "istio"
+#      envoy_admin_local_port: 15000
 #      istio_identity_domain: "svc.cluster.local"
 #      istio_injection_annotation: "sidecar.istio.io/inject"
 #      istio_sidecar_annotation: "sidecar.istio.io/status"

--- a/manifests/kiali-community/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
@@ -334,6 +334,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - post
+          - create
         - apiGroups: ["apps"]
           resources:
           - deployments

--- a/manifests/kiali-community/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
@@ -334,12 +334,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: [""]
-          resources:
-          - pods/portforward
-          verbs:
-          - post
-          - create
         - apiGroups: ["apps"]
           resources:
           - deployments
@@ -482,6 +476,12 @@ spec:
           - list
           - watch
           - patch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - create
+          - post
         - apiGroups: ["extensions", "apps"]
           resources:
           - deployments

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -476,6 +476,12 @@ spec:
           - list
           - patch
           - watch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - post
+          - create
         - apiGroups: ["extensions", "apps"]
           resources:
           - deployments

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -480,8 +480,8 @@ spec:
           resources:
           - pods/portforward
           verbs:
-          - post
           - create
+          - post
         - apiGroups: ["extensions", "apps"]
           resources:
           - deployments

--- a/manifests/kiali-upstream/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
@@ -334,6 +334,12 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - post
+          - create
         - apiGroups: ["apps"]
           resources:
           - deployments

--- a/manifests/kiali-upstream/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.28.0/kiali.v1.28.0.clusterserviceversion.yaml
@@ -334,12 +334,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: [""]
-          resources:
-          - pods/portforward
-          verbs:
-          - post
-          - create
         - apiGroups: ["apps"]
           resources:
           - deployments
@@ -482,6 +476,12 @@ spec:
           - list
           - watch
           - patch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - create
+          - post
         - apiGroups: ["extensions", "apps"]
           resources:
           - deployments

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -134,6 +134,7 @@ kiali_defaults:
           is_core: false
           namespace: ""
       config_map_name: "istio"
+      envoy_admin_local_port: 15000
       istio_identity_domain: "svc.cluster.local"
       istio_injection_annotation: "sidecar.istio.io/inject"
       istio_sidecar_annotation: "sidecar.istio.io/status"

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -19,12 +19,19 @@ rules:
   - pods
   - pods/log
   - pods/proxy
+  - pods/portforward
   - replicationcontrollers
   - services
   verbs:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - post
+  - create
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -19,7 +19,6 @@ rules:
   - pods
   - pods/log
   - pods/proxy
-  - pods/portforward
   - replicationcontrollers
   - services
   verbs:
@@ -30,8 +29,8 @@ rules:
   resources:
   - pods/portforward
   verbs:
-  - post
   - create
+  - post
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -30,8 +30,8 @@ rules:
   resources:
   - pods/portforward
   verbs:
-  - post
   - create
+  - post
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -26,6 +26,12 @@ rules:
   - list
   - patch
   - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - post
+  - create
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -25,6 +25,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - post
+  - create
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -29,8 +29,8 @@ rules:
   resources:
   - pods/portforward
   verbs:
-  - post
   - create
+  - post
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -30,8 +30,8 @@ rules:
   resources:
   - pods/portforward
   verbs:
-  - post
   - create
+  - post
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -26,6 +26,12 @@ rules:
   - list
   - patch
   - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - post
+  - create
 - apiGroups: ["extensions", "apps"]
   resources:
   - deployments


### PR DESCRIPTION
Kiali needs to port-forward against a pod in the mesh in order to get the envoy dump of an specific envoy.
This PR adds the necessary for the operator to add the `post|create` permissions for the `pod/portforward` subresource.

Needs https://github.com/kiali/helm-charts/pull/23
Relates to https://github.com/kiali/kiali/pull/3400
Relates to https://github.com/kiali/kiali-ui/pull/2006