### PR TITLE
Fix the accessible namespace regex check

### DIFF
--- a/molecule/accessible-namespaces-test/converge.yml
+++ b/molecule/accessible-namespaces-test/converge.yml
@@ -13,31 +13,53 @@
     assert:
       that:
       - kiali_configmap.api.namespaces.label_selector is not defined
+
   # change to accessible_namespaces to a fixed list of namespaces
   - k8s:
       state: present
       api_version: v1
       kind: Namespace
-      name: foo
+      name: kialitestns
+  - k8s:
+      state: present
+      api_version: v1
+      kind: Namespace
+      name: kialitestns2
+  - k8s:
+      state: present
+      api_version: v1
+      kind: Namespace
+      name: kialianothertestns
   - import_tasks: ../common/set_accessible_namespaces_to_list.yml
     vars:
-      namespace_list: [ 'istio-system', 'foo' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'kialitestns', 'kialianother.*' ]
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
   - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
   - import_tasks: ../asserts/accessible_namespaces_equals.yml
     vars:
-      namespace_list: [ 'istio-system', 'foo' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'kialitestns', 'kialianothertestns' ]
   - name: "Make sure label_selector is set properly"
     assert:
       that:
-      - kiali_configmap.api.namespaces.label_selector == 'kiali.io/member-of=istio-system'
+      - kiali_configmap.api.namespaces.label_selector == "kiali.io/member-of={{ istio.control_plane_namespace }}"
   - k8s:
       state: absent
       api_version: v1
       kind: Namespace
-      name: foo
+      name: kialitestns
+  - k8s:
+      state: absent
+      api_version: v1
+      kind: Namespace
+      name: kialitestns2
+  - k8s:
+      state: absent
+      api_version: v1
+      kind: Namespace
+      name: kialianothertestns
+
   # change to accessible_namespaces back to **
   - import_tasks: ../common/set_accessible_namespaces_to_all.yml
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml

--- a/roles/default/kiali-deploy/filter_plugins/only_accessible_namespaces.py
+++ b/roles/default/kiali-deploy/filter_plugins/only_accessible_namespaces.py
@@ -16,7 +16,7 @@ def only_accessible_namespaces(value, accessible_namespaces=[]):
   all_accessible_namespaces = []
   for namespace in value:
     for accessible_namespace_regex in accessible_namespaces:
-      if re.match(accessible_namespace_regex, namespace):
+      if re.match('^' + accessible_namespace_regex + '$', namespace):
         all_accessible_namespaces.append(namespace)
         break
   return all_accessible_namespaces

--- a/roles/v1.24/kiali-deploy/filter_plugins/only_accessible_namespaces.py
+++ b/roles/v1.24/kiali-deploy/filter_plugins/only_accessible_namespaces.py
@@ -16,7 +16,7 @@ def only_accessible_namespaces(value, accessible_namespaces=[]):
   all_accessible_namespaces = []
   for namespace in value:
     for accessible_namespace_regex in accessible_namespaces:
-      if re.match(accessible_namespace_regex, namespace):
+      if re.match('^' + accessible_namespace_regex + '$', namespace):
         all_accessible_namespaces.append(namespace)
         break
   return all_accessible_namespaces


### PR DESCRIPTION
If you put these two lines at the bottom of only_accessible_namespaces.py and run it with "python":

```
print (only_accessible_namespaces(['2alpha', 'alpha', 'alpha2', 'beta'], ['alpha', 'beta']))
print (only_accessible_namespaces(['2alpha', 'alpha', 'alpha2', 'beta'], ['alpha.*', 'beta']))
```

With the bug, both will print out `alpha` and `alpha2`.
With the bug fixed, the first will only print out `alpha`.

fixes: https://github.com/kiali/kiali/issues/3709