### PR TITLE
add true can-i check to make sure the operator has the permissions it needs

### DIFF
--- a/manifests/kiali-community/1.38.0/manifests/kiali.v1.38.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.38.0/manifests/kiali.v1.38.0.clusterserviceversion.yaml
@@ -335,6 +335,11 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["authorization.k8s.io"]
+          resources:
+          - selfsubjectaccessreviews
+          verbs:
+          - list
         - apiGroups: ["rbac.authorization.k8s.io"]
           resources:
           - clusterrolebindings

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -376,6 +376,11 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["authorization.k8s.io"]
+          resources:
+          - selfsubjectaccessreviews
+          verbs:
+          - list
         - apiGroups: ["rbac.authorization.k8s.io"]
           resources:
           - clusterrolebindings

--- a/manifests/kiali-upstream/1.38.0/manifests/kiali.v1.38.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.38.0/manifests/kiali.v1.38.0.clusterserviceversion.yaml
@@ -335,6 +335,11 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["authorization.k8s.io"]
+          resources:
+          - selfsubjectaccessreviews
+          verbs:
+          - list
         - apiGroups: ["rbac.authorization.k8s.io"]
           resources:
           - clusterrolebindings

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -542,7 +542,7 @@
       kind: SelfSubjectAccessReview
       spec:
         resourceAttributes:
-          group: rbac.authorization.k8s.io/v1
+          group: rbac.authorization.k8s.io
           resource: clusterroles
           verb: create
   when:
@@ -558,14 +558,14 @@
       kind: SelfSubjectAccessReview
       spec:
         resourceAttributes:
-          group: rbac.authorization.k8s.io/v1
+          group: rbac.authorization.k8s.io
           resource: clusterrolebindings
           verb: create
   when:
   - '"**" in kiali_vars.deployment.accessible_namespaces'
 
-- debug:
-    msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterroles: {{ can_i_create_clusterroles }}"
+- fail:
+    msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterroles"
   when:
   - '"**" in kiali_vars.deployment.accessible_namespaces'
   - can_i_create_clusterroles is defined
@@ -574,8 +574,8 @@
   - can_i_create_clusterroles.result.status.allowed is defined
   - can_i_create_clusterroles.result.status.allowed == False
 
-- debug:
-    msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterrolebindings: {{ can_i_create_clusterrolebindings }}"
+- fail:
+    msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterrolebindings"
   when:
   - '"**" in kiali_vars.deployment.accessible_namespaces'
   - can_i_create_clusterrolebindings is defined

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -564,7 +564,7 @@
   when:
   - '"**" in kiali_vars.deployment.accessible_namespaces'
 
-- fail:
+- debug:
     msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterroles: {{ can_i_create_clusterroles }}"
   when:
   - '"**" in kiali_vars.deployment.accessible_namespaces'
@@ -574,7 +574,7 @@
   - can_i_create_clusterroles.result.status.allowed is defined
   - can_i_create_clusterroles.result.status.allowed == False
 
-- fail:
+- debug:
     msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterrolebindings: {{ can_i_create_clusterrolebindings }}"
   when:
   - '"**" in kiali_vars.deployment.accessible_namespaces'

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -532,6 +532,58 @@
     role_kind: "{{ 'ClusterRole' if '**' in kiali_vars.deployment.accessible_namespaces else 'Role' }}"
     role_binding_kind: "{{ 'ClusterRoleBinding' if '**' in kiali_vars.deployment.accessible_namespaces else 'RoleBinding' }}"
 
+- name: Determine if the operator can support accessible_namespaces=** - can_i create clusterroles
+  register: can_i_create_clusterroles
+  ignore_errors: yes
+  k8s:
+    state: present
+    definition:
+      apiVersion: authorization.k8s.io/v1
+      kind: SelfSubjectAccessReview
+      spec:
+        resourceAttributes:
+          group: rbac.authorization.k8s.io/v1
+          resource: clusterroles
+          verb: create
+  when:
+  - '"**" in kiali_vars.deployment.accessible_namespaces'
+
+- name: Determine if the operator can support accessible_namespaces=** - can_i create clusterrolebindings
+  register: can_i_create_clusterrolebindings
+  ignore_errors: yes
+  k8s:
+    state: present
+    definition:
+      apiVersion: authorization.k8s.io/v1
+      kind: SelfSubjectAccessReview
+      spec:
+        resourceAttributes:
+          group: rbac.authorization.k8s.io/v1
+          resource: clusterrolebindings
+          verb: create
+  when:
+  - '"**" in kiali_vars.deployment.accessible_namespaces'
+
+- fail:
+    msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterroles: {{ can_i_create_clusterroles }}"
+  when:
+  - '"**" in kiali_vars.deployment.accessible_namespaces'
+  - can_i_create_clusterroles is defined
+  - can_i_create_clusterroles.result is defined
+  - can_i_create_clusterroles.result.status is defined
+  - can_i_create_clusterroles.result.status.allowed is defined
+  - can_i_create_clusterroles.result.status.allowed == False
+
+- fail:
+    msg: "The operator cannot support deployment.accessible_namespaces set to ['**'] because it does not have permissions to create clusterrolebindings: {{ can_i_create_clusterrolebindings }}"
+  when:
+  - '"**" in kiali_vars.deployment.accessible_namespaces'
+  - can_i_create_clusterrolebindings is defined
+  - can_i_create_clusterrolebindings.result is defined
+  - can_i_create_clusterrolebindings.result.status is defined
+  - can_i_create_clusterrolebindings.result.status.allowed is defined
+  - can_i_create_clusterrolebindings.result.status.allowed == False
+
 - name: Find all namespaces (this is limited to what the operator has permission to see)
   set_fact:
     all_namespaces: "{{ lookup(k8s_plugin, api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3241

associated Helm Chart PR: https://github.com/kiali/helm-charts/pull/70

Do NOT merge until the Ansible Operator SDK we are using has the community.kubernetes collection with the bug fix (we need at least 1.1). ~Right now we only have 0.11 so the bug fix isn't available for us to use yet~ UPDATE we can merge now, we are up to 1.2 now:
```
$ docker run -it --rm  --entrypoint ''  quay.io/openshift/origin-ansible-operator:4.7.0 cat /opt/ansible/.ansible/collections/ansible_collections/community/kubernetes/MANIFEST.json | grep version
  "version": "0.11.1",
```