### PR TITLE
Abort on ad hoc kiali namespace deployment when it is not allowed

### DIFF
--- a/manifests/kiali-community/1.33.0/kiali.crd.yaml
+++ b/manifests/kiali-community/1.33.0/kiali.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-community/1.33.0/kiali.monitoringdashboards.crd.yaml
+++ b/manifests/kiali-community/1.33.0/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -1,0 +1,568 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.33.0
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.33.0
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2021-04-07T15:31:41Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.33.0
+  maturity: stable
+  replaces: kiali-operator.v1.32.0
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see the file
+    [kiali_cr.yaml](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio.
+    If you already have Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the installed Kiali first.
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `token`.
+
+    If you wish to use the `openid` authentication strategy, you must have an
+    OpenID Connect available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Installation Guide
+    url: https://www.kiali.io/documentation/latest/installation-guide
+  - name: Features
+    url: https://www.kiali.io/documentation/latest/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  - name: Operator Source Code
+    url: https://github.com/kiali/kiali-operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                # required for the operator SDK metric service selector
+                name: kiali-operator
+                version: v1.33.0
+                app.kubernetes.io/name: kiali-operator
+                app.kubernetes.io/version: v1.33.0
+                app.kubernetes.io/part-of: kiali-operator
+              annotations:
+                prometheus.io/scrape: "true"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.33.0
+                imagePullPolicy: "IfNotPresent"
+                args:
+                - "--zap-log-level=info"
+                - "--leader-election-id=kiali-operator"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
+                  value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
+                ports:
+                - name: http-metrics
+                  containerPort: 8080
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["networking.k8s.io"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - pods/proxy
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - create
+          - post
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - networking.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        - apiGroups: ["iter8.tools"]
+          resources:
+          - experiments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["authentication.k8s.io"]
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        serviceAccountName: kiali-operator

--- a/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -271,6 +271,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_KIALI_NAMESPACE
+                  value: "false"
                 - name: ANSIBLE_DEBUG_LOGS
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO

--- a/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -272,7 +272,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: ALLOW_AD_HOC_KIALI_NAMESPACE
-                  value: "false"
+                  value: "true"
                 - name: ANSIBLE_DEBUG_LOGS
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO

--- a/manifests/kiali-community/kiali.package.yaml
+++ b/manifests/kiali-community/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.32.0
+  currentCSV: kiali-operator.v1.33.0
 - name: stable
-  currentCSV: kiali-operator.v1.32.0
+  currentCSV: kiali-operator.v1.33.0
 defaultChannel: stable

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -267,6 +267,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_KIALI_NAMESPACE
+                  value: "false"
                 - name: ANSIBLE_DEBUG_LOGS
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO

--- a/manifests/kiali-upstream/1.33.0/kiali.crd.yaml
+++ b/manifests/kiali-upstream/1.33.0/kiali.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-upstream/1.33.0/kiali.monitoringdashboards.crd.yaml
+++ b/manifests/kiali-upstream/1.33.0/kiali.monitoringdashboards.crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: monitoringdashboards.monitoring.kiali.io
+  labels:
+    app: kiali
+spec:
+  group: monitoring.kiali.io
+  names:
+    kind: MonitoringDashboard
+    listKind: MonitoringDashboardList
+    plural: monitoringdashboards
+    singular: monitoringdashboard
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -1,0 +1,568 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.33.0
+  namespace: placeholder
+  annotations:
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.33.0
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2021-04-07T15:32:04Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "default",
+              "view_only_mode": false
+            },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+spec:
+  version: 1.33.0
+  maturity: stable
+  replaces: kiali-operator.v1.32.0
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    By default, the Kiali operator exposes the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see the file
+    [kiali_cr.yaml](https://github.com/kiali/kiali-operator/blob/master/deploy/kiali/kiali_cr.yaml)
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio.
+    If you already have Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the installed Kiali first.
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `token`.
+
+    If you wish to use the `openid` authentication strategy, you must have an
+    OpenID Connect available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Installation Guide
+    url: https://www.kiali.io/documentation/latest/installation-guide
+  - name: Features
+    url: https://www.kiali.io/documentation/latest/features
+  - name: Documentation Home
+    url: https://www.kiali.io/documentation
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  - name: Operator Source Code
+    url: https://github.com/kiali/kiali-operator
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                # required for the operator SDK metric service selector
+                name: kiali-operator
+                version: v1.33.0
+                app.kubernetes.io/name: kiali-operator
+                app.kubernetes.io/version: v1.33.0
+                app.kubernetes.io/part-of: kiali-operator
+              annotations:
+                prometheus.io/scrape: "true"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.33.0
+                imagePullPolicy: "IfNotPresent"
+                args:
+                - "--zap-log-level=info"
+                - "--leader-election-id=kiali-operator"
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
+                  value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
+                ports:
+                - name: http-metrics
+                  containerPort: 8080
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - events
+          - persistentvolumeclaims
+          - pods
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["networking.k8s.io"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - namespaces
+          - nodes
+          - pods
+          - pods/log
+          - pods/proxy
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - create
+          - post
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - networking.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
+        - apiGroups: ["iter8.tools"]
+          resources:
+          - experiments
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["authentication.k8s.io"]
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        serviceAccountName: kiali-operator

--- a/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -271,6 +271,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_KIALI_NAMESPACE
+                  value: "false"
                 - name: ANSIBLE_DEBUG_LOGS
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO

--- a/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -272,7 +272,7 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: ALLOW_AD_HOC_KIALI_NAMESPACE
-                  value: "false"
+                  value: "true"
                 - name: ANSIBLE_DEBUG_LOGS
                   value: "True"
                 - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO

--- a/manifests/kiali-upstream/kiali.package.yaml
+++ b/manifests/kiali-upstream/kiali.package.yaml
@@ -1,7 +1,7 @@
 packageName: kiali
 channels:
 - name: alpha
-  currentCSV: kiali-operator.v1.32.0
+  currentCSV: kiali-operator.v1.33.0
 - name: stable
-  currentCSV: kiali-operator.v1.32.0
+  currentCSV: kiali-operator.v1.33.0
 defaultChannel: stable

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -77,6 +77,8 @@
       - "--set"
       - "debug.enableProfiler={{ lookup('env', 'MOLECULE_OPERATOR_PROFILER_ENABLED') | default('true', True) }}"
       - "--set"
+      - "allowAdHocKialiNamespace=true"
+      - "--set"
       - "cr.create=false"
       - "--set"
       - "image.repo={{ kiali.operator_image_name }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -213,6 +213,13 @@
   when:
   - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
 
+- name: Only allow ad-hoc kiali namespace when appropriate
+  fail:
+    msg: "The operator is forbidden from installing Kiali in a namespace [{{ kiali_vars.deployment.namespace }}] that is different from the namespace where the CR was created [{{ current_cr.metadata.namespace }}]"
+  when:
+  - kiali_vars.deployment.namespace != current_cr.metadata.namespace
+  - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
+
 - name: Set default istio namespace
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'istio_namespace': kiali_vars.deployment.namespace}, recursive=True) }}"

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -171,6 +171,13 @@
   when:
   - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
 
+- name: Only allow ad-hoc kiali namespace when appropriate
+￼  fail:
+￼    msg: "The operator is forbidden from installing Kiali in a namespace [{{ kiali_vars.deployment.namespace }}] that is different from the namespace where the CR was created [{{ current_cr.metadata.namespace }}]"
+￼  when:
+￼  - kiali_vars.deployment.namespace != current_cr.metadata.namespace
+￼  - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
+
 - name: Set default istio namespace
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'istio_namespace': kiali_vars.deployment.namespace}, recursive=True) }}"

--- a/roles/v1.24/kiali-deploy/tasks/main.yml
+++ b/roles/v1.24/kiali-deploy/tasks/main.yml
@@ -177,6 +177,13 @@
   when:
   - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
 
+- name: Only allow ad-hoc kiali namespace when appropriate
+￼  fail:
+￼    msg: "The operator is forbidden from installing Kiali in a namespace [{{ kiali_vars.deployment.namespace }}] that is different from the namespace where the CR was created [{{ current_cr.metadata.namespace }}]"
+￼  when:
+￼  - kiali_vars.deployment.namespace != current_cr.metadata.namespace
+￼  - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
+
 - name: Set default istio namespace
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'istio_namespace': kiali_vars.deployment.namespace}, recursive=True) }}"


### PR DESCRIPTION
OSSM-438

This fails the reconciliation if user tries to install kiali in a namespace different from where the CR is. This failure only happens when the Operator is configured to disallow such a thing (which is going to be the default)

- https://github.com/kiali/kiali/pull/3850
- https://github.com/kiali/helm-charts/pull/59 