### PR TITLE
No need to check for the istiod endpoint at all - assume it is there.

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -204,12 +204,6 @@
   when:
   - kiali_vars.istio_component_namespaces.tracing is not defined or kiali_vars.istio_component_namespaces.tracing == ""
 
-- name: "Set default istio component namespace: pilot - needed for Istio 1.5 and earlier"
-  set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'pilot': kiali_vars.istio_namespace}}, recursive=True) }}"
-  when:
-  - kiali_vars.istio_component_namespaces.pilot is not defined or kiali_vars.istio_component_namespaces.pilot == ""
-
 - name: "Set default istio component namespace: istiod - needed for Istio 1.6 and later"
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'istiod': kiali_vars.istio_namespace}}, recursive=True) }}"
@@ -240,27 +234,9 @@
   when:
     kiali_vars.external_services.tracing.in_cluster_url == "" and is_maistra == False
 
-- name: Check for the existence of istiod version endpoint
-  uri:
-    url: "http://istiod.{{ kiali_vars.istio_component_namespaces.istiod }}:15014/version"
-  register: istiod_version_url_results_raw
-  until: istiod_version_url_results_raw.status == 200
-  retries: 5
-  delay: 1
-  ignore_errors: yes
-  when:
-  - kiali_vars.external_services.istio.url_service_version == ""
-
-- name: Set default Istio service that provides version info (istiod for Istio 1.6 and later)
+- name: Set default Istio service that provides version info (istiod service that was introduced in Istio 1.6)
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'url_service_version': 'http://istiod.' + kiali_vars.istio_component_namespaces.istiod + ':15014/version'}}}, recursive=True) }}"
-  when:
-  - kiali_vars.external_services.istio.url_service_version == ""
-  - istiod_version_url_results_raw.status == 200
-
-- name: Fallback to Istio pilot service that provides version info (for Istio 1.5 and earlier)
-  set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'url_service_version': 'http://istio-pilot.' + kiali_vars.istio_component_namespaces.pilot + ':8080/version'}}}, recursive=True) }}"
   when:
   - kiali_vars.external_services.istio.url_service_version == ""
 

--- a/roles/v1.24/kiali-deploy/tasks/main.yml
+++ b/roles/v1.24/kiali-deploy/tasks/main.yml
@@ -195,12 +195,6 @@
   when:
   - kiali_vars.istio_component_namespaces.tracing is not defined or kiali_vars.istio_component_namespaces.tracing == ""
 
-- name: "Set default istio component namespace: pilot - needed for Istio 1.5 and earlier"
-  set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'pilot': kiali_vars.istio_namespace}}, recursive=True) }}"
-  when:
-  - kiali_vars.istio_component_namespaces.pilot is not defined or kiali_vars.istio_component_namespaces.pilot == ""
-
 - name: "Set default istio component namespace: istiod - needed for Istio 1.6 and later"
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'istio_component_namespaces': {'istiod': kiali_vars.istio_namespace}}, recursive=True) }}"
@@ -231,27 +225,9 @@
   when:
     kiali_vars.external_services.tracing.in_cluster_url == "" and is_maistra == False
 
-- name: Check for the existence of istiod version endpoint
-  uri:
-    url: "http://istiod.{{ kiali_vars.istio_component_namespaces.istiod }}:15014/version"
-  register: istiod_version_url_results_raw
-  until: istiod_version_url_results_raw.status == 200
-  retries: 5
-  delay: 1
-  ignore_errors: yes
-  when:
-  - kiali_vars.external_services.istio.url_service_version == ""
-
-- name: Set default Istio service that provides version info (istiod for Istio 1.6 and later)
+- name: Set default Istio service that provides version info (istiod service that was introduced in Istio 1.6)
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'url_service_version': 'http://istiod.' + kiali_vars.istio_component_namespaces.istiod + ':15014/version'}}}, recursive=True) }}"
-  when:
-  - kiali_vars.external_services.istio.url_service_version == ""
-  - istiod_version_url_results_raw.status == 200
-
-- name: Fallback to Istio pilot service that provides version info (for Istio 1.5 and earlier)
-  set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'url_service_version': 'http://istio-pilot.' + kiali_vars.istio_component_namespaces.pilot + ':8080/version'}}}, recursive=True) }}"
   when:
   - kiali_vars.external_services.istio.url_service_version == ""
 


### PR DESCRIPTION
Since v1.24 does not support 1.5 or earlier, we remove this from there as well.

part of https://github.com/kiali/kiali/issues/3469