### PR TITLE
Add host stanza to Ingress

### DIFF
--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -30,4 +30,7 @@ spec:
         backend:
           serviceName: kiali
           servicePort: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.web_fqdn|length != 0 %}
+    host: {{ kiali_vars.server.web_fqdn }}
+{% endif %}
 {% endif %}


### PR DESCRIPTION
In Kubernetes, Ingress is setup as a catch-all ingress. This is
annoying. If the Kiali CR already contains the `web_fqdn` config, the
Ingress resource shouldn't be created as catch-all.