### PR TITLE
Removing PATCH verb from pods/proxy sub-resource

### DIFF
--- a/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -478,7 +478,6 @@ spec:
           - nodes
           - pods
           - pods/log
-          - pods/proxy
           - replicationcontrollers
           - services
           verbs:
@@ -492,6 +491,13 @@ spec:
           verbs:
           - create
           - post
+        - apiGroups: [""]
+          resources:
+          - pods/proxy
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups: ["extensions", "apps"]
           resources:
           - daemonsets

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -482,7 +482,6 @@ spec:
           - nodes
           - pods
           - pods/log
-          - pods/proxy
           - replicationcontrollers
           - services
           verbs:
@@ -496,6 +495,13 @@ spec:
           verbs:
           - create
           - post
+        - apiGroups: [""]
+          resources:
+          - pods/proxy
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups: ["extensions", "apps"]
           resources:
           - daemonsets

--- a/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.33.0/kiali.v1.33.0.clusterserviceversion.yaml
@@ -478,7 +478,6 @@ spec:
           - nodes
           - pods
           - pods/log
-          - pods/proxy
           - replicationcontrollers
           - services
           verbs:
@@ -492,6 +491,13 @@ spec:
           verbs:
           - create
           - post
+        - apiGroups: [""]
+          resources:
+          - pods/proxy
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups: ["extensions", "apps"]
           resources:
           - daemonsets

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -18,7 +18,6 @@ rules:
   - nodes
   - pods
   - pods/log
-  - pods/proxy
   - replicationcontrollers
   - services
   verbs:
@@ -32,6 +31,13 @@ rules:
   verbs:
   - create
   - post
+- apiGroups: [""]
+  resources:
+  - pods/proxy
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -18,7 +18,6 @@ rules:
   - nodes
   - pods
   - pods/log
-  - pods/proxy
   - replicationcontrollers
   - services
   verbs:
@@ -32,6 +31,13 @@ rules:
   verbs:
   - create
   - post
+- apiGroups: [""]
+  resources:
+  - pods/proxy
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["extensions", "apps"]
   resources:
   - daemonsets


### PR DESCRIPTION
fixes https://github.com/kiali/kiali/issues/3878
part of https://github.com/kiali/kiali/issues/3871
needs helm-chart: https://github.com/kiali/helm-charts/pull/64

There are no `pods/proxy` usage in `v1.12` and `v1.24`.

![Screenshot of Kiali (23)](https://user-images.githubusercontent.com/613814/114859471-16c7cb80-9deb-11eb-8174-1f830a18710c.png)

To test:

Building the operator from this branch and helm-chart branch, should not imply any regression.
This `pods/proxy` is used in the health.