### PR TITLE
Introduce Graph Find/Hide presets

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -701,17 +701,17 @@ spec:
 #      ---
 #      graph:
 #        find_options:
-#          - description: "Find: slow edges (> 1s)"
-#            expression: "rt > 1000"
-#          - description: "Find: unhealthy nodes"
-#            expression:  "! healthy"
-#          - description: "Find: unknown nodes"
-#            Expression:  "name = unknown"
+#        - description: "Find: slow edges (> 1s)"
+#          expression: "rt > 1000"
+#        - description: "Find: unhealthy nodes"
+#          expression:  "! healthy"
+#        - description: "Find: unknown nodes"
+#          expression:  "name = unknown"
 #        hide_options:
-#          - description: "Hide: healthy nodes"
-#            expression: "healthy"
-#          - description: "Hide: unknown nodes"
-#            expression:  "name = unknown"
+#        - description: "Hide: healthy nodes"
+#          expression: "healthy"
+#        - description: "Hide: unknown nodes"
+#          expression:  "name = unknown"
 #
 # Duration of metrics to fetch on each refresh. Omit for default.
 # Valid values: 1m, 5m, 10m, 30m, 1h, 3h, 6h, 12h, 1d, 7d, 30d

--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -697,6 +697,22 @@ spec:
 #    ---
 #    ui_defaults:
 #
+# Default presets for Graph Find/Hide
+#      ---
+#      graph:
+#        find_options:
+#          - description: "Find: slow edges (> 1s)"
+#            expression: "rt > 1000"
+#          - description: "Find: unhealthy nodes"
+#            expression:  "! healthy"
+#          - description: "Find: unknown nodes"
+#            Expression:  "name = unknown"
+#        hide_options:
+#          - description: "Hide: healthy nodes"
+#            expression: "healthy"
+#          - description: "Hide: unknown nodes"
+#            expression:  "name = unknown"
+#
 # Duration of metrics to fetch on each refresh. Omit for default.
 # Valid values: 1m, 5m, 10m, 30m, 1h, 3h, 6h, 12h, 1d, 7d, 30d
 #      ---

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -207,6 +207,19 @@ kiali_defaults:
   kiali_feature_flags:
     istio_injection_action: true
     ui_defaults:
+      graph:
+        find_options:
+          - description: "Find: slow edges (> 1s)"
+            expression: "rt > 1000"
+          - description: "Find: unhealthy nodes"
+            expression:  "! healthy"
+          - description: "Find: unknown nodes"
+            Expression:  "name = unknown"
+        hide_options:
+          - description: "Hide: healthy nodes"
+            expression: "healthy"
+          - description: "Hide: unknown nodes"
+            expression:  "name = unknown"
       metrics_per_refresh: "1m"
       namespaces: []
       refresh_interval: "15s"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -209,17 +209,17 @@ kiali_defaults:
     ui_defaults:
       graph:
         find_options:
-          - description: "Find: slow edges (> 1s)"
-            expression: "rt > 1000"
-          - description: "Find: unhealthy nodes"
-            expression:  "! healthy"
-          - description: "Find: unknown nodes"
-            Expression:  "name = unknown"
+        - description: "Find: slow edges (> 1s)"
+          expression: "rt > 1000"
+        - description: "Find: unhealthy nodes"
+          expression:  "! healthy"
+        - description: "Find: unknown nodes"
+          expression:  "name = unknown"
         hide_options:
-          - description: "Hide: healthy nodes"
-            expression: "healthy"
-          - description: "Hide: unknown nodes"
-            expression:  "name = unknown"
+        - description: "Hide: healthy nodes"
+          expression: "healthy"
+        - description: "Hide: unknown nodes"
+          expression:  "name = unknown"
       metrics_per_refresh: "1m"
       namespaces: []
       refresh_interval: "15s"


### PR DESCRIPTION

Graph Find/Hide now offers preset expressions via new dropdowns on each input. The preset expressions are supplied via the UIDefaults supplied by the server, and so can be configured by users via the CR.

Part-Of https://github.com/kiali/kiali/issues/3708

Server PR: https://github.com/kiali/kiali/pull/4020
UI PR: https://github.com/kiali/kiali-ui/pull/2159

