### PR TITLE
Updated labels to support amd64, s390z and ppc64le (#236)

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -3,6 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   name: kiali-operator.v${KIALI_OPERATOR_VERSION}
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
   annotations:
     categories: Monitoring,Logging & Tracing
     certified: "false"


### PR DESCRIPTION
this is a backport PR for https://github.com/kiali/kiali-operator/pull/236