### PR TITLE
openshift-auth-test molecule test

### DIFF
--- a/molecule/openshift-auth-test/converge.yml
+++ b/molecule/openshift-auth-test/converge.yml
@@ -1,0 +1,218 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # Wait for Kiali to be running and accepting requests.
+  # This has the added benefit of confirming that we can access a
+  # Kiali endpoint that does not need authentication.
+  - import_tasks: ../common/wait_for_kiali_running.yml
+
+  - name: Make sure the test set the strategy to openshift
+    assert:
+      that:
+      - kiali_configmap.auth.strategy == "openshift"
+
+  - name: Assert that we can access Kiali console login screen that does not need authentication
+    uri:
+      url: "{{ kiali_base_url }}/console"
+      validate_certs: false
+
+  - name: Try to access Kiali api endpoint that requires authentication (should return 401)
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces"
+      status_code: 401
+      validate_certs: false
+
+  - name: Attempt login with invalid credentials
+    uri:
+      url: "{{ kiali_base_url }}/api/authenticate"
+      user: invalid
+      password: invalid
+      status_code: 500
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+
+  - name: Attempt login with good credentials but not logging in via OpenShift OAuth
+    uri:
+      url: "{{ kiali_base_url }}/api/authenticate"
+      user: "{{ openshift.username }}"
+      password: "{{ openshift.password }}"
+      status_code: 500
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+
+  # BEGIN A SUCCESSFUL OPENSHIFT OAUTH LOGIN PROCESS
+
+  - name: Get /api/auth/info from Kiali Server
+    uri:
+      url: "{{ kiali_base_url }}/api/auth/info"
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+  - name: Assert that the auth info is for openshift and we have expected data
+    assert:
+      that:
+      - kiali_output.json.strategy == "openshift"
+      - kiali_output.json.authorizationEndpoint is search("oauth/authorize")
+      - kiali_output.json.sessionInfo.keys() | length == 0
+  - name: Set the auth endpoint we are being redirected to and assume our test credentials are for the htpasswd provider
+    set_fact:
+      auth_endpoint: "{{ kiali_output.json.authorizationEndpoint | regex_replace('\\?', '?idp=htpasswd&') }}"
+
+  - name: Send request to oauth-openshift /oauth/authorize endpoint
+    uri:
+      url: "{{ auth_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 302
+    register: kiali_output
+  - name: Assert that the auth endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.location is defined
+
+  - name: Determine next auth2 endpoint (strip some weirdness off the location - why is ansible doing that?)
+    set_fact:
+      auth2_endpoint: "{{ kiali_output.location | regex_replace('\\?.+(\\/login)', '\\1') }}"
+
+  - name: Send request to auth2 endpoint /login/htpasswd which is the OpenShift login screen
+    uri:
+      url: "{{ auth2_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 200
+    register: kiali_output
+  - name: Assert that the auth2 endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.url is defined
+      - kiali_output.set_cookie is defined
+      - kiali_output.set_cookie is search("csrf")
+  - name: Set post login endpoint by stripping query string and extract data needed for the next request
+    set_fact:
+      openshift_login_endpoint: "{{ auth2_endpoint | regex_replace('([^?]+).*', '\\1') }}"
+      csrf_cookie_value: "{{ kiali_output.set_cookie | regex_replace('.*csrf=([^;]+).*', '\\1') }}"
+      then_value: "{{ auth2_endpoint | regex_replace('.*then=([^&;]+).*', '\\1') | urldecode }}"
+
+  - name: Send login post request to OpenShift login screen endpoint /login/htpasswd
+    uri:
+      url: "{{ openshift_login_endpoint }}"
+      headers:
+        Cookie: "csrf={{ csrf_cookie_value }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 302
+      method: POST
+      body_format: form-urlencoded
+      body:
+        username: "{{ openshift.username }}"
+        password: "{{ openshift.password }}"
+        csrf: "{{ csrf_cookie_value }}"
+        then: "{{ then_value }}"
+    register: kiali_output
+  - name: Assert that the login endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.location is defined
+      - kiali_output.set_cookie is defined
+      - kiali_output.set_cookie is search("ssn")
+  - name: Extract the preliminary ssn cookie
+    set_fact:
+      ssn_cookie: "{{ kiali_output.set_cookie | regex_replace('.*(ssn=[^;]+).*', '\\1') }}"
+
+  - name: Set the final approval endpoint
+    set_fact:
+      openshift_approval_endpoint: "{{ auth_endpoint }}"
+
+  - name: Send request to final approval endpoint to complete login
+    uri:
+      url: "{{ openshift_approval_endpoint }}"
+      headers:
+        Cookie: "{{ ssn_cookie }}; csrf={{ csrf_cookie_value }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 302
+    register: kiali_output
+  - name: Assert that the final approval endpoint returned valid data
+    assert:
+      that:
+      - kiali_output.location is defined
+      - kiali_output.set_cookie is defined
+      - kiali_output.set_cookie is search("ssn")
+  - name: Extract the final ssn cookie and the Kiali endpoint containing our token data
+    set_fact:
+      ssn_cookie: "{{ kiali_output.set_cookie | regex_replace('.*(ssn=[^;]+).*', '\\1') }}"
+      kiali_endpoint: "{{ kiali_output.location }}"
+
+  - name: Extract the token data from the Kiali endpoint we are being redirected to
+    set_fact:
+      access_token: "{{ kiali_endpoint | regex_replace('.*access_token=([^&]+).*', '\\1') }}"
+      expires_in: "{{ kiali_endpoint | regex_replace('.*expires_in=([^&]+).*', '\\1') }}"
+      scope: "{{ kiali_endpoint | regex_replace('.*scope=([^&]+).*', '\\1') }}"
+      token_type: "{{ kiali_endpoint | regex_replace('.*token_type=([^&]+).*', '\\1') }}"
+
+  - name: Now logged in - confirm by going to the redirected Kiali endpoint
+    uri:
+      url: "{{ kiali_endpoint }}"
+      return_content: yes
+      validate_certs: false
+      follow_redirects: none
+      status_code: 200
+    register: kiali_output
+
+  - name: Now get our Kiali token via /api/authenticate
+    uri:
+      url: "{{ kiali_base_url }}/api/authenticate"
+      status_code: 200
+      return_content: yes
+      validate_certs: false
+      method: POST
+      body_format: form-urlencoded
+      body:
+        access_token: "{{ access_token }}"
+        expires_in: "{{ expires_in }}"
+        scope: "{{ scope }}"
+        token_type: "{{ token_type }}"
+    register: kiali_output
+  - name: Assert that the Kiali token was returned
+    assert:
+      that:
+      - kiali_output.set_cookie is defined
+      - kiali_output.set_cookie is search("kiali-token")
+      - kiali_output.json.expiresOn is defined
+      - kiali_output.json.token is defined
+      - kiali_output.json.username is defined
+
+  - name: Get Kiali token from output
+    set_fact:
+      kiali_token_from_cookie: "{{ kiali_output.set_cookie | regex_replace('.*(kiali-token=[^;]+).*', '\\1') }}"
+      kiali_token_from_json: "kiali-token={{ kiali_output.json.token }}"
+  - name: Make sure set-cookie and json Kiali tokens match
+    assert:
+      that:
+      - kiali_token_from_cookie == kiali_token_from_json
+
+  - name: With the Kiali token, make a Kiali API request that requires authentication (should now return 200)
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces"
+      headers:
+        Cookie: "{{ kiali_token_from_cookie }}"
+      return_content: yes
+      validate_certs: false
+    register: kiali_output
+  - name: Assert that we were able to get the list of namespaces
+    assert:
+      that:
+      - kiali_output.json | length > 0
+

--- a/molecule/openshift-auth-test/kiali-cr.yaml
+++ b/molecule/openshift-auth-test/kiali-cr.yaml
@@ -1,0 +1,20 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+spec:
+  version: default
+  istio_namespace: {{ istio.control_plane_namespace }}
+  auth:
+    strategy: openshift
+  deployment:
+    accessible_namespaces: {{ kiali.accessible_namespaces }}
+    custom_dashboards:
+      includes: []
+    image_name: {{ kiali.image_name }}
+    image_pull_policy: {{ kiali.image_pull_policy }}
+    image_version: {{ kiali.image_version }}
+    logger:
+      log_level: "trace"
+    namespace: {{ kiali.install_namespace }}
+    service_type: NodePort

--- a/molecule/openshift-auth-test/molecule.yml
+++ b/molecule/openshift-auth-test/molecule.yml
@@ -1,0 +1,47 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/openshift-auth-test/kiali-cr.yaml"
+        cr_namespace: kiali-operator
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        openshift:
+          username: kiali
+          password: kiali
+        kiali:
+          install_namespace: istio-system
+          accessible_namespaces: ["**"]
+          operator_namespace: kiali-operator
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: kiali-operator
+          operator_cluster_role_creator: "true"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+scenario:
+  name: openshift-auth-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3608

This molecule test requires that you set up the htpasswd identity provider in OpenShift so it has a user `kiali` with password `kiali`.

You can set this up by logging into an OpenShift cluster via `oc` and then running `make cluster-add-users`.