### PR TITLE
operator should be looking for crd v1 now

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -797,7 +797,7 @@
 
 - name: Wait for Monitoring Dashboards CRD to be ready
   community.kubernetes.k8s_info:
-    api_version: apiextensions.k8s.io/v1beta1
+    api_version: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io
   register: monitoringdashboards_crd


### PR DESCRIPTION
Forgot to update this when [operator moved to CRD v1.](https://github.com/kiali/kiali/issues/1757)

fixes: https://github.com/kiali/kiali/issues/3893