### PR TITLE
Make sure we pass through camelCase for node_selector.

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -179,6 +179,15 @@
   - kiali_vars.deployment.hpa.spec is defined
   - kiali_vars.deployment.hpa.spec | length > 0
 
+- name: Replace snake_case with camelCase in deployment.node_selector
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['deployment'].pop('node_selector') %}
+      {{ kiali_vars | combine({'deployment': {'node_selector': current_cr.spec.deployment.node_selector }}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.node_selector is defined
+  - kiali_vars.deployment.node_selector | length > 0
+
 - name: Print some debug information
   vars:
     msg: |


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3760

Note: cannot easily create a molecule test because it requires the test node to have the test labels on them, which currently the minikube and openshift nodes won't necessarily have. But this is such a simple change and mimics the same kind of change for the other things we do have tests for, that it shouldn't be a problem... I did do a manual test and confirmed this works. Just look at the kiali deployment yaml and see that the `nodeSelector` in the template is as expected (you don't have to worry if the pod doesn't come up - it won't if you used bogus test labels like "anotherCamelCase-Test: foo")