### PR TITLE
Kiali metrics: add "hits rate" charts and "Service" label

### DIFF
--- a/roles/default/kiali-deploy/templates/dashboards/kiali.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/kiali.yaml
@@ -10,6 +10,15 @@ spec:
   title: Kiali Internal Metrics
   items:
   - chart:
+      name: "API hit rate"
+      unit: "ops"
+      spans: 6
+      metricName: "kiali_api_processing_duration_seconds_count"
+      dataType: "rate"
+      aggregations:
+      - label: "route"
+        displayName: "Route"
+  - chart:
       name: "API processing duration"
       unit: "seconds"
       spans: 6
@@ -19,6 +28,19 @@ spec:
       - label: "route"
         displayName: "Route"
   - chart:
+      name: "Functions hit rate"
+      unit: "ops"
+      spans: 6
+      metricName: "kiali_go_function_processing_duration_seconds_count"
+      dataType: "rate"
+      aggregations:
+      - label: "function"
+        displayName: "Function"
+      - label: "type"
+        displayName: "Service"
+      - label: "package"
+        displayName: "Package"
+  - chart:
       name: "Functions processing duration"
       unit: "seconds"
       spans: 6
@@ -27,6 +49,8 @@ spec:
       aggregations:
       - label: "function"
         displayName: "Function"
+      - label: "type"
+        displayName: "Service"
       - label: "package"
         displayName: "Package"
   - chart:


### PR DESCRIPTION
Screenshot:
![Capture d’écran de 2021-01-19 09-55-37](https://user-images.githubusercontent.com/2153442/105010935-9fc5a580-5a3c-11eb-8034-ee8e2d7ae839.png)

This is a prequel to https://github.com/kiali/kiali/issues/3514 (I want some metrics & charts easily available to measure performance gain prior to that task)

@jmazzitelli I've only modified one dashboard, is it correct that it's the main one, and the future versioned ones will be derived from there? There's no need to modify the already released ones I think.