### PR TITLE
Fix deprecated api link

### DIFF
--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -9,9 +9,6 @@ metadata:
     app.kubernetes.io/name: kiali
     app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
     app.kubernetes.io/part-of: kiali
-  annotations:
-    kiali.io/api-spec: https://kiali.io/api
-    kiali.io/api-type: rest
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}
   selector:

--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -10,8 +10,6 @@ metadata:
     app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
     app.kubernetes.io/part-of: kiali
   annotations:
-    kiali.io/api-spec: https://kiali.io/api
-    kiali.io/api-type: rest
 {% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}
     kiali.io/external-url: {{ kiali_vars.server.web_schema + '://' + kiali_vars.server.web_fqdn + ((':' + kiali_vars.server.web_port | string) if (kiali_vars.server.web_port | string | length != 0) else '') + (kiali_vars.server.web_root | default('')) }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -9,9 +9,6 @@ metadata:
     app.kubernetes.io/name: kiali
     app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
     app.kubernetes.io/part-of: kiali
-  annotations:
-    kiali.io/api-spec: https://kiali.io/api
-    kiali.io/api-type: rest
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}
   selector:

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -11,8 +11,6 @@ metadata:
     app.kubernetes.io/part-of: kiali
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: kiali-cert-secret
-    kiali.io/api-spec: https://kiali.io/api
-    kiali.io/api-type: rest
 {% if kiali_vars.deployment.service_annotations|length > 0 %}
     {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
 {% endif %}


### PR DESCRIPTION
Fixes https://github.com/kiali/kiali/issues/3026

Kiali API is not public and that link is wrong, there is no expectation to have it back in the kiali site, so, better to remove this annotation from the operator.

Please, @jmazzitelli let me know if it looks good for you.

@hhovsepy this is a very small fix but I haven't completely checked if there is nothing broken, specifically when browing the Kiali workload/service from Kiali itself.