### PR TITLE
We don't need to mention Ingress in the metadata, remove it to save work in the future

### DIFF
--- a/manifests/kiali-community/1.31.0/kiali.v1.31.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.31.0/kiali.v1.31.0.clusterserviceversion.yaml
@@ -188,8 +188,6 @@ spec:
         version: oauth.openshift.io/v1
       - kind: Route
         version: route.openshift.io/v1
-      - kind: Ingress
-        version: networking.k8s.io/v1beta1
       specDescriptors:
       - displayName: Authentication Strategy
         description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -182,8 +182,6 @@ spec:
         version: oauth.openshift.io/v1
       - kind: Route
         version: route.openshift.io/v1
-      - kind: Ingress
-        version: networking.k8s.io/v1beta1
       - kind: ConsoleLink
         version: consolelinks.console.openshift.io/v1
       specDescriptors:

--- a/manifests/kiali-upstream/1.31.0/kiali.v1.31.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.31.0/kiali.v1.31.0.clusterserviceversion.yaml
@@ -188,8 +188,6 @@ spec:
         version: oauth.openshift.io/v1
       - kind: Route
         version: route.openshift.io/v1
-      - kind: Ingress
-        version: networking.k8s.io/v1beta1
       specDescriptors:
       - displayName: Authentication Strategy
         description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"


### PR DESCRIPTION
At some point in the near future, the Ingress version is going to change. Rather than make more work in the future, just take it out. This will allow us to maintain a simple set of PRs for https://github.com/kiali/kiali/issues/3706 that we can merge in the future without having to worry about future conflicts.

related to https://github.com/kiali/kiali/issues/3706