### PR TITLE
Annotate Kiali Service with external URL settings

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -796,6 +796,8 @@ spec:
 # of the URL (usually it's a fully-qualified domain name).
 # For example, "kiali.example.org".
 # When empty, Kiali will try to guess this value from HTTP headers.
+# You must populate this value if you want to enable cross-linking between Kiali
+# instances in a multi-cluster setup.
 #    ---
 #    web_fqdn: ""
 #
@@ -823,5 +825,7 @@ spec:
 # Defines the public HTTP schema used to serve Kiali. This can only take
 # two possible values: either "http" or "https".
 # When empty, Kiali will try to guess this value from HTTP headers.
+# You must populate this value if you want to enable cross-linking between Kiali
+# instances in a multi-cluster setup.
 #    ---
 #    web_schema: ""

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -796,8 +796,8 @@ spec:
 # of the URL (usually it's a fully-qualified domain name).
 # For example, "kiali.example.org".
 # When empty, Kiali will try to guess this value from HTTP headers.
-# You must populate this value if you want to enable cross-linking between Kiali
-# instances in a multi-cluster setup.
+# On non-OpenShift clusters, you must populate this value if you want to enable
+# cross-linking between Kiali instances in a multi-cluster setup.
 #    ---
 #    web_fqdn: ""
 #
@@ -825,7 +825,7 @@ spec:
 # Defines the public HTTP schema used to serve Kiali. This can only take
 # two possible values: either "http" or "https".
 # When empty, Kiali will try to guess this value from HTTP headers.
-# You must populate this value if you want to enable cross-linking between Kiali
-# instances in a multi-cluster setup.
+# On non-OpenShift clusters, you must populate this value if you want to enable
+# cross-linking between Kiali instances in a multi-cluster setup.
 #    ---
 #    web_schema: ""

--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -12,6 +12,9 @@ metadata:
   annotations:
     kiali.io/api-spec: https://kiali.io/api
     kiali.io/api-type: rest
+{% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}
+    kiali.io/external-url: {{ kiali_vars.server.web_schema + '://' + kiali_vars.server.web_fqdn + ((':' + kiali_vars.server.web_port | string) if (kiali_vars.server.web_port | string | length != 0) else '') + (kiali_vars.server.web_root | default('')) }}
+{% endif %}
 {% if kiali_vars.deployment.service_annotations|length > 0 %}
     {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
 {% endif %}


### PR DESCRIPTION
Given the following settings in the Kiali CR:

```yaml
spec:
    server:
      web_fqdn: example.domain.com
      web_port: 8443
      web_root: /dashboard
      web_schema: https
```

This is an example of the resulting Service:

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    kiali.io/api-spec: https://kiali.io/api
    kiali.io/api-type: rest
    kiali.io/external-url: https://example.domain.com:8443/dashboard # This is the new annotation
    operator-sdk/primary-resource: kiali-operator/kiali
    operator-sdk/primary-resource-type: Kiali.kiali.io
  labels:
    app: kiali
    app.kubernetes.io/name: kiali
    app.kubernetes.io/part-of: kiali
    app.kubernetes.io/version: dev
    version: dev
spec:
  clusterIP: 172.21.32.170
  ports:
  - name: http
    port: 20001
    protocol: TCP
    targetPort: 20001
  - name: http-metrics
    port: 9090
    protocol: TCP
    targetPort: 9090
  selector:
    app: kiali
    version: dev
  sessionAffinity: None
  type: ClusterIP
```

Related front-end PR: https://github.com/kiali/kiali-ui/pull/2102

Related to kiali/kiali#3526