### PR TITLE
fix molecule image to workaround k8s py library bug

### DIFF
--- a/molecule/docker/Dockerfile
+++ b/molecule/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/ansible/molecule:3.0.6
 RUN apk add gettext gcc libc-dev
-RUN pip install openshift junit-xml jmespath docker kubernetes
+RUN pip install openshift junit-xml jmespath docker 'kubernetes==11.0.0'
 RUN ansible-galaxy collection install community.kubernetes
 RUN apk add curl bash openssl
 RUN curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash && helm version


### PR DESCRIPTION
There is a bug in the 12.x version of the kubernetes py library. Force downgrade to 11.0.0 which works.

See this github issue explaining the bug: https://github.com/kubernetes-client/python/issues/1333

We will want to revert this when that bug is fixed so we can upgrade the py library. For now, we don't need 12.x so using 11.0.0 is fine.

In order to pick up the fix if you've already build the kiali-molecule image, run these two commands:

```
docker rmi kiali-molecule:latest
make molecule-build
```

That should rebuild the image. Run this to confirm you have 11.0.0 of the library:

```
$ docker run --rm -i -t kiali-molecule:latest pip list | grep kubernetes
kubernetes                    11.0.0
```