### PR TITLE
speed up monitoring dashboard creation

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -832,8 +832,12 @@
   k8s:
     state: "present"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    definition: "{{ lookup('template', item) }}"
-  loop: "{{ monitoring_dashboard_yamls_to_deploy }}"
+    definition: |
+      {% for mdy in monitoring_dashboard_yamls_to_deploy %}
+      ---
+      {{ lookup("template", mdy) }}
+      ...
+      {% endfor %}
   when:
   - monitoringdashboards_crd_exists == True
   - monitoring_dashboard_yamls_to_deploy is defined


### PR DESCRIPTION
part of performance enhancement issue https://github.com/kiali/kiali/issues/3469

Quick test on minikube shows this task now takes roughly 3.5 seconds versus originally taking 25s. Much faster.

We need to backport this to v1.24 also.