### PR TITLE
Adding istiod deployment name into the CR

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -515,6 +515,7 @@ spec:
 # istio_identity_domain: The annotation used by Istio to identify domains.
 # istio_injection_annotation: The annotation used by Istio to automatically inject a specific workload
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
+# istiod_deployment_name: The name of the istiod deployment.
 # url_service_version: The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.
 #    ---
 #    istio:
@@ -532,6 +533,7 @@ spec:
 #      istio_identity_domain: "svc.cluster.local"
 #      istio_injection_annotation: "sidecar.istio.io/inject"
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
+#      istiod_deployment_name: "istiod"
 #      url_service_version: ""
 #
 #

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -149,6 +149,7 @@ kiali_defaults:
       istio_identity_domain: "svc.cluster.local"
       istio_injection_annotation: "sidecar.istio.io/inject"
       istio_sidecar_annotation: "sidecar.istio.io/status"
+      istiod_deployment_name: "istiod"
       url_service_version: ""
     prometheus:
       auth:


### PR DESCRIPTION
Adding a field into the `external_services.istio` section to allow users define the specific name of the istiod deployment.
Scenarios like: Istio canary upgrades and OSSM needs a different name.

This approach has been followed a previous work related to the config map:
```
external_services:
  istio:
    istiod_deployment_name: "istiod-1-9-1"
    config_map_name: "istio-1-9-1"
```

This PR needs https://github.com/kiali/kiali/pull/3796 to be merged first.