### PR TITLE
Be able to customize the names of the kiali resources.

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -41,6 +41,9 @@ spec:
 
 ##########
 # Tag used to identify a particular instance/installation of the Kiali server.
+# This is merely a human-readable string that will be used within Kiali to
+# help a user identify the Kiali being used (e.g. in the Kiali UI title bar).
+# See deployment.instance_name for the setting used to customize Kiali resource names that are created.
 #  ---
 #  installation_tag: ""
 
@@ -100,9 +103,11 @@ spec:
 # (e.g. "myLabel=myValue") which is used when fetching the list of available namespaces.
 # This does not affect explicit namespace access.
 # Note that if you do not set this but deployment.accessible_namespaces does not have the
-# special "all namespaces" value of "**" then this label_selector will be set
-# to a default value of "kiali.io/member-of=<deployment.namespace>" where
-# <deployment.namespace> is the namespace where Kiali is to be installed.
+# special "all namespaces" entry of "**" then this label_selector will be set
+# to a default value of "kiali.io/[<deployment.instance_name>.]member-of=<deployment.namespace>"
+# where [<deployment.instance_name>.] is the instance name assigned to the Kiali installation
+# if it is not the default 'kiali' (otherwise, this is omitted) and <deployment.namespace>
+# is the namespace where Kiali is to be installed.
 # If deployment.accessible_namespaces does not have the special value of "**"
 # then the Kiali operator will add a new label to all accessible namespaces - that new
 # label will be this label_selector.
@@ -268,8 +273,8 @@ spec:
 #    ---
 #    ingress_enabled: true
 #
-# The instance name of this Kiali installation. This will be the prefix prepended
-# to the names of all Kiali resources created by the operator and will be used
+# The instance name of this Kiali installation. This instance name will be the prefix
+# prepended to the names of all Kiali resources created by the operator and will be used
 # to label those resources as belonging to this Kiali installation instance.
 # You cannot change this instance name after a Kiali CR is created. If you attempt
 # to change it, the operator will abort with an error. If you want to change it,
@@ -280,6 +285,8 @@ spec:
 # Kiali instances in the same deployment namespace. If you want a different
 # signing key secret, you are free to create your own and tell the operator about it via
 # the login_token.signing_key setting. See the docs on that setting for more details.
+# Note also that if you are setting this value, you may also want to change
+# the installation_tag setting, but this is not required.
 #    ---
 #    instance_name: "kiali"
 #

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -333,6 +333,18 @@ spec:
 #    ---
 #    replicas: 1
 #
+# Defines the prefix prepended to the names of all Kiali resources created by the operator.
+# You cannot change this prefix after a Kiali CR is created. If you attempt to change it,
+# the operator will abort with an error. If you want to change it, you must first
+# delete the original Kiali CR and create a new one.
+# Note that this does not affect the name of the auto-generated signing key secret. If
+# you do not supply a signing key, the operator will create one for you in a secret,
+# but that secret will always be named "kiali-signing-key". If you want a different
+# signing key secret, you are free to create your own and tell the operator about it via
+# the login_token.signing_key setting. See the docs on that setting for more details.
+#    ---
+#    resource_names_prefix: "kiali"
+#
 # Defines compute resources that are to be given to the Kiali pod's container.
 # The value is a dict as defined by Kubernetes. See the Kubernetes documentation
 # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -268,6 +268,21 @@ spec:
 #    ---
 #    ingress_enabled: true
 #
+# The instance name of this Kiali installation. This will be the prefix prepended
+# to the names of all Kiali resources created by the operator and will be used
+# to label those resources as belonging to this Kiali installation instance.
+# You cannot change this instance name after a Kiali CR is created. If you attempt
+# to change it, the operator will abort with an error. If you want to change it,
+# you must first delete the original Kiali CR and create a new one.
+# Note that this does not affect the name of the auto-generated signing key secret. If
+# you do not supply a signing key, the operator will create one for you in a secret,
+# but that secret will always be named "kiali-signing-key" and shared across all
+# Kiali instances in the same deployment namespace. If you want a different
+# signing key secret, you are free to create your own and tell the operator about it via
+# the login_token.signing_key setting. See the docs on that setting for more details.
+#    ---
+#    instance_name: "kiali"
+#
 # Determines the logger configuration.
 # log_format supports text and json.
 # log_level supports trace, debug, info, warn, error, fatal.
@@ -332,18 +347,6 @@ spec:
 # The replica count for the Kiail deployment.
 #    ---
 #    replicas: 1
-#
-# Defines the prefix prepended to the names of all Kiali resources created by the operator.
-# You cannot change this prefix after a Kiali CR is created. If you attempt to change it,
-# the operator will abort with an error. If you want to change it, you must first
-# delete the original Kiali CR and create a new one.
-# Note that this does not affect the name of the auto-generated signing key secret. If
-# you do not supply a signing key, the operator will create one for you in a secret,
-# but that secret will always be named "kiali-signing-key". If you want a different
-# signing key secret, you are free to create your own and tell the operator about it via
-# the login_token.signing_key setting. See the docs on that setting for more details.
-#    ---
-#    resource_names_prefix: "kiali"
 #
 # Defines compute resources that are to be given to the Kiali pod's container.
 # The value is a dict as defined by Kubernetes. See the Kubernetes documentation

--- a/molecule/asserts/roles-test/ro_clusterrole_asserts.yml
+++ b/molecule/asserts/roles-test/ro_clusterrole_asserts.yml
@@ -1,8 +1,10 @@
 - name: Get cluster roles
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRole
-   name: kiali-viewer
+   name: "{{ instance_name }}-viewer"
   register: clusterroles
 
 - name: Assert that cluster roles exist
@@ -11,14 +13,18 @@
     fail_msg: "The kiali-viewer cluster role does not exist"
 
 - name: Get cluster role binding
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
-   name: kiali
+   name: "{{ instance_name }}"
   register: clusterrolebindings
 
 - name: Assert the cluster role binding provides the read-only viewer role
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   assert:
     that:
-    - "{{ clusterrolebindings.resources[0] | default({}) | json_query('roleRef.name') == 'kiali-viewer' }}"
-    fail_msg: "The kiali cluster role binding did not have the read-only roleref 'kiali-viewer'"
+    - "{{ clusterrolebindings.resources[0] | default({}) | json_query('roleRef.name') == instance_name + '-viewer' }}"
+    fail_msg: "The kiali cluster role binding did not have the read-only roleref {{ instance_name }}-viewer"

--- a/molecule/asserts/roles-test/ro_role_asserts.yml
+++ b/molecule/asserts/roles-test/ro_role_asserts.yml
@@ -1,4 +1,6 @@
 - name: Get roles
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: Role
@@ -7,7 +9,7 @@
   register: roles
   with_nested:
   - "{{ kiali.accessible_namespaces }}"
-  - kiali-viewer
+  - "{{ instance_name}}-viewer"
 
 - name: Assert that namespaces have the correct roles
   assert:
@@ -16,6 +18,8 @@
   - "{{ roles.results }}"
 
 - name: Get role binding
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: RoleBinding
@@ -24,12 +28,14 @@
   register: rolebindings
   with_nested:
   - "{{ kiali.accessible_namespaces }}"
-  - kiali
+  - "{{ instance_name}}"
 
 - name: Assert the role binding provides the read-only viewer role
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   assert:
     that:
-    - "{{ item.resources[0] | default({}) | json_query('roleRef.name') == 'kiali-viewer' }}"
-    fail_msg: "The kiali role binding did not have the read-only roleref 'kiali-viewer'"
+    - "{{ item.resources[0] | default({}) | json_query('roleRef.name') == instance_name + '-viewer' }}"
+    fail_msg: "The kiali role binding did not have the read-only roleref {{ instance_name }}-viewer"
   with_items:
   - "{{ rolebindings.results }}"

--- a/molecule/asserts/roles-test/rw_clusterrole_asserts.yml
+++ b/molecule/asserts/roles-test/rw_clusterrole_asserts.yml
@@ -1,8 +1,10 @@
 - name: Get cluster roles
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRole
-   name: kiali
+   name: "{{ instance_name }}"
   register: clusterroles
 
 - name: Assert that cluster roles exist
@@ -11,14 +13,18 @@
     fail_msg: "The kiali cluster role does not exist"
 
 - name: Get cluster role binding
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: ClusterRoleBinding
-   name: kiali
+   name: "{{ instance_name }}"
   register: clusterrolebindings
 
 - name: Assert the cluster role binding provides the read-write role
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   assert:
     that:
-    - "{{ clusterrolebindings.resources[0] | default({}) | json_query('roleRef.name') == 'kiali' }}"
-    fail_msg: "The kiali cluster role binding did not have the read-write roleref 'kiali'"
+    - "{{ clusterrolebindings.resources[0] | default({}) | json_query('roleRef.name') == instance_name }}"
+    fail_msg: "The kiali cluster role binding did not have the read-write roleref {{ instance_name }}"

--- a/molecule/asserts/roles-test/rw_role_asserts.yml
+++ b/molecule/asserts/roles-test/rw_role_asserts.yml
@@ -1,4 +1,6 @@
 - name: Get roles
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: Role
@@ -7,7 +9,7 @@
   register: roles
   with_nested:
   - "{{ kiali.accessible_namespaces }}"
-  - kiali
+  - "{{ instance_name }}"
 
 - name: Assert that namespaces have the correct roles
   assert:
@@ -16,6 +18,8 @@
   - "{{ roles.results }}"
 
 - name: Get role binding
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
    api_version: rbac.authorization.k8s.io/v1
    kind: RoleBinding
@@ -24,12 +28,14 @@
   register: rolebindings
   with_nested:
   - "{{ kiali.accessible_namespaces }}"
-  - kiali
+  - "{{ instance_name }}"
 
 - name: Assert the role binding provides the read-write role
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   assert:
     that:
-    - "{{ item.resources[0] | default({}) | json_query('roleRef.name') == 'kiali' }}"
-    fail_msg: "The kiali role binding did not have the read-write roleref 'kiali'"
+    - "{{ item.resources[0] | default({}) | json_query('roleRef.name') == instance_name }}"
+    fail_msg: "The kiali role binding did not have the read-write roleref {{ instance_name }}"
   with_items:
   - "{{ rolebindings.results }}"

--- a/molecule/common/tasks.yml
+++ b/molecule/common/tasks.yml
@@ -19,7 +19,7 @@
     kind: Pod
     namespace: "{{ kiali.operator_namespace }}"
     label_selectors:
-    - app = kiali-operator
+    - app.kubernetes.io/name = kiali-operator
   register: kiali_operator_pod
 
 - name: Get Kiali Pod
@@ -28,7 +28,7 @@
     kind: Pod
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app = kiali
+    - app.kubernetes.io/name = kiali
   register: kiali_pod
 
 - name: Get Kiali Configmap
@@ -45,7 +45,7 @@
     kind: Deployment
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app = kiali
+    - app.kubernetes.io/name = kiali
   register: kiali_deployment
 
 - name: Get Kiali Service
@@ -54,7 +54,7 @@
     kind: Service
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app = kiali
+    - app.kubernetes.io/name = kiali
   register: kiali_service
 
 - name: Get Kiali Route
@@ -63,7 +63,7 @@
     kind: Route
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app = kiali
+    - app.kubernetes.io/name = kiali
   register: kiali_route
   when:
   - is_openshift == True

--- a/molecule/common/tasks.yml
+++ b/molecule/common/tasks.yml
@@ -79,8 +79,10 @@
   - is_openshift == True
 
 - name: Determine the Kiali Route URL on OpenShift
+  vars:
+    web_root: "{{ kiali_configmap.server.web_root if kiali_configmap.server.web_root != '/' else '' }}"
   set_fact:
-    kiali_base_url: "https://{{ kiali_route.resources[0].spec.host }}"
+    kiali_base_url: "https://{{ kiali_route.resources[0].spec.host }}{{ web_root }}"
   when:
   - is_openshift == True
 
@@ -88,8 +90,9 @@
 - name: Determine the Kiali Ingress URL on minikube
   vars:
     instance_name: "{{ kiali.instance_name | default('kiali') }}"
+    web_root: "{{ kiali_configmap.server.web_root if kiali_configmap.server.web_root != '/' else '' }}"
   set_fact:
-    kiali_base_url: "https://{{ lookup('env', 'MOLECULE_MINIKUBE_IP') }}/{{ instance_name }}"
+    kiali_base_url: "https://{{ lookup('env', 'MOLECULE_MINIKUBE_IP') }}{{ web_root }}"
   when:
   - is_k8s == True
 

--- a/molecule/common/tasks.yml
+++ b/molecule/common/tasks.yml
@@ -23,47 +23,57 @@
   register: kiali_operator_pod
 
 - name: Get Kiali Pod
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app.kubernetes.io/name = kiali
+    - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_pod
 
 - name: Get Kiali Configmap
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   set_fact:
-    kiali_configmap: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace=kiali.install_namespace, resource_name='kiali') }}"
+    kiali_configmap: "{{ lookup('k8s', api_version='v1', kind='ConfigMap', namespace=kiali.install_namespace, resource_name=instance_name) }}"
 
 - name: Format Configmap
   set_fact:
     kiali_configmap: "{{ kiali_configmap.data['config.yaml'] | from_yaml }}"
 
 - name: Get Kiali Deployment
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
     api_version: apps/v1
     kind: Deployment
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app.kubernetes.io/name = kiali
+    - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_deployment
 
 - name: Get Kiali Service
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
     api_version: v1
     kind: Service
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app.kubernetes.io/name = kiali
+    - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_service
 
 - name: Get Kiali Route
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app.kubernetes.io/name = kiali
+    - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_route
   when:
   - is_openshift == True
@@ -74,9 +84,12 @@
   when:
   - is_openshift == True
 
+# To avoid problems with Ingress/Minikube conflicts, if installing multiple kiali instances set web_root to the instance name
 - name: Determine the Kiali Ingress URL on minikube
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   set_fact:
-    kiali_base_url: "https://{{ lookup('env', 'MOLECULE_MINIKUBE_IP') }}/kiali"
+    kiali_base_url: "https://{{ lookup('env', 'MOLECULE_MINIKUBE_IP') }}/{{ instance_name }}"
   when:
   - is_k8s == True
 

--- a/molecule/common/wait_for_kiali_running.yml
+++ b/molecule/common/wait_for_kiali_running.yml
@@ -1,10 +1,12 @@
 - name: Asserting that Kiali Pod exists and there is only one
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
     api_version: v1
     kind: Pod
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app.kubernetes.io/name = kiali
+    - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_pod
   until:
   - kiali_pod is success

--- a/molecule/common/wait_for_kiali_running.yml
+++ b/molecule/common/wait_for_kiali_running.yml
@@ -4,7 +4,7 @@
     kind: Pod
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app = kiali
+    - app.kubernetes.io/name = kiali
   register: kiali_pod
   until:
   - kiali_pod is success

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -31,11 +31,13 @@
 
   # Wait for the last things to be removed (which are the configmap and monitoring dashboards). This avoids the namespace-stuck-problem.
   - name: Wait for Kiali ConfigMap to be uninstalled
+    vars:
+      instance_name: "{{ kiali.instance_name | default('kiali') }}"
     k8s_info:
       api_version: v1
       kind: ConfigMap
       namespace: "{{ kiali.install_namespace }}"
-      name: kiali
+      name: "{{ instance_name }}"
     register: doomed_list
     until:
     - doomed_list is success

--- a/molecule/default/dump-logs.yml
+++ b/molecule/default/dump-logs.yml
@@ -8,7 +8,7 @@
   k8s_log:
     namespace: "{{ kiali.operator_namespace }}"
     label_selectors:
-    - app=kiali-operator
+    - app.kubernetes.io/name=kiali-operator
   register: kiali_operator_logs
   ignore_errors: yes
   when:
@@ -25,7 +25,7 @@
   k8s_log:
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app=kiali
+    - app.kubernetes.io/name=kiali
   register: kiali_logs
   ignore_errors: yes
   when:

--- a/molecule/default/dump-logs.yml
+++ b/molecule/default/dump-logs.yml
@@ -22,10 +22,12 @@
   - kiali_operator_logs is defined and kiali_operator_logs.log_lines is defined
 
 - name: Get Kiali Server Pod logs
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_log:
     namespace: "{{ kiali.install_namespace }}"
     label_selectors:
-    - app.kubernetes.io/name=kiali
+    - "app.kubernetes.io/name={{ instance_name }}"
   register: kiali_logs
   ignore_errors: yes
   when:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -130,12 +130,14 @@
     - prometheus_config is defined
 
   - name: Asserting that Kiali is Deployed
+    vars:
+      instance_name: "{{ kiali.instance_name | default('kiali') }}"
     k8s_info:
       api_version: v1
       kind: Deployment
       namespace: "{{ kiali.install_namespace }}"
       label_selectors:
-      - app.kubernetes.io/name = kiali
+      - "app.kubernetes.io/name={{ instance_name }}"
     register: kiali_deployment
     until:
     - kiali_deployment is success

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -135,7 +135,7 @@
       kind: Deployment
       namespace: "{{ kiali.install_namespace }}"
       label_selectors:
-      - app = kiali
+      - app.kubernetes.io/name = kiali
     register: kiali_deployment
     until:
     - kiali_deployment is success

--- a/molecule/instance-name-test/converge.yml
+++ b/molecule/instance-name-test/converge.yml
@@ -1,0 +1,175 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  collections:
+  - community.kubernetes
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+
+  # the first kiali install is coming online - it has the default instance_name of 'kiali'
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+  - import_tasks: ../asserts/accessible_namespaces_contains.yml
+    vars:
+      namespace_list: [ 'instancenametest' ]
+
+  - name: Make sure the one new namespace label exists
+    vars:
+      namespacesWithLabel: "{{ query('k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+    assert:
+      that:
+      - namespacesWithLabel | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 1
+
+  # now install a second kiali with the instance_name of 'kialitwo' and wait for it to come online
+  - set_fact:
+      kiali: "{{ kiali | combine({'instance_name': 'kialitwo'}, recursive=True) }}"
+  - set_fact:
+      custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+
+  - debug:
+      msg: "INSTALL KIALITWO"
+
+  - import_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ custom_resource }}"
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  - name: Make sure the two new namespace labels exists and the two labels on the signing key exist
+    vars:
+      namespacesWithLabel1: "{{ query('k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      namespacesWithLabel2: "{{ query('k8s', kind='Namespace', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel1: "{{ query('k8s', kind='Secret', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel2: "{{ query('k8s', kind='Secret', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+    assert:
+      that:
+      - namespacesWithLabel1 | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 1
+      - namespacesWithLabel2 | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 1
+      - signingKeyWithLabel1 | selectattr('metadata.name', 'equalto', 'kiali-signing-key') | length == 1
+      - signingKeyWithLabel2 | selectattr('metadata.name', 'equalto', 'kiali-signing-key') | length == 1
+
+  - name: Kubernetes - Make sure we have the basic resources we expect, with the labels we expect
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Ingress',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+    loop:
+    - app.kubernetes.io/instance=kiali
+    - app.kubernetes.io/instance=kialitwo
+    when:
+    - is_k8s == True
+
+  - name: OpenShift - Make sure we have the basic resources we expect, with the labels we expect
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Route',          namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+    loop:
+    - app.kubernetes.io/instance=kiali
+    - app.kubernetes.io/instance=kialitwo
+    when:
+    - is_openshift == True
+
+  # now delete the second kiali (the one with the instance_name of 'kialitwo') and see that things get cleaned up
+  - debug:
+      msg: "DELETE KIALITWO"
+
+  - name: Deleting kialitwo instance
+    k8s:
+      state: absent
+      wait: yes
+      api_version: kiali.io/v1alpha1
+      kind: Kiali
+      name: "{{ custom_resource.metadata.name }}"
+      namespace: "{{ cr_namespace }}"
+
+  - name: Make sure the first namespace label exists but the second one is gone, same with the signing key
+    vars:
+      namespacesWithLabel1: "{{ query('k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      namespacesWithLabel2: "{{ query('k8s', kind='Namespace', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel1: "{{ query('k8s', kind='Secret', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel2: "{{ query('k8s', kind='Secret', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+    assert:
+      that:
+      - namespacesWithLabel1 | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 1
+      - namespacesWithLabel2 | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 0
+      - signingKeyWithLabel1 | selectattr('metadata.name', 'equalto', 'kiali-signing-key') | length == 1
+      - signingKeyWithLabel2 | selectattr('metadata.name', 'equalto', 'kiali-signing-key') | length == 0
+
+  # Check that the resources for the remaining instance still exist
+
+  - name: Kubernetes - Make sure we have the basic resources we expect, with the labels we expect for the remaining instance
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Ingress',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+    loop:
+    - app.kubernetes.io/instance=kiali
+    when:
+    - is_k8s == True
+
+  - name: OpenShift - Make sure we have the basic resources we expect, with the labels we expect for the remaining instance
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='Route',          namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+    loop:
+    - app.kubernetes.io/instance=kiali
+    when:
+    - is_openshift == True
+
+  # Check that the resources for the deleted instance have been removed
+
+  - name: Kubernetes - Confirm we have no more resources for the deleted instance
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Ingress',        namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+    loop:
+    - app.kubernetes.io/instance=kialitwo
+    when:
+    - is_k8s == True
+
+  - name: OpenShift - Confirm we have no more resources for the deleted instance
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='Route',          namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+    loop:
+    - app.kubernetes.io/instance=kialitwo
+    when:
+    - is_openshift == True
+

--- a/molecule/instance-name-test/converge.yml
+++ b/molecule/instance-name-test/converge.yml
@@ -51,16 +51,28 @@
       - signingKeyWithLabel1 | selectattr('metadata.name', 'equalto', 'kiali-signing-key') | length == 1
       - signingKeyWithLabel2 | selectattr('metadata.name', 'equalto', 'kiali-signing-key') | length == 1
 
+  # just set some common constants so our assert code below is easier to read
+  - set_fact:
+      queryNamespace: "{{ istio.control_plane_namespace }}"
+      apiCMap: "v1"
+      apiDepl: "apps/v1"
+      apiRole: "rbac.authorization.k8s.io/v1"
+      apiRoBi: "rbac.authorization.k8s.io/v1"
+      apiServ: "v1"
+      apiSvcA: "v1"
+      apiIngr: "networking.k8s.io/v1beta1"
+      apiRout: "route.openshift.io/v1"
+
   - name: Kubernetes - Make sure we have the basic resources we expect, with the labels we expect
     assert:
       that:
-      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Ingress',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     - app.kubernetes.io/instance=kialitwo
@@ -70,13 +82,13 @@
   - name: OpenShift - Make sure we have the basic resources we expect, with the labels we expect
     assert:
       that:
-      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Route',          namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 2
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     - app.kubernetes.io/instance=kialitwo
@@ -114,13 +126,13 @@
   - name: Kubernetes - Make sure we have the basic resources we expect, with the labels we expect for the remaining instance
     assert:
       that:
-      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Ingress',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     when:
@@ -129,13 +141,13 @@
   - name: OpenShift - Make sure we have the basic resources we expect, with the labels we expect for the remaining instance
     assert:
       that:
-      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 2
-      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 1
-      - query('k8s', kind='Route',          namespace=istio.control_plane_namespace, label_selector=item) | length == 1
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 2
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     when:
@@ -146,13 +158,13 @@
   - name: Kubernetes - Confirm we have no more resources for the deleted instance
     assert:
       that:
-      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Ingress',        namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 0
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 0
+      - query('k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 0
+      - query('k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 0
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 0
     loop:
     - app.kubernetes.io/instance=kialitwo
     when:
@@ -161,13 +173,13 @@
   - name: OpenShift - Confirm we have no more resources for the deleted instance
     assert:
       that:
-      - query('k8s', kind='ConfigMap',      namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Deployment',     namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Role',           namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='RoleBinding',    namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Service',        namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='ServiceAccount', namespace=istio.control_plane_namespace, label_selector=item) | length == 0
-      - query('k8s', kind='Route',          namespace=istio.control_plane_namespace, label_selector=item) | length == 0
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 0
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 0
+      - query('k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 0
+      - query('k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 0
     loop:
     - app.kubernetes.io/instance=kialitwo
     when:

--- a/molecule/instance-name-test/destroy-instance-name-test.yml
+++ b/molecule/instance-name-test/destroy-instance-name-test.yml
@@ -1,0 +1,13 @@
+- name: Destroy
+  hosts: localhost
+  connection: local
+  collections:
+  - community.kubernetes
+
+- name: Include the base destroy play to destroy the first kiali install
+  import_playbook: ../default/destroy.yml
+
+- name: Delete the test namespace
+  import_playbook: ./process-namespace.yml
+  vars:
+    state: absent

--- a/molecule/instance-name-test/kiali-cr.yaml
+++ b/molecule/instance-name-test/kiali-cr.yaml
@@ -1,0 +1,21 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: {{ kiali.instance_name }}
+spec:
+  version: {{ kiali.spec_version }}
+  istio_namespace: {{ istio.control_plane_namespace }}
+  auth:
+    strategy: {{ kiali.auth_strategy }}
+  deployment:
+    custom_dashboards:
+      includes: []
+    namespace: {{ kiali.install_namespace }}
+    image_name: {{ kiali.image_name }}
+    image_pull_policy: {{ kiali.image_pull_policy }}
+    image_version: {{ kiali.image_version }}
+    accessible_namespaces: {{ kiali.accessible_namespaces }}
+    service_type: NodePort
+    instance_name: {{ kiali.instance_name }}
+  server:
+    web_root: /{{ kiali.instance_name }}

--- a/molecule/instance-name-test/molecule.yml
+++ b/molecule/instance-name-test/molecule.yml
@@ -1,0 +1,47 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ./destroy-instance-name-test.yml
+    prepare: ./prepare-instance-name-test.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/instance-name-test/kiali-cr.yaml"
+        cr_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR must go in control plane namespace
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          spec_version: "{{ lookup('env', 'MOLECULE_KIALI_CR_SPEC_VERSION') | default('default', True) }}"
+          install_namespace: istio-system
+          accessible_namespaces: ["instancenametest"]
+          auth_strategy: anonymous
+          operator_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'openshift-operators' }}" # if external operator, assume operator is in OLM location
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: kiali-operator
+          operator_cluster_role_creator: "true"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+          instance_name: "kiali" # we start by installing the default instance - we'll later install one with a different instance name
+scenario:
+  name: instance-name-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/molecule/instance-name-test/prepare-instance-name-test.yml
+++ b/molecule/instance-name-test/prepare-instance-name-test.yml
@@ -1,0 +1,13 @@
+- name: Prepare
+  hosts: localhost
+  connection: local
+  collections:
+  - community.kubernetes
+
+- name: Create the test namespace
+  import_playbook: ./process-namespace.yml
+  vars:
+    state: present
+
+- name: Include the base prepare play to create the first kiali install
+  import_playbook: ../default/prepare.yml

--- a/molecule/instance-name-test/process-namespace.yml
+++ b/molecule/instance-name-test/process-namespace.yml
@@ -1,0 +1,12 @@
+- name: "Process Test Namespace [state={{ state }}]"
+  hosts: localhost
+  connection: local
+  collections:
+  - community.kubernetes
+
+  tasks:
+  - k8s:
+      state: "{{ state }}"
+      api_version: v1
+      kind: Namespace
+      name: instancenametest

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -78,6 +78,7 @@ kiali_defaults:
     pod_labels: {}
     priority_class_name: ""
     replicas: 1
+    resource_names_prefix: "kiali"
     resources: {}
     secret_name: "kiali"
     service_annotations: {}

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -66,6 +66,7 @@ kiali_defaults:
     image_pull_secrets: []
     image_version: ""
     ingress_enabled: true
+    instance_name: "kiali"
     logger:
       log_format: "text"
       log_level: "info"
@@ -78,7 +79,6 @@ kiali_defaults:
     pod_labels: {}
     priority_class_name: ""
     replicas: 1
-    resource_names_prefix: "kiali"
     resources: {}
     secret_name: "kiali"
     service_annotations: {}

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -31,7 +31,7 @@
     api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
     kind: "HorizontalPodAutoscaler"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "kiali"
+    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
   when:
   - is_k8s == True
   - kiali_vars.deployment.hpa.spec | length == 0
@@ -55,7 +55,7 @@
     api_version: "networking.k8s.io/v1beta1"
     kind: "Ingress"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "kiali"
+    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
   when:
   - is_k8s == True
   - kiali_vars.deployment.ingress_enabled|bool == False

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -31,7 +31,7 @@
     api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
     kind: "HorizontalPodAutoscaler"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
   when:
   - is_k8s == True
   - kiali_vars.deployment.hpa.spec | length == 0
@@ -55,7 +55,7 @@
     api_version: "networking.k8s.io/v1beta1"
     kind: "Ingress"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
   when:
   - is_k8s == True
   - kiali_vars.deployment.ingress_enabled|bool == False

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -394,6 +394,13 @@
   - is_openshift == True
   - kiali_vars.external_services.tracing.auth.ca_file is not defined or kiali_vars.external_services.tracing.auth.ca_file == ''
 
+- name: Make sure the correct auth.openshift.client_id_prefix is defined when using openshift auth strategy
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'auth': {'openshift': {'client_id_prefix': kiali_vars.deployment.resource_names_prefix }}}, recursive=True) }}"
+  when:
+  - kiali_vars.auth.strategy == 'openshift'
+  - kiali_vars.auth.openshift.client_id_prefix != kiali_vars.deployment.resource_names_prefix
+
 # Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
 - debug:
     msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"
@@ -479,6 +486,16 @@
 - debug:
     msg: "IMAGE_NAME={{ kiali_vars.deployment.image_name }}; IMAGE VERSION={{ kiali_vars.deployment.image_version }}; VERSION LABEL={{ kiali_vars.deployment.version_label }}"
 
+- name: Determine what metadata labels to apply to all created resources
+  set_fact:
+    kiali_resource_metadata_labels:
+      app: kiali
+      version: "{{ kiali_vars.deployment.version_label }}"
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/version: "{{ kiali_vars.deployment.version_label }}"
+      app.kubernetes.io/instance: "{{ kiali_vars.deployment.resource_names_prefix }}"
+      app.kubernetes.io/part-of: kiali
+
 # Determine the accessible namespaces. The user may have specified names using regex expressions.
 # We need to get a list of all namespaces and match them to the regex expressions.
 # Note that we replace kiali_vars.deployment.accessible_namespaces with the full list of actual namespace names
@@ -559,12 +576,7 @@
       metadata:
         namespace: "{{ kiali_vars.deployment.namespace }}"
         name: kiali-signing-key
-        labels:
-          app: kiali
-          version: "{{ kiali_vars.deployment.version_label }}"
-          app.kubernetes.io/name: kiali
-          app.kubernetes.io/version: "{{ kiali_vars.deployment.version_label }}"
-          app.kubernetes.io/part-of: kiali
+        labels: "{{ kiali_resource_metadata_labels }}"
       type: Opaque
       data:
         key: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') | b64encode }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -201,22 +201,22 @@
     msg: "{{ msg.split('\n') }}"
   tags: test
 
-# Never allow the resource names prefix to change to avoid leaking resources that we fail to update or clean up.
-- name: Ensure the resource_names_prefix has not changed
+# Never allow the instance_name to change to avoid leaking resources that we fail to update or clean up.
+- name: Ensure the instance_name has not changed
   fail:
-    msg: "The deployment.resource_names_prefix cannot be changed to a different value. It was [{{ current_cr.status.deployment.resourceNamesPrefix }}] but is now [{{ kiali_vars.deployment.resource_names_prefix }}]. In order to install Kiali with a different resource names prefix, please uninstall Kiali first."
+    msg: "The deployment.instance_name cannot be changed to a different value. It was [{{ current_cr.status.deployment.instanceName }}] but is now [{{ kiali_vars.deployment.instance_name }}]. In order to install Kiali with a different deployment.instance_name, please uninstall Kiali first."
   when:
   - current_cr.status is defined
   - current_cr.status.deployment is defined
-  - current_cr.status.deployment.resourceNamesPrefix is defined
-  - current_cr.status.deployment.resourceNamesPrefix != kiali_vars.deployment.resource_names_prefix
+  - current_cr.status.deployment.instanceName is defined
+  - current_cr.status.deployment.instanceName != kiali_vars.deployment.instance_name
 
 - include_tasks: update-status-progress.yml
   vars:
     status_progress_message: "Setting up configuration"
     status_vars:
       deployment:
-        resourceNamesPrefix: "{{ kiali_vars.deployment.resource_names_prefix }}"
+        instanceName: "{{ kiali_vars.deployment.instance_name }}"
 
 # We do not want to blindly default to istio-system for some namespaces. If the istio_namespace is not
 # provided, assume it is the same namespace where Kiali is being deployed. Set the other istio namespace
@@ -396,10 +396,10 @@
 
 - name: Make sure the correct auth.openshift.client_id_prefix is defined when using openshift auth strategy
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'auth': {'openshift': {'client_id_prefix': kiali_vars.deployment.resource_names_prefix }}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'auth': {'openshift': {'client_id_prefix': kiali_vars.deployment.instance_name }}}, recursive=True) }}"
   when:
   - kiali_vars.auth.strategy == 'openshift'
-  - kiali_vars.auth.openshift.client_id_prefix != kiali_vars.deployment.resource_names_prefix
+  - kiali_vars.auth.openshift.client_id_prefix != kiali_vars.deployment.instance_name
 
 # Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
 - debug:
@@ -493,7 +493,7 @@
       version: "{{ kiali_vars.deployment.version_label }}"
       app.kubernetes.io/name: kiali
       app.kubernetes.io/version: "{{ kiali_vars.deployment.version_label }}"
-      app.kubernetes.io/instance: "{{ kiali_vars.deployment.resource_names_prefix }}"
+      app.kubernetes.io/instance: "{{ kiali_vars.deployment.instance_name }}"
       app.kubernetes.io/part-of: kiali
 
 # Determine the accessible namespaces. The user may have specified names using regex expressions.
@@ -552,7 +552,7 @@
 
 # If the signing key is empty string, we need to ensure a signing key secret exists. If one does not exist, we need to generate one.
 # Note that to avoid granting to the operator the very powerful permission to CRUD all secrets in all namespaces, we always generate
-# a signing key secret with the name "kiali-signing-key" regardless of the value of kiali_vars.deployment.resource_names_prefix.
+# a signing key secret with the name "kiali-signing-key" regardless of the value of kiali_vars.deployment.instance_name.
 # Thus, all Kiali instances will be using the same signing key secret name. If the user does not want this, they can generate their
 # own secret with their own key (which is a smart thing to do anyway). The user tells the operator what the name of that secret
 # signing key is via "login_token.signing_key" with value "secret:<theSecretName>:<theSecretKey>".
@@ -645,7 +645,7 @@
 
 - name: Find current configmap, if it exists
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 
 - name: Find some current configuration settings
   set_fact:
@@ -654,21 +654,21 @@
     current_view_only_mode: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.view_only_mode') }}"
     current_image_name: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_name') }}"
     current_image_version: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_version') }}"
-    current_resource_names_prefix: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.resource_names_prefix') }}"
+    current_instance_name: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.instance_name') }}"
   when:
   - current_configmap is defined
   - current_configmap.data is defined
   - current_configmap.data['config.yaml'] is defined
 
-# Never allow the resource names prefix to change to avoid leaking resources that we fail to update or clean up.
-# I actually don't know how this will ever fail because we would not have found the configmap if the prefix is different,
+# Never allow the instance name to change to avoid leaking resources that we fail to update or clean up.
+# I actually don't know how this will ever fail because we would not have found the configmap if the instance name is different,
 # but do this at least as a sanity check.
-- name: Do not allow user to change resource names prefix
+- name: Do not allow user to change deployment.instance_name
   fail:
-    msg: "The deployment.resource_names_prefix cannot be changed to a different value. It was [{{ current_resource_names_prefix }}] but is now [{{ kiali_vars.deployment.resource_names_prefix }}]. In order to install Kiali with a different resource names prefix, please uninstall Kiali first."
+    msg: "The deployment.instance_name cannot be changed to a different value. It was [{{ current_instance_name }}] but is now [{{ kiali_vars.deployment.instance_name }}]. In order to install Kiali with a different deployment.instance_name, please uninstall Kiali first."
   when:
-  - current_resource_names_prefix is defined
-  - current_resource_names_prefix != kiali_vars.deployment.resource_names_prefix
+  - current_instance_name is defined
+  - current_instance_name != kiali_vars.deployment.instance_name
 
 # Because we need to remove the labels that were created before, we must not allow the user to change
 # the label_selector. So if the current accessible_namespaces is not ** but the label_select is being changed,
@@ -783,7 +783,7 @@
     api_version: apps/v1
     kind: Deployment
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
   when:
   - current_image_name is defined and current_image_version is defined
   - (current_image_name != kiali_vars.deployment.image_name) or (current_image_version != kiali_vars.deployment.image_version)
@@ -793,7 +793,7 @@
 # that requires a pod restart - in which case we update this timestamp.
 - name: Find current deployment, if it exists
   set_fact:
-    current_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+    current_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
 
 - name: Get current deployment last-updated annotation timestamp from existing deployment
   set_fact:
@@ -947,7 +947,7 @@
 # If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
 - name: Force the Kiali pod to restart if necessary
   vars:
-    updated_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+    updated_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
   k8s:
     state: "present"
     definition: "{{ updated_deployment }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -588,6 +588,25 @@
   - signing_key_secret_raw.resources is defined
   - signing_key_secret_raw.resources | length == 0
 
+# Because we must use a fixed name for the secret, we need to attach a label to indicate this Kiali install will be using it.
+# This allows multiple Kiali instances deployed in the same namespace to share the secret. This secret won't be removed
+# as long as our label exists on the secret resource.
+- name: Add label to kiali-signing-key secret to make it known this Kiali instance will be using it
+  vars:
+    the_label: "{{ 'kiali.io/' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + 'member-of' }}"
+  k8s:
+    state: present
+    definition: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+        name: kiali-signing-key
+        labels:
+          {{ the_label }}: {{ kiali_vars.deployment.namespace }}
+  when:
+  - kiali_vars.login_token.signing_key == ""
+
 - name: Point signing key to the generated secret
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'login_token': {'signing_key': 'secret:kiali-signing-key:key'}}, recursive=True) }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -535,9 +535,11 @@
   debug:
     msg: "{{ kiali_vars.deployment.accessible_namespaces }}"
 
+# Note that we add the instance name to the member-of key name only if the instance name is not the default 'kiali'.
+# This is for backward compatibility, and for simplicity when deploying under normal default conditions.
 - name: When accessible namespaces are specified, ensure label selector is set
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'api': {'namespaces': {'label_selector': ('kiali.io/member-of=' + kiali_vars.deployment.namespace)}}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'api': {'namespaces': {'label_selector': ('kiali.io/' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + 'member-of=' + kiali_vars.deployment.namespace)}}}, recursive=True) }}"
   when:
   - '"**" not in kiali_vars.deployment.accessible_namespaces'
   - kiali_vars.api.namespaces.label_selector is not defined

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -5,6 +5,9 @@
 - include_tasks: update-status-progress.yml
   vars:
     status_progress_message: "Initializing"
+    status_vars:
+      deployment:
+        accessibleNamespaces: null
 
 - name: Get information about the cluster
   set_fact:
@@ -197,6 +200,23 @@
   debug:
     msg: "{{ msg.split('\n') }}"
   tags: test
+
+# Never allow the resource names prefix to change to avoid leaking resources that we fail to update or clean up.
+- name: Ensure the resource_names_prefix has not changed
+  fail:
+    msg: "The deployment.resource_names_prefix cannot be changed to a different value. It was [{{ current_cr.status.deployment.resourceNamesPrefix }}] but is now [{{ kiali_vars.deployment.resource_names_prefix }}]. In order to install Kiali with a different resource names prefix, please uninstall Kiali first."
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.resourceNamesPrefix is defined
+  - current_cr.status.deployment.resourceNamesPrefix != kiali_vars.deployment.resource_names_prefix
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Setting up configuration"
+    status_vars:
+      deployment:
+        resourceNamesPrefix: "{{ kiali_vars.deployment.resource_names_prefix }}"
 
 # We do not want to blindly default to istio-system for some namespaces. If the istio_namespace is not
 # provided, assume it is the same namespace where Kiali is being deployed. Set the other istio namespace
@@ -513,7 +533,12 @@
   # this regex is not 100% accurate, but we want to at least catch obvious errors
   - kiali_vars.api.namespaces.label_selector is not regex('^[a-zA-Z0-9/_.-]+=[a-zA-Z0-9_.-]+$')
 
-# If the signing key is empty string, we need to ensure a signing key secret exists - if it does not generate one.
+# If the signing key is empty string, we need to ensure a signing key secret exists. If one does not exist, we need to generate one.
+# Note that to avoid granting to the operator the very powerful permission to CRUD all secrets in all namespaces, we always generate
+# a signing key secret with the name "kiali-signing-key" regardless of the value of kiali_vars.deployment.resource_names_prefix.
+# Thus, all Kiali instances will be using the same signing key secret name. If the user does not want this, they can generate their
+# own secret with their own key (which is a smart thing to do anyway). The user tells the operator what the name of that secret
+# signing key is via "login_token.signing_key" with value "secret:<theSecretName>:<theSecretKey>".
 
 - name: Get information about any existing signing key secret if we need to know if it exists or not
   k8s_info:
@@ -525,7 +550,7 @@
   when:
   - kiali_vars.login_token.signing_key == ""
 
-- name: Create secret to store a random signing key if a secret does not already exist and we need one
+- name: Create kiali-signing-key secret to store a random signing key if a secret does not already exist and we need one
   k8s:
     state: present
     definition:
@@ -537,6 +562,9 @@
         labels:
           app: kiali
           version: "{{ kiali_vars.deployment.version_label }}"
+          app.kubernetes.io/name: kiali
+          app.kubernetes.io/version: "{{ kiali_vars.deployment.version_label }}"
+          app.kubernetes.io/part-of: kiali
       type: Opaque
       data:
         key: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') | b64encode }}"
@@ -605,7 +633,7 @@
 
 - name: Find current configmap, if it exists
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 
 - name: Find some current configuration settings
   set_fact:
@@ -614,10 +642,21 @@
     current_view_only_mode: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.view_only_mode') }}"
     current_image_name: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_name') }}"
     current_image_version: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_version') }}"
+    current_resource_names_prefix: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.resource_names_prefix') }}"
   when:
   - current_configmap is defined
   - current_configmap.data is defined
   - current_configmap.data['config.yaml'] is defined
+
+# Never allow the resource names prefix to change to avoid leaking resources that we fail to update or clean up.
+# I actually don't know how this will ever fail because we would not have found the configmap if the prefix is different,
+# but do this at least as a sanity check.
+- name: Do not allow user to change resource names prefix
+  fail:
+    msg: "The deployment.resource_names_prefix cannot be changed to a different value. It was [{{ current_resource_names_prefix }}] but is now [{{ kiali_vars.deployment.resource_names_prefix }}]. In order to install Kiali with a different resource names prefix, please uninstall Kiali first."
+  when:
+  - current_resource_names_prefix is defined
+  - current_resource_names_prefix != kiali_vars.deployment.resource_names_prefix
 
 # Because we need to remove the labels that were created before, we must not allow the user to change
 # the label_selector. So if the current accessible_namespaces is not ** but the label_select is being changed,
@@ -732,7 +771,7 @@
     api_version: apps/v1
     kind: Deployment
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: kiali
+    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
   when:
   - current_image_name is defined and current_image_version is defined
   - (current_image_name != kiali_vars.deployment.image_name) or (current_image_version != kiali_vars.deployment.image_version)
@@ -742,7 +781,7 @@
 # that requires a pod restart - in which case we update this timestamp.
 - name: Find current deployment, if it exists
   set_fact:
-    current_deployment: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+    current_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
 
 - name: Get current deployment last-updated annotation timestamp from existing deployment
   set_fact:
@@ -894,14 +933,9 @@
   ignore_errors: yes
 
 # If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
-
-- include_tasks: update-status-progress.yml
-  vars:
-    status_progress_message: "Finished all resource creation"
-
 - name: Force the Kiali pod to restart if necessary
   vars:
-    updated_deployment: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+    updated_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
   k8s:
     state: "present"
     definition: "{{ updated_deployment }}"
@@ -915,7 +949,9 @@
 # So instead - if the list of namespaces is manageable, store them in a comma-separate list.
 # Otherwise, we'll just log the count. The purpose of this accessibleNamespaces status field is
 # just to inform the user how many namespaces the operator processed.
-- include_tasks: update-status.yml
+- include_tasks: update-status-progress.yml
   vars:
+    status_progress_message: "Finished all resource creation"
     status_vars:
-      accessibleNamespaces: "{{ ('Number of accessible namespaces (including control plane namespace): ' + (kiali_vars.deployment.accessible_namespaces | length | string)) if (kiali_vars.deployment.accessible_namespaces | length > 20) else (kiali_vars.deployment.accessible_namespaces | join(',')) }}"
+      deployment:
+        accessibleNamespaces: "{{ ('Number of accessible namespaces (including control plane namespace): ' + (kiali_vars.deployment.accessible_namespaces | length | string)) if (kiali_vars.deployment.accessible_namespaces | length > 20) else (kiali_vars.deployment.accessible_namespaces | join(',')) }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -201,8 +201,14 @@
     msg: "{{ msg.split('\n') }}"
   tags: test
 
-# Never allow the instance_name to change to avoid leaking resources that we fail to update or clean up.
-- name: Ensure the instance_name has not changed
+- name: Set default deployment namespace to the same namespace where the CR lives
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
+
+# Never allow the deployment.instance_name or deployment.namespace to change to avoid leaking resources - to uninstall resources you must delete the Kiali CR
+- name: Ensure the deployment.instance_name has not changed
   fail:
     msg: "The deployment.instance_name cannot be changed to a different value. It was [{{ current_cr.status.deployment.instanceName }}] but is now [{{ kiali_vars.deployment.instance_name }}]. In order to install Kiali with a different deployment.instance_name, please uninstall Kiali first."
   when:
@@ -211,23 +217,14 @@
   - current_cr.status.deployment.instanceName is defined
   - current_cr.status.deployment.instanceName != kiali_vars.deployment.instance_name
 
-- include_tasks: update-status-progress.yml
-  vars:
-    status_progress_message: "Setting up configuration"
-    status_vars:
-      deployment:
-        instanceName: "{{ kiali_vars.deployment.instance_name }}"
-
-# We do not want to blindly default to istio-system for some namespaces. If the istio_namespace is not
-# provided, assume it is the same namespace where Kiali is being deployed. Set the other istio namespace
-# values accordingly.
-# We determine the default Istio namespace var first, and the rest will use it for their default as appropriate.
-
-- name: Set default deployment namespace to the same namespace where the CR lives
-  set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+- name: Ensure the deployment.namespace has not changed
+  fail:
+    msg: "The deployment.namespace cannot be changed to a different value. It was [{{ current_cr.status.deployment.namespace }}] but is now [{{ kiali_vars.deployment.namespace }}]. In order to install Kiali with a different deployment.namespace, please uninstall Kiali first."
   when:
-  - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.namespace is defined
+  - current_cr.status.deployment.namespace != kiali_vars.deployment.namespace
 
 - name: Only allow ad-hoc kiali namespace when appropriate
   fail:
@@ -235,6 +232,19 @@
   when:
   - kiali_vars.deployment.namespace != current_cr.metadata.namespace
   - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Setting up configuration"
+    status_vars:
+      deployment:
+        instanceName: "{{ kiali_vars.deployment.instance_name }}"
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+
+# We do not want to blindly default to istio-system for some namespaces. If the istio_namespace is not
+# provided, assume it is the same namespace where Kiali is being deployed. Set the other istio namespace
+# values accordingly.
+# We determine the default Istio namespace var first, and the rest will use it for their default as appropriate.
 
 - name: Set default istio namespace
   set_fact:

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -233,6 +233,14 @@
   - kiali_vars.deployment.namespace != current_cr.metadata.namespace
   - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
 
+- name: Make sure instance_name follows the DNS label standard because it will be a Service name
+  fail:
+    msg: "The value for deployment.instance_name [{{ kiali_vars.deployment.instance_name }}] does not follow the DNS label standard as defined in RFC 1123. In short, it must only contain lowercase alphanumeric characters or '-'."
+  when:
+  # regex must follow https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+  # restrict to 40 chars, not 63, because instance_name is a prefix and we need to prepend additional chars for some resource names (like "-service-account")
+  - kiali_vars.deployment.instance_name is not regex('^(?![0-9]+$)(?!-)[a-z0-9-]{,40}(?<!-)$')
+
 - include_tasks: update-status-progress.yml
   vars:
     status_progress_message: "Setting up configuration"

--- a/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -6,7 +6,7 @@
   k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
-    name: kiali
+    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
     namespace: "{{ kiali_vars.deployment.namespace }}"
   register: kiali_route_raw
   until:

--- a/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -6,7 +6,7 @@
   k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
-    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
     namespace: "{{ kiali_vars.deployment.namespace }}"
   register: kiali_route_raw
   until:

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -32,7 +32,7 @@
     api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
     kind: "HorizontalPodAutoscaler"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "kiali"
+    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
   when:
   - is_openshift == True
   - kiali_vars.deployment.hpa.spec | length == 0
@@ -56,7 +56,7 @@
     api_version: "route.openshift.io/v1"
     kind: "Route"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "kiali"
+    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
   when:
   - is_openshift == True
   - kiali_vars.deployment.ingress_enabled|bool == False
@@ -113,7 +113,7 @@
       apiVersion: console.openshift.io/v1
       kind: ConsoleLink
       metadata:
-        name: "kiali-namespace-{{ namespace }}"
+        name: "{{ kiali_vars.deployment.resource_names_prefix }}-namespace-{{ namespace }}"
       ...
       {% endfor %}
   when:

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -32,7 +32,7 @@
     api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
     kind: "HorizontalPodAutoscaler"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
   when:
   - is_openshift == True
   - kiali_vars.deployment.hpa.spec | length == 0
@@ -56,7 +56,7 @@
     api_version: "route.openshift.io/v1"
     kind: "Route"
     namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
   when:
   - is_openshift == True
   - kiali_vars.deployment.ingress_enabled|bool == False
@@ -113,7 +113,7 @@
       apiVersion: console.openshift.io/v1
       kind: ConsoleLink
       metadata:
-        name: "{{ kiali_vars.deployment.resource_names_prefix }}-namespace-{{ namespace }}"
+        name: "{{ kiali_vars.deployment.instance_name }}-namespace-{{ namespace }}"
       ...
       {% endfor %}
   when:

--- a/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/default/kiali-deploy/tasks/remove-roles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-roles.yml
@@ -7,21 +7,21 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+        name: "{{ kiali_vars.deployment.instance_name }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+        name: "{{ kiali_vars.deployment.instance_name }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: "{{ kiali_vars.deployment.resource_names_prefix }}-viewer"
+        name: "{{ kiali_vars.deployment.instance_name }}-viewer"
         namespace: "{{ namespace }}"
       ...
       {% endfor %}

--- a/roles/default/kiali-deploy/tasks/remove-roles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-roles.yml
@@ -7,21 +7,21 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: kiali
+        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: kiali
+        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: kiali-viewer
+        name: "{{ kiali_vars.deployment.resource_names_prefix }}-viewer"
         namespace: "{{ namespace }}"
       ...
       {% endfor %}

--- a/roles/default/kiali-deploy/tasks/update-status-progress.yml
+++ b/roles/default/kiali-deploy/tasks/update-status-progress.yml
@@ -4,14 +4,13 @@
     status_progress_step: "{{ 1 if status_progress_step is not defined else (status_progress_step|int + 1) }}"
     status_progress_start: "{{ ('%Y-%m-%d %H:%M:%S' | strftime) if status_progress_start is not defined else (status_progress_start) }}"
 
-- name: Update CR status progress field
+- name: Update CR status progress field with any additional status fields
   ignore_errors: yes
+  vars:
+    duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
   operator_sdk.util.k8s_status:
     api_version: "{{ current_cr.apiVersion }}"
     kind: "{{ current_cr.kind }}"
     name: "{{ current_cr.metadata.name }}"
     namespace: "{{ current_cr.metadata.namespace }}"
-    status:
-      progress:
-        message: "{{ status_progress_step }}. {{ status_progress_message }}"
-        duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
+    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"

--- a/roles/default/kiali-deploy/templates/dashboards/envoy.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/envoy.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: envoy
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   title: Envoy Metrics
   discoverOn: "envoy_server_uptime"

--- a/roles/default/kiali-deploy/templates/dashboards/go.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/go.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: go
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   title: Go Metrics
   runtime: Go

--- a/roles/default/kiali-deploy/templates/dashboards/kiali.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/kiali.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: kiali
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   title: Kiali Internal Metrics
   items:

--- a/roles/default/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm-pool.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: micrometer-1.0.6-jvm-pool
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: JVM
   title: JVM Pool Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/micrometer-1.0.6-jvm.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: micrometer-1.0.6-jvm
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: JVM
   title: JVM Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/micrometer-1.1-jvm.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/micrometer-1.1-jvm.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: micrometer-1.1-jvm
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: JVM
   title: JVM Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/microprofile-1.1.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/microprofile-1.1.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: microprofile-1.1
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   title: MicroProfile Metrics
   runtime: MicroProfile

--- a/roles/default/kiali-deploy/templates/dashboards/microprofile-x.y.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/microprofile-x.y.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: microprofile-x.y
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   title: MicroProfile Metrics
   runtime: MicroProfile

--- a/roles/default/kiali-deploy/templates/dashboards/nodejs.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/nodejs.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: nodejs
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Node.js
   title: Node.js Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/quarkus.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/quarkus.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: quarkus
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   title: Quarkus Metrics
   runtime: Quarkus

--- a/roles/default/kiali-deploy/templates/dashboards/springboot-jvm-pool.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/springboot-jvm-pool.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: springboot-jvm-pool
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Spring Boot
   title: JVM Pool Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/springboot-jvm.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/springboot-jvm.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: springboot-jvm
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Spring Boot
   title: JVM Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/springboot-tomcat.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/springboot-tomcat.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: springboot-tomcat
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Spring Boot
   title: Tomcat Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/thorntail.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/thorntail.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: thorntail
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Thorntail
   title: Thorntail Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/tomcat.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/tomcat.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: tomcat
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Tomcat
   title: Tomcat Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/vertx-client.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/vertx-client.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-client
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Vert.x
   title: Vert.x Client Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/vertx-eventbus.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/vertx-eventbus.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-eventbus
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Vert.x
   title: Vert.x Eventbus Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/vertx-jvm.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/vertx-jvm.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-jvm
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Vert.x
   title: JVM Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/vertx-pool.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/vertx-pool.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-pool
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Vert.x
   title: Vert.x Pools Metrics

--- a/roles/default/kiali-deploy/templates/dashboards/vertx-server.yaml
+++ b/roles/default/kiali-deploy/templates/dashboards/vertx-server.yaml
@@ -1,11 +1,8 @@
-apiVersion: "monitoring.kiali.io/v1alpha1"
+apiVersion: monitoring.kiali.io/v1alpha1
 kind: MonitoringDashboard
 metadata:
   name: vertx-server
-  labels:
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   runtime: Vert.x
   title: Vert.x Server Metrics

--- a/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -3,12 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 data:
   config.yaml: |
     {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}

--- a/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 data:

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 spec:
@@ -9,7 +9,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kiali
-      app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -17,7 +17,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: {{ kiali_vars.deployment.resource_names_prefix }}
+      name: {{ kiali_vars.deployment.instance_name }}
       labels: {{ kiali_resource_metadata_labels | combine(kiali_vars.deployment.pod_labels) }}
       annotations:
 {% if kiali_vars.server.metrics_enabled|bool == True %}
@@ -33,7 +33,7 @@ spec:
         {{ kiali_vars.deployment.pod_annotations | to_nice_yaml(indent=0) | trim | indent(8) }}
 {% endif %}
     spec:
-      serviceAccount: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+      serviceAccount: {{ kiali_vars.deployment.instance_name }}-service-account
 {% if kiali_vars.deployment.priority_class_name != "" %}
       priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
 {% endif %}
@@ -108,10 +108,10 @@ spec:
       volumes:
       - name: kiali-configuration
         configMap:
-          name: {{ kiali_vars.deployment.resource_names_prefix }}
+          name: {{ kiali_vars.deployment.instance_name }}
       - name: kiali-cert
         secret:
-          secretName: "istio.{{ kiali_vars.deployment.resource_names_prefix }}-service-account"
+          secretName: "istio.{{ kiali_vars.deployment.instance_name }}-service-account"
 {% if kiali_vars.identity.cert_file == "" %}
           optional: true
 {% endif %}

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -21,7 +21,7 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      name: kiali
+      name: {{ kiali_vars.deployment.resource_names_prefix }}
       labels:
         app: kiali
         version: {{ kiali_vars.deployment.version_label }}
@@ -45,7 +45,7 @@ spec:
         {{ kiali_vars.deployment.pod_annotations | to_nice_yaml(indent=0) | trim | indent(8) }}
 {% endif %}
     spec:
-      serviceAccount: kiali-service-account
+      serviceAccount: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
 {% if kiali_vars.deployment.priority_class_name != "" %}
       priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
 {% endif %}
@@ -94,7 +94,7 @@ spec:
         - name: LOG_LEVEL
           value: "{{ kiali_vars.deployment.verbose_mode if kiali_vars.deployment.verbose_mode is defined else kiali_vars.deployment.logger.log_level }}"
         - name: LOG_SAMPLER_RATE
-          value: "{{ kiali_vars.deployment.logger.sampler_rate }}"  
+          value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT
           value: "{{ kiali_vars.deployment.logger.time_field_format }}" 
 {% for env in kiali_deployment_environment_variables %}
@@ -120,10 +120,10 @@ spec:
       volumes:
       - name: kiali-configuration
         configMap:
-          name: kiali
+          name: {{ kiali_vars.deployment.resource_names_prefix }}
       - name: kiali-cert
         secret:
-          secretName: istio.kiali-service-account
+          secretName: "istio.{{ kiali_vars.deployment.resource_names_prefix }}-service-account"
 {% if kiali_vars.identity.cert_file == "" %}
           optional: true
 {% endif %}

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -3,17 +3,13 @@ kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -22,15 +18,7 @@ spec:
   template:
     metadata:
       name: {{ kiali_vars.deployment.resource_names_prefix }}
-      labels:
-        app: kiali
-        version: {{ kiali_vars.deployment.version_label }}
-        app.kubernetes.io/name: kiali
-        app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-        app.kubernetes.io/part-of: kiali
-{% if kiali_vars.deployment.pod_labels|length > 0 %}
-        {{ kiali_vars.deployment.pod_labels | to_nice_yaml(indent=0) | trim | indent(8) }}
-{% endif %}
+      labels: {{ kiali_resource_metadata_labels | combine(kiali_vars.deployment.pod_labels) }}
       annotations:
 {% if kiali_vars.server.metrics_enabled|bool == True %}
         prometheus.io/scrape: "true"
@@ -96,7 +84,7 @@ spec:
         - name: LOG_SAMPLER_RATE
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT
-          value: "{{ kiali_vars.deployment.logger.time_field_format }}" 
+          value: "{{ kiali_vars.deployment.logger.time_field_format }}"
 {% for env in kiali_deployment_environment_variables %}
         - name: {{ env }}
           valueFrom:

--- a/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -14,6 +14,6 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: kiali
+    name: {{ kiali_vars.deployment.resource_names_prefix }}
   {{ kiali_vars.deployment.hpa.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -4,12 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ kiali_vars.deployment.resource_names_prefix }}
+    name: {{ kiali_vars.deployment.instance_name }}
   {{ kiali_vars.deployment.hpa.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -3,12 +3,7 @@ kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% else %}

--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
@@ -23,7 +23,7 @@ spec:
       paths:
       - path: {{ kiali_vars.server.web_root }}
         backend:
-          serviceName: {{ kiali_vars.deployment.resource_names_prefix }}
+          serviceName: {{ kiali_vars.deployment.instance_name }}
           servicePort: {{ kiali_vars.server.port }}
 {% if kiali_vars.server.web_fqdn|length != 0 %}
     host: {{ kiali_vars.server.web_fqdn }}

--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -28,7 +28,7 @@ spec:
       paths:
       - path: {{ kiali_vars.server.web_root }}
         backend:
-          serviceName: kiali
+          serviceName: {{ kiali_vars.deployment.resource_names_prefix }}
           servicePort: {{ kiali_vars.server.port }}
 {% if kiali_vars.server.web_fqdn|length != 0 %}
     host: {{ kiali_vars.server.web_fqdn }}

--- a/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
+  name: {{ kiali_vars.deployment.instance_name }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 rules:

--- a/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kiali-controlplane
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -3,12 +3,7 @@ kind: Role
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]
   resources:

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -5,12 +5,7 @@ kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-viewer
   namespace: {{ namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]
   resources:

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-viewer
+  name: {{ kiali_vars.deployment.instance_name }}-viewer
   namespace: {{ namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 rules:

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: kiali-viewer
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-viewer
   namespace: {{ namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -5,12 +5,7 @@ kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]
   resources:

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 rules:

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kiali-controlplane
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels:
     app: kiali
@@ -12,8 +12,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kiali-controlplane
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
 subjects:
 - kind: ServiceAccount
-  name: kiali-service-account
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
+  name: {{ kiali_vars.deployment.instance_name }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
+  name: {{ kiali_vars.deployment.instance_name }}-controlplane
 subjects:
 - kind: ServiceAccount
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -3,12 +3,7 @@ kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
   labels:
     app: kiali
@@ -14,9 +14,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ role_kind }}
-  name: {{ 'kiali-viewer' if kiali_vars.deployment.view_only_mode|bool == True else 'kiali' }}
+  name: {{ (kiali_vars.deployment.resource_names_prefix + '-viewer') if kiali_vars.deployment.view_only_mode|bool == True else kiali_vars.deployment.resource_names_prefix }}
 subjects:
 - kind: ServiceAccount
-  name: kiali-service-account
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -3,15 +3,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ role_kind }}
-  name: {{ (kiali_vars.deployment.resource_names_prefix + '-viewer') if kiali_vars.deployment.view_only_mode|bool == True else kiali_vars.deployment.resource_names_prefix }}
+  name: {{ (kiali_vars.deployment.instance_name + '-viewer') if kiali_vars.deployment.view_only_mode|bool == True else kiali_vars.deployment.instance_name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -5,12 +5,7 @@ kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ role_kind }}

--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -3,12 +3,7 @@ kind: Service
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
   annotations:
 {% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}
     kiali.io/external-url: {{ kiali_vars.server.web_schema + '://' + kiali_vars.server.web_fqdn + ((':' + kiali_vars.server.web_port | string) if (kiali_vars.server.web_port | string | length != 0) else '') + (kiali_vars.server.web_root | default('')) }}
@@ -31,5 +26,5 @@ spec:
 {% endif %}
   selector:
     app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
+    app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
@@ -26,5 +26,5 @@ spec:
 {% endif %}
   selector:
     app.kubernetes.io/name: kiali
-    app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
+    app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -30,6 +30,6 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kiali-service-account
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -3,9 +3,4 @@ kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}

--- a/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-cabundle
+  name: {{ kiali_vars.deployment.instance_name }}-cabundle
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
   annotations:

--- a/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
@@ -3,11 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-cabundle
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali-cabundle
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-cabundle
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/configmap.yaml
@@ -3,12 +3,7 @@ kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 data:
   config.yaml: |
     {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}

--- a/roles/default/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 data:

--- a/roles/default/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/console-links.yaml
@@ -3,7 +3,7 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-namespace-{{ namespace }}
+  name: {{ kiali_vars.deployment.instance_name }}-namespace-{{ namespace }}
   labels: {{ kiali_resource_metadata_labels | combine({'kiali.io/home': kiali_vars.deployment.namespace }) }}
 spec:
   href: {{ kiali_route_url }}{{ '/' if kiali_vars.server.web_root == '/' else (kiali_vars.server.web_root + '/') }}console/graph/namespaces?namespaces={{ namespace }}

--- a/roles/default/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/console-links.yaml
@@ -4,13 +4,7 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-namespace-{{ namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
-    kiali.io/home: {{ kiali_vars.deployment.namespace }}
+  labels: {{ kiali_resource_metadata_labels | combine({'kiali.io/home': kiali_vars.deployment.namespace }) }}
 spec:
   href: {{ kiali_route_url }}{{ '/' if kiali_vars.server.web_root == '/' else (kiali_vars.server.web_root + '/') }}console/graph/namespaces?namespaces={{ namespace }}
   location: NamespaceDashboard

--- a/roles/default/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/console-links.yaml
@@ -4,11 +4,12 @@ apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-namespace-{{ namespace }}
-  labels: {{ kiali_resource_metadata_labels | combine({'kiali.io/home': kiali_vars.deployment.namespace }) }}
+  labels: {{ kiali_resource_metadata_labels | combine({'kiali.io/home': ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + kiali_vars.deployment.namespace }) }}
 spec:
   href: {{ kiali_route_url }}{{ '/' if kiali_vars.server.web_root == '/' else (kiali_vars.server.web_root + '/') }}console/graph/namespaces?namespaces={{ namespace }}
   location: NamespaceDashboard
   text: Kiali
+  text: {{ ('Kiali [' + kiali_vars.deployment.instance_name + ']') if kiali_vars.deployment.instance_name != 'kiali' else 'Kiali' }}
   namespaceDashboard:
     namespaces:
     - {{ namespace }}

--- a/roles/default/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/console-links.yaml
@@ -3,7 +3,7 @@
 apiVersion: console.openshift.io/v1
 kind: ConsoleLink
 metadata:
-  name: kiali-namespace-{{ namespace }}
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-namespace-{{ namespace }}
   labels:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -3,29 +3,17 @@ kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
   template:
     metadata:
       name: {{ kiali_vars.deployment.resource_names_prefix }}
-      labels:
-        app: kiali
-        version: {{ kiali_vars.deployment.version_label }}
-        app.kubernetes.io/name: kiali
-        app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-        app.kubernetes.io/part-of: kiali
-{% if kiali_vars.deployment.pod_labels|length > 0 %}
-        {{ kiali_vars.deployment.pod_labels | to_nice_yaml(indent=0) | trim | indent(8) }}
-{% endif %}
+      labels: {{ kiali_resource_metadata_labels | combine(kiali_vars.deployment.pod_labels) }}
       annotations:
 {% if kiali_vars.server.metrics_enabled|bool == True %}
         prometheus.io/scrape: "true"
@@ -96,7 +84,7 @@ spec:
         - name: LOG_SAMPLER_RATE
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT
-          value: "{{ kiali_vars.deployment.logger.time_field_format }}" 
+          value: "{{ kiali_vars.deployment.logger.time_field_format }}"
 {% for env in kiali_deployment_environment_variables %}
         - name: {{ env }}
           valueFrom:

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -16,7 +16,7 @@ spec:
       app.kubernetes.io/name: kiali
   template:
     metadata:
-      name: kiali
+      name: {{ kiali_vars.deployment.resource_names_prefix }}
       labels:
         app: kiali
         version: {{ kiali_vars.deployment.version_label }}
@@ -45,7 +45,7 @@ spec:
         maxAvailable: 1
       type: RollingUpdate
     spec:
-      serviceAccount: kiali-service-account
+      serviceAccount: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
 {% if kiali_vars.deployment.priority_class_name != "" %}
       priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
 {% endif %}
@@ -122,10 +122,10 @@ spec:
       volumes:
       - name: kiali-configuration
         configMap:
-          name: kiali
+          name: {{ kiali_vars.deployment.resource_names_prefix }}
       - name: kiali-cert
         secret:
-          secretName: kiali-cert-secret
+          secretName: {{ kiali_vars.deployment.resource_names_prefix }}-cert-secret
 {% if kiali_vars.identity.cert_file == "" %}
           optional: true
 {% endif %}
@@ -135,7 +135,7 @@ spec:
           optional: true
       - name: kiali-cabundle
         configMap:
-          name: kiali-cabundle
+          name: {{ kiali_vars.deployment.resource_names_prefix }}-cabundle
 {% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
       affinity:
 {% if kiali_vars.deployment.affinity.node|length > 0 %}

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 spec:
@@ -9,10 +9,10 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: kiali
-      app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   template:
     metadata:
-      name: {{ kiali_vars.deployment.resource_names_prefix }}
+      name: {{ kiali_vars.deployment.instance_name }}
       labels: {{ kiali_resource_metadata_labels | combine(kiali_vars.deployment.pod_labels) }}
       annotations:
 {% if kiali_vars.server.metrics_enabled|bool == True %}
@@ -33,7 +33,7 @@ spec:
         maxAvailable: 1
       type: RollingUpdate
     spec:
-      serviceAccount: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+      serviceAccount: {{ kiali_vars.deployment.instance_name }}-service-account
 {% if kiali_vars.deployment.priority_class_name != "" %}
       priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
 {% endif %}
@@ -110,10 +110,10 @@ spec:
       volumes:
       - name: kiali-configuration
         configMap:
-          name: {{ kiali_vars.deployment.resource_names_prefix }}
+          name: {{ kiali_vars.deployment.instance_name }}
       - name: kiali-cert
         secret:
-          secretName: {{ kiali_vars.deployment.resource_names_prefix }}-cert-secret
+          secretName: {{ kiali_vars.deployment.instance_name }}-cert-secret
 {% if kiali_vars.identity.cert_file == "" %}
           optional: true
 {% endif %}
@@ -123,7 +123,7 @@ spec:
           optional: true
       - name: kiali-cabundle
         configMap:
-          name: {{ kiali_vars.deployment.resource_names_prefix }}-cabundle
+          name: {{ kiali_vars.deployment.instance_name }}-cabundle
 {% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
       affinity:
 {% if kiali_vars.deployment.affinity.node|length > 0 %}

--- a/roles/default/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/hpa.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -14,6 +14,6 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: kiali
+    name: {{ kiali_vars.deployment.resource_names_prefix }}
   {{ kiali_vars.deployment.hpa.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/hpa.yaml
@@ -4,12 +4,7 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/roles/default/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/hpa.yaml
@@ -2,13 +2,13 @@
 apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ kiali_vars.deployment.resource_names_prefix }}
+    name: {{ kiali_vars.deployment.instance_name }}
   {{ kiali_vars.deployment.hpa.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/oauth.yaml
@@ -2,12 +2,7 @@ apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-{{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 redirectURIs:
   - {{ kiali_route_url }}
 grantMethod: auto

--- a/roles/default/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/oauth.yaml
@@ -1,7 +1,7 @@
 apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-{{ kiali_vars.deployment.namespace }}
+  name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 redirectURIs:
   - {{ kiali_route_url }}

--- a/roles/default/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/oauth.yaml
@@ -1,7 +1,7 @@
 apiVersion: oauth.openshift.io/v1
 kind: OAuthClient
 metadata:
-  name: kiali-{{ kiali_vars.deployment.namespace }}
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-{{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
     version: {{ kiali_vars.deployment.version_label }}

--- a/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
+  name: {{ kiali_vars.deployment.instance_name }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 rules:

--- a/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kiali-controlplane
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -3,12 +3,7 @@ kind: Role
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]
   resources:

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -5,12 +5,7 @@ kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-viewer
   namespace: {{ namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]
   resources:

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-viewer
+  name: {{ kiali_vars.deployment.instance_name }}-viewer
   namespace: {{ namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 rules:

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: kiali-viewer
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-viewer
   namespace: {{ namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -5,12 +5,7 @@ kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]
   resources:

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 rules:

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kiali-controlplane
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels:
     app: kiali
@@ -12,8 +12,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: kiali-controlplane
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
 subjects:
 - kind: ServiceAccount
-  name: kiali-service-account
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
+  name: {{ kiali_vars.deployment.instance_name }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
+  name: {{ kiali_vars.deployment.instance_name }}-controlplane
 subjects:
 - kind: ServiceAccount
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -3,12 +3,7 @@ kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-controlplane
   namespace: {{ kiali_vars.istio_namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
   labels:
     app: kiali
@@ -14,9 +14,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ role_kind }}
-  name: {{ 'kiali-viewer' if kiali_vars.deployment.view_only_mode|bool == True else 'kiali' }}
+  name: {{ (kiali_vars.deployment.resource_names_prefix + '-viewer') if kiali_vars.deployment.view_only_mode|bool == True else kiali_vars.deployment.resource_names_prefix }}
 subjects:
 - kind: ServiceAccount
-  name: kiali-service-account
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -3,15 +3,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ role_kind }}
-  name: {{ (kiali_vars.deployment.resource_names_prefix + '-viewer') if kiali_vars.deployment.view_only_mode|bool == True else kiali_vars.deployment.resource_names_prefix }}
+  name: {{ (kiali_vars.deployment.instance_name + '-viewer') if kiali_vars.deployment.view_only_mode|bool == True else kiali_vars.deployment.instance_name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -5,12 +5,7 @@ kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ role_kind }}

--- a/roles/default/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -22,5 +22,5 @@ spec:
   to:
     kind: Service
     targetPort: {{ kiali_vars.server.port }}
-    name: kiali
+    name: {{ kiali_vars.deployment.resource_names_prefix }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
@@ -17,5 +17,5 @@ spec:
   to:
     kind: Service
     targetPort: {{ kiali_vars.server.port }}
-    name: {{ kiali_vars.deployment.resource_names_prefix }}
+    name: {{ kiali_vars.deployment.instance_name }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/route.yaml
@@ -3,12 +3,7 @@ kind: Route
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}
+  name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.resource_names_prefix }}-cert-secret
+    service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.instance_name }}-cert-secret
 {% if kiali_vars.deployment.service_annotations|length > 0 %}
     {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
 {% endif %}
@@ -24,5 +24,5 @@ spec:
 {% endif %}
   selector:
     app.kubernetes.io/name: kiali
-    app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
+    app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -3,12 +3,7 @@ kind: Service
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.resource_names_prefix }}-cert-secret
 {% if kiali_vars.deployment.service_annotations|length > 0 %}
@@ -29,5 +24,5 @@ spec:
 {% endif %}
   selector:
     app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
+    app.kubernetes.io/instance: {{ kiali_vars.deployment.resource_names_prefix }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kiali
+  name: {{ kiali_vars.deployment.resource_names_prefix }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
     app.kubernetes.io/part-of: kiali
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: kiali-cert-secret
+    service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.resource_names_prefix }}-cert-secret
 {% if kiali_vars.deployment.service_annotations|length > 0 %}
     {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
 {% endif %}
@@ -28,6 +28,6 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: kiali-service-account
+  name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
   labels:
     app: kiali

--- a/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -3,9 +3,4 @@ kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.resource_names_prefix }}-service-account
   namespace: {{ kiali_vars.deployment.namespace }}
-  labels:
-    app: kiali
-    version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/name: kiali
-    app.kubernetes.io/version: {{ kiali_vars.deployment.version_label }}
-    app.kubernetes.io/part-of: kiali
+  labels: {{ kiali_resource_metadata_labels }}

--- a/roles/default/kiali-remove/defaults/main.yml
+++ b/roles/default/kiali-remove/defaults/main.yml
@@ -5,7 +5,7 @@ kiali_defaults:
     accessible_namespaces: []
     hpa:
       api_version: "autoscaling/v2beta2"
-    resource_names_prefix: "kiali"
+    instance_name: "kiali"
 
 # Will be auto-detected, but for debugging purposes you can force one of these to true
 is_k8s: false

--- a/roles/default/kiali-remove/defaults/main.yml
+++ b/roles/default/kiali-remove/defaults/main.yml
@@ -5,6 +5,7 @@ kiali_defaults:
     accessible_namespaces: []
     hpa:
       api_version: "autoscaling/v2beta2"
+    resource_names_prefix: "kiali"
 
 # Will be auto-detected, but for debugging purposes you can force one of these to true
 is_k8s: false

--- a/roles/default/kiali-remove/filter_plugins/stripnone.py
+++ b/roles/default/kiali-remove/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -42,20 +42,20 @@
   debug:
     msg: "{{ msg.split('\n') }}"
 
-# There is an edge case where a user installed Kiali with one prefix, then changed the prefix in the CR.
+# There is an edge case where a user installed Kiali with one instance name, then changed the instance name in the CR.
 # This is not allowed. When this happens, the operator will abort with an error message telling the user to uninstall Kiali.
 # The user will do this by deleting the Kiali CR, at which time this ansible role is executed.
-# In this case we must use the prefix stored in the status not the spec because the spec will have the bad prefix
-# and the status will have the correct prefix that was used to initially install Kiali.
-- name: Ensure the correct resource_names_prefix is used
+# In this case we must use the instance name stored in the status not the spec because the spec will have the bad name
+# and the status will have the correct name that was used to initially install Kiali.
+- name: Ensure the correct instance_name is used
   ignore_errors: yes
   set_fact:
-    kiali_vars: "{{ kiali_vars | combine({'deployment': {'resource_names_prefix': current_cr.status.deployment.resourceNamesPrefix}}, recursive=True) }}"
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'instance_name': current_cr.status.deployment.instanceName}}, recursive=True) }}"
   when:
   - current_cr.status is defined
   - current_cr.status.deployment is defined
-  - current_cr.status.deployment.resourceNamesPrefix is defined
-  - current_cr.status.deployment.resourceNamesPrefix != kiali_vars.deployment.resource_names_prefix
+  - current_cr.status.deployment.instanceName is defined
+  - current_cr.status.deployment.instanceName != kiali_vars.deployment.instance_name
 
 - name: Set default deployment namespace to the same namespace where the CR lives
   ignore_errors: yes
@@ -85,7 +85,7 @@
 - name: Find current configmap, if it exists
   ignore_errors: yes
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 - name: Find currently accessible namespaces
   ignore_errors: yes
   set_fact:
@@ -105,21 +105,21 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+        name: "{{ kiali_vars.deployment.instance_name }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
+        name: "{{ kiali_vars.deployment.instance_name }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: "{{ kiali_vars.deployment.resource_names_prefix }}-viewer"
+        name: "{{ kiali_vars.deployment.instance_name }}-viewer"
         namespace: "{{ namespace }}"
       ...
       {% endfor %}
@@ -188,21 +188,21 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name=kiali_vars.deployment.resource_names_prefix, api_version=kiali_vars.deployment.hpa.api_version) }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='networking.k8s.io/v1beta1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='apps/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name=kiali_vars.deployment.resource_names_prefix + '-service-account', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.resource_names_prefix + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name=kiali_vars.deployment.instance_name, api_version=kiali_vars.deployment.hpa.api_version) }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name=kiali_vars.deployment.instance_name, api_version='networking.k8s.io/v1beta1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name=kiali_vars.deployment.instance_name, api_version='apps/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name=kiali_vars.deployment.instance_name + '-service-account', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.resource_names_prefix + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item
 
@@ -226,9 +226,9 @@
   - os_item.metadata is defined
   - os_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='OAuthClient', resource_name=kiali_vars.deployment.resource_names_prefix + '-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.resource_names_prefix + '-cabundle', api_version='v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', kind='OAuthClient', resource_name=kiali_vars.deployment.instance_name + '-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name=kiali_vars.deployment.instance_name, api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name + '-cabundle', api_version='v1') if is_openshift == True else [] }}"
   loop_control:
     loop_var: os_item
 

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -200,11 +200,44 @@
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item
+
+- name: Unlabel the signing key secret if it exists to indicate this Kiali instance no longer uses it
+  ignore_errors: yes
+  vars:
+    doomed_label: "{{ 'kiali.io/' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + 'member-of' }}"
+  k8s:
+    state: present
+    definition: |
+      apiVersion: "{{ k8s_item.apiVersion }}"
+      kind: "{{ k8s_item.kind }}"
+      metadata:
+        name: "{{ k8s_item.metadata.name }}"
+        namespace: "{{ k8s_item.metadata.namespace }}"
+        labels:
+          {{ doomed_label }}: null
+  with_items:
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
+  loop_control:
+    loop_var: k8s_item
+
+- name: Delete the signing key secret if no other Kiali installation is using it
+  ignore_errors: yes
+  vars:
+    signing_key_secret_labels: "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') | default({}) | json_query('metadata.labels') }}"
+  k8s:
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kiali-signing-key
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+  when:
+  - (signing_key_secret_labels is not defined) or (signing_key_secret_labels | length == 0) or (signing_key_secret_labels | dict2items | selectattr('key', 'match', 'kiali.io/.*member-of') | list | length == 0)
 
 - name: Delete OpenShift-specific Kiali resources
   ignore_errors: yes

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -237,7 +237,7 @@
   k8s:
     state: absent
     definition: |
-      {% for cl in query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + kiali_vars.deployment.namespace) %}
+      {% for cl in query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + kiali_vars.deployment.namespace) %}
       ---
       apiVersion: "{{ cl.apiVersion }}"
       kind: "{{ cl.kind }}"

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -5,6 +5,11 @@
 # the user will never be able to delete the Kiali CR - in fact, the delete will hang indefinitely
 # and the user will need to do an ugly hack to fix it.
 
+- name: Get the original CR that was deleted
+  ignore_errors: yes
+  set_fact:
+    current_cr: "{{ _kiali_io_kiali }}"
+
 - name: Get information about the cluster
   ignore_errors: yes
   set_fact:
@@ -37,10 +42,23 @@
   debug:
     msg: "{{ msg.split('\n') }}"
 
+# There is an edge case where a user installed Kiali with one prefix, then changed the prefix in the CR.
+# This is not allowed. When this happens, the operator will abort with an error message telling the user to uninstall Kiali.
+# The user will do this by deleting the Kiali CR, at which time this ansible role is executed.
+# In this case we must use the prefix stored in the status not the spec because the spec will have the bad prefix
+# and the status will have the correct prefix that was used to initially install Kiali.
+- name: Ensure the correct resource_names_prefix is used
+  ignore_errors: yes
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'resource_names_prefix': current_cr.status.deployment.resourceNamesPrefix}}, recursive=True) }}"
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.resourceNamesPrefix is defined
+  - current_cr.status.deployment.resourceNamesPrefix != kiali_vars.deployment.resource_names_prefix
+
 - name: Set default deployment namespace to the same namespace where the CR lives
   ignore_errors: yes
-  vars:
-    current_cr: "{{ _kiali_io_kiali }}"
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
   when:
@@ -67,7 +85,7 @@
 - name: Find current configmap, if it exists
   ignore_errors: yes
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name='kiali', namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.resource_names_prefix, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 - name: Find currently accessible namespaces
   ignore_errors: yes
   set_fact:
@@ -87,21 +105,21 @@
       apiVersion: rbac.authorization.k8s.io/v1
       kind: RoleBinding
       metadata:
-        name: kiali
+        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: kiali
+        name: "{{ kiali_vars.deployment.resource_names_prefix }}"
         namespace: "{{ namespace }}"
       ...
       ---
       apiVersion: rbac.authorization.k8s.io/v1
       kind: Role
       metadata:
-        name: kiali-viewer
+        name: "{{ kiali_vars.deployment.resource_names_prefix }}-viewer"
         namespace: "{{ namespace }}"
       ...
       {% endfor %}
@@ -170,21 +188,21 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name='kiali', api_version=kiali_vars.deployment.hpa.api_version) }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name='kiali', api_version='networking.k8s.io/v1beta1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name='kiali', api_version='apps/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name='kiali', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name='kiali', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name='kiali', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name='kiali-service-account', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name=kiali_vars.deployment.resource_names_prefix, api_version=kiali_vars.deployment.hpa.api_version) }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='networking.k8s.io/v1beta1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='apps/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name=kiali_vars.deployment.resource_names_prefix + '-service-account', api_version='v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.resource_names_prefix + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='v1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='MonitoringDashboard', api_version='monitoring.kiali.io/v1alpha1') }}"
   - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name='kiali-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='Role', resource_name='kiali-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.resource_names_prefix + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item
 
@@ -208,9 +226,9 @@
   - os_item.metadata is defined
   - os_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='OAuthClient', resource_name='kiali-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name='kiali', api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name='kiali-cabundle', api_version='v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', kind='OAuthClient', resource_name=kiali_vars.deployment.resource_names_prefix + '-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.resource_names_prefix + '-cabundle', api_version='v1') if is_openshift == True else [] }}"
   loop_control:
     loop_var: os_item
 

--- a/roles/default/kiali-remove/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-remove/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name='kiali-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/default/kiali-remove/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-remove/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.resource_names_prefix + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/default/kiali-remove/vars/main.yml
+++ b/roles/default/kiali-remove/vars/main.yml
@@ -3,7 +3,7 @@ kiali_vars:
 
   deployment: |
     {%- if deployment is defined and deployment is iterable -%}
-    {{ kiali_defaults.deployment | combine(deployment, recursive=True) }}
+    {{ kiali_defaults.deployment | combine((deployment | stripnone), recursive=True) }}
     {%- else -%}
     {{ kiali_defaults.deployment }}
     {%- endif -%}


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3920

There is now a new setting in the Kiali CR `spec.deployment.instance_name` whose default is `kiali`. If you set it, all the resources (except for the signing key secret) will have that as its name prefix. For example, I set this to `mazzwashere` and the resulting objects are:

```
$ kubectl get deployment,pod,service,sa,cm,ingress,clusterrole,clusterrolebinding,role,rolebinding,secret -n istio-system -l app.kubernetes.io/name=kiali -o name
deployment.apps/mazzwashere
pod/mazzwashere-574b7c7fb8-grzpj
service/mazzwashere
serviceaccount/mazzwashere-service-account
configmap/mazzwashere
ingress.networking.k8s.io/mazzwashere
clusterrole.rbac.authorization.k8s.io/mazzwashere
clusterrolebinding.rbac.authorization.k8s.io/mazzwashere
role.rbac.authorization.k8s.io/mazzwashere-controlplane
rolebinding.rbac.authorization.k8s.io/mazzwashere-controlplane
secret/kiali-signing-key
```

A few caveats. Unlike the helm charts behavior, all the app labels remain fixed with `kiali`. I'm not sure which way it should go, but it seems to me the app labels (e.g. `app` and `app.kubernetes.io/name`) should be fixed with `kiali` since this indicates the resources belong to the Kiali application (regardless of what the resource names are). The helm charts behave differently and, in fact, I would almost consider it a bug that the helm charts do not do this. I updated the helm charts with this PR https://github.com/kiali/helm-charts/pull/75 so the labels are consistent with this new operator behavior (with that PR, the helm charts will also support this new `deployment.instance_name` value, again for more consistency with the operator).

A second thing is the auto-generated signing key secret name is fixed to `kiali-signing-key`. If the user does not provide a signing key (used for encrypting https traffic to the server), the operator has to create one. And when it does so, it puts that signing key in a secret. In order to create a secret, the operator is given CRUD permissions in its cluster role for secrets named `kiali-signing-key`. We cannot have this secret name dynamic (i.e. it cannot be determined at run time with this new instance_name setting) because "resourceNames" in the k8s role definition do not support regex (so we can't give permission to resourceNames of `*-signing-key` in the role - [note that this enhancement request was rejected by the k8s community](https://github.com/kubernetes/kubernetes/issues/56582)). We do not want to grant CRUD permissions to all secrets in the operator role (for security purposes) so we are going to limit the name of this signing key secret to always be `kiali-signing-key`. If the user does not like this, they can very easily create their own signing key and put it in their own secret and tell the operator about that secret via the [`spec.login_token.signing_key` setting](https://github.com/kiali/kiali-operator/blob/v1.34.0/deploy/kiali/kiali_cr.yaml#L776-L784).