### PR TITLE
[v1.24] fix molecule test so it parses and passes now

### DIFF
--- a/molecule/config-values-test/converge.yml
+++ b/molecule/config-values-test/converge.yml
@@ -52,21 +52,21 @@
     vars:
       custom_health_config:
         rates:
-          - namespace: "bookinfo"
-            tolerance:
-              - code: "404"
-                failure: 10
-                protocol: "http"
-              - code: "[45]\\d[^\\D4]"
-                protocol: "http"
-          - namespace: ".*"
-            tolerance:
-              - code: "[4]\\d\\d"
-                degraded: 30
-                failure: 40
-                protocol: "http"
-              - code: "[5]\\d\\d"
-                protocol: "http"
+        - namespace: "bookinfo"
+          tolerance:
+          - code: "404"
+            failure: 10
+            protocol: "http"
+          - code: "[45]\\d[^\\D4]"
+            protocol: "http"
+        - namespace: ".*"
+          tolerance:
+          - code: "[4]\\d\\d"
+            degraded: 30
+            failure: 40
+            protocol: "http"
+          - code: "[5]\\d\\d"
+            protocol: "http"
     set_fact:
       current_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'health_config': custom_health_config}}, recursive=True) }}"
 
@@ -102,17 +102,21 @@
       fail_msg: "Must have 1 custom_dashboard: {{ custom_dashboards }}"
 
   - name: Make sure the custom health config made it to the config map
-      assert:
-        that:
-        - kiali_configmap.health_config.rates | length == 2
-        - kiali_configmap.health_config.rates[0].namespace == "bookinfo"
-        - kiali_configmap.health_config.rates[0].tolerance | length == 2
-        - kiali_configmap.health_config.rates[0].tolerance[1].failure == 10
-        - kiali_configmap.health_config.rates[0].tolerance[1].code == "[45]\\d[^\\D4]"
-        - kiali_configmap.health_config.rates[1].namespace == ".*"
-        - kiali_configmap.health_config.rates[1].tolerance | length == 2
-        - kiali_configmap.health_config.rates[1].tolerance[0].degraded == 30
-        - kiali_configmap.health_config.rates[1].tolerance[1].code == "[5]\\d\\d"
+    assert:
+      that:
+      - kiali_configmap.health_config.rates | length == 2
+      - kiali_configmap.health_config.rates[0].namespace == "bookinfo"
+      - kiali_configmap.health_config.rates[0].tolerance | length == 2
+      - kiali_configmap.health_config.rates[0].tolerance[0].code == "404"
+      - kiali_configmap.health_config.rates[0].tolerance[0].failure == 10
+      - kiali_configmap.health_config.rates[0].tolerance[0].protocol == "http"
+      - kiali_configmap.health_config.rates[0].tolerance[1].code == "[45]\\d[^\\D4]"
+      - kiali_configmap.health_config.rates[0].tolerance[1].failure is not defined
+      - kiali_configmap.health_config.rates[0].tolerance[1].protocol == "http"
+      - kiali_configmap.health_config.rates[1].namespace == ".*"
+      - kiali_configmap.health_config.rates[1].tolerance | length == 2
+      - kiali_configmap.health_config.rates[1].tolerance[0].degraded == 30
+      - kiali_configmap.health_config.rates[1].tolerance[1].code == "[5]\\d\\d"
 
   # NEW CONFIG TEST #2
 


### PR DESCRIPTION
This is a backport of https://github.com/kiali/kiali-operator/pull/191

This simply fixes some syntax errors in a molecule test. We need this fixed if QE wants to run our molecule tests on the v1.24 branch.

@mattmahoneyrh 