### PR TITLE
revert back to CRD v1beta1

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: kialis.kiali.io
@@ -12,13 +12,9 @@ spec:
     plural: kialis
     singular: kiali
   scope: Namespaced
+  subresources:
+    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
-    subresources:
-      status: {}
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-ossm/manifests/kiali.monitoringdashboards.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.monitoringdashboards.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: monitoringdashboards.monitoring.kiali.io
@@ -16,7 +16,3 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
When we stop supporting OS 4.4, we can revert this revert.
Note this only affects the OSSM metadata - we keep the rest (all upstream stuff) at v1.