### PR TITLE
[operator][molecule] increase wait timeout when deleting resource

### DIFF
--- a/molecule/instance-name-test/converge.yml
+++ b/molecule/instance-name-test/converge.yml
@@ -103,6 +103,8 @@
     k8s:
       state: absent
       wait: yes
+      wait_sleep: 5
+      wait_timeout: "{{ 5 * wait_retries|int }}"
       api_version: kiali.io/v1alpha1
       kind: Kiali
       name: "{{ custom_resource.metadata.name }}"


### PR DESCRIPTION
molecule test fails sometimes because the default wait timeout is too short - give the test enough time to delete this kiali instance