### PR TITLE
checks for namespace existence immediately prior to attempting to add/remove the label

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -685,11 +685,13 @@
     # everything to the left of the = is the name of the label we want to remove
     the_namespace_label_name: "{{ current_label_selector | regex_replace('^(.*)=.*$', '\\1') }}"
   # if a namespace happened to have been deleted, we do not want to (nor can we) resurrect it, hence we check for its existence
+  # https://github.com/kiali/kiali/issues/3949 : the if-stmt to query the namespace for existence is temporary - remove when that issue is truly fixed
   k8s:
     state: present
     definition: |
       {% for namespace in no_longer_accessible_namespaces %}
       {% if namespace in all_namespaces %}
+      {% if (query('k8s', kind='Namespace', resource_name=namespace) | length) > 0 %}
       ---
       apiVersion: v1
       kind: Namespace
@@ -698,6 +700,7 @@
         labels:
           {{ the_namespace_label_name }}: null
       ...
+      {% endif %}
       {% endif %}
       {% endfor %}
   when:

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -124,11 +124,13 @@
     # everything to the left of the = is the name of the label we want to remove
     the_namespace_label_name: "{{ current_label_selector | regex_replace('^(.*)=.*$', '\\1') }}"
   # if a namespace happened to have been deleted, we do not want to (nor can we) resurrect it, hence we check for its existence
+  # https://github.com/kiali/kiali/issues/3949 : the if-stmt to query the namespace for existence is temporary - remove when that issue is truly fixed
   k8s:
     state: present
     definition: |
       {% for namespace in current_accessible_namespaces %}
       {% if namespace in all_namespaces %}
+      {% if (query('k8s', kind='Namespace', resource_name=namespace) | length) > 0 %}
       ---
       apiVersion: v1
       kind: Namespace
@@ -137,6 +139,7 @@
         labels:
           {{ the_namespace_label_name }}: null
       ...
+      {% endif %}
       {% endif %}
       {% endfor %}
   when:


### PR DESCRIPTION
Temporary fix for https://github.com/kiali/kiali/issues/3949 - when that issue is really fixed, we should revert this commit.

This temp fix checks for namespace existence immediately prior to attempting to add/remove the label