### PR TITLE
move to CRD v1

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: kialis.kiali.io
@@ -12,9 +12,13 @@ spec:
     plural: kialis
     singular: kiali
   scope: Namespaced
-  subresources:
-    status: {}
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-ossm/manifests/kiali.monitoringdashboards.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.monitoringdashboards.crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: monitoringdashboards.monitoring.kiali.io
@@ -16,3 +16,7 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/roles/v1.12/kiali-deploy/tasks/main.yml
+++ b/roles/v1.12/kiali-deploy/tasks/main.yml
@@ -700,7 +700,7 @@
 
 - name: Wait for Monitoring Dashboards CRD to be ready
   k8s_info:
-    api_version: apiextensions.k8s.io/v1beta1
+    api_version: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io
     namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.24/kiali-deploy/tasks/main.yml
+++ b/roles/v1.24/kiali-deploy/tasks/main.yml
@@ -707,7 +707,7 @@
 
 - name: Wait for Monitoring Dashboards CRD to be ready
   k8s_info:
-    api_version: apiextensions.k8s.io/v1beta1
+    api_version: apiextensions.k8s.io/v1
     kind: CustomResourceDefinition
     name: monitoringdashboards.monitoring.kiali.io
   register: monitoringdashboards_crd


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/3912

Note that no helm changes are necessary - we already moved those to v1. This just moves the previous versions and OSSM metadata to v1.