### PR TITLE
community metadata fix

### DIFF
--- a/manifests/kiali-community/1.37.0/bundle.Dockerfile
+++ b/manifests/kiali-community/1.37.0/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=kiali
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/manifests/kiali-community/1.37.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-community/1.37.0/manifests/kiali.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-community/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
@@ -1,17 +1,17 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kiali-operator.v1.36.0
+  name: kiali-operator.v1.37.0
   namespace: placeholder
   annotations:
     categories: Monitoring,Logging & Tracing
     certified: "false"
-    containerImage: quay.io/kiali/kiali-operator:v1.36.0
+    containerImage: quay.io/kiali/kiali-operator:v1.37.0
     capabilities: Deep Insights
     support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: 2021-05-29T13:10:11Z
+    createdAt: 2021-06-09T18:30:20Z
     alm-examples: |-
       [
         {
@@ -27,54 +27,16 @@ metadata:
               "namespace": "istio-system",
               "view_only_mode": false
             },
-            "external_services": {
-              "grafana": {
-                "url": ""
-              },
-              "prometheus": {
-                "url": ""
-              },
-              "tracing": {
-                "url": ""
-              }
-            },
             "server": {
               "web_root": "/mykiali"
             }
           }
-        },
-        {
-          "apiVersion": "monitoring.kiali.io/v1alpha1",
-          "kind": "MonitoringDashboard",
-          "metadata": {
-            "name": "myappdashboard"
-          },
-          "spec": {
-            "title": "My App Dashboard",
-            "items": [
-              {
-                "chart": {
-                  "name": "My App Processing Duration",
-                  "unit": "seconds",
-                  "spans": 6,
-                  "metricName": "my_app_duration_seconds",
-                  "dataType": "histogram",
-                  "aggregations": [
-                    {
-                      "label": "id",
-                      "displayName": "ID"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
         }
       ]
 spec:
-  version: 1.36.0
+  version: 1.37.0
   maturity: stable
-  replaces: kiali-operator.v1.35.0
+  replaces: kiali-operator.v1.36.0
   displayName: Kiali Operator
   description: |-
     ## About the managed application
@@ -209,19 +171,6 @@ spec:
         path: server.web_root
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:label'
-    - name: monitoringdashboards.monitoring.kiali.io
-      group: monitoring.kiali.io
-      description: A configuration file for defining an individual metric dashboard.
-      displayName: Monitoring Dashboard
-      kind: MonitoringDashboard
-      version: v1alpha1
-      resources: []
-      specDescriptors:
-      - displayName: Title
-        description: "The title of the dashboard."
-        path: title
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:label'
   apiservicedefinitions: {}
   install:
     strategy: deployment
@@ -240,9 +189,9 @@ spec:
                 app: kiali-operator
                 # required for the operator SDK metric service selector
                 name: kiali-operator
-                version: v1.36.0
+                version: v1.37.0
                 app.kubernetes.io/name: kiali-operator
-                app.kubernetes.io/version: v1.36.0
+                app.kubernetes.io/version: v1.37.0
                 app.kubernetes.io/part-of: kiali-operator
               annotations:
                 prometheus.io/scrape: "true"
@@ -250,7 +199,7 @@ spec:
               serviceAccountName: kiali-operator
               containers:
               - name: operator
-                image: quay.io/kiali/kiali-operator:v1.36.0
+                image: quay.io/kiali/kiali-operator:v1.37.0
                 imagePullPolicy: "IfNotPresent"
                 args:
                 - "--zap-log-level=info"
@@ -464,17 +413,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: ["monitoring.kiali.io"]
-          resources:
-          - monitoringdashboards
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
         - apiGroups: [""]
           resources:
@@ -575,12 +513,6 @@ spec:
           - routes
           verbs:
           - get
-        - apiGroups: ["monitoring.kiali.io"]
-          resources:
-          - monitoringdashboards
-          verbs:
-          - get
-          - list
         - apiGroups: ["iter8.tools"]
           resources:
           - experiments

--- a/manifests/kiali-community/1.37.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.37.0/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kiali

--- a/manifests/kiali-upstream/1.36.0/manifests/kiali.v1.36.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.36.0/manifests/kiali.v1.36.0.clusterserviceversion.yaml
@@ -27,9 +27,47 @@ metadata:
               "namespace": "default",
               "view_only_mode": false
             },
+            "external_services": {
+              "grafana": {
+                "url": ""
+              },
+              "prometheus": {
+                "url": ""
+              },
+              "tracing": {
+                "url": ""
+              }
+            },
             "server": {
               "web_root": "/mykiali"
             }
+          }
+        },
+        {
+          "apiVersion": "monitoring.kiali.io/v1alpha1",
+          "kind": "MonitoringDashboard",
+          "metadata": {
+            "name": "myappdashboard"
+          },
+          "spec": {
+            "title": "My App Dashboard",
+            "items": [
+              {
+                "chart": {
+                  "name": "My App Processing Duration",
+                  "unit": "seconds",
+                  "spans": 6,
+                  "metricName": "my_app_duration_seconds",
+                  "dataType": "histogram",
+                  "aggregations": [
+                    {
+                      "label": "id",
+                      "displayName": "ID"
+                    }
+                  ]
+                }
+              }
+            ]
           }
         }
       ]
@@ -169,6 +207,19 @@ spec:
       - displayName: Web Root
         description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
         path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+    - name: monitoringdashboards.monitoring.kiali.io
+      group: monitoring.kiali.io
+      description: A configuration file for defining an individual metric dashboard.
+      displayName: Monitoring Dashboard
+      kind: MonitoringDashboard
+      version: v1alpha1
+      resources: []
+      specDescriptors:
+      - displayName: Title
+        description: "The title of the dashboard."
+        path: title
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:label'
   apiservicedefinitions: {}
@@ -413,6 +464,17 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
         - apiGroups: [""]
           resources:
@@ -513,6 +575,12 @@ spec:
           - routes
           verbs:
           - get
+        - apiGroups: ["monitoring.kiali.io"]
+          resources:
+          - monitoringdashboards
+          verbs:
+          - get
+          - list
         - apiGroups: ["iter8.tools"]
           resources:
           - experiments

--- a/manifests/kiali-upstream/1.37.0/bundle.Dockerfile
+++ b/manifests/kiali-upstream/1.37.0/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=kiali
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/manifests/kiali-upstream/1.37.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/1.37.0/manifests/kiali.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-upstream/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
@@ -1,17 +1,17 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: kiali-operator.v1.36.0
+  name: kiali-operator.v1.37.0
   namespace: placeholder
   annotations:
     categories: Monitoring,Logging & Tracing
     certified: "false"
-    containerImage: quay.io/kiali/kiali-operator:v1.36.0
+    containerImage: quay.io/kiali/kiali-operator:v1.37.0
     capabilities: Deep Insights
     support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: 2021-05-29T13:10:11Z
+    createdAt: 2021-06-09T18:30:15Z
     alm-examples: |-
       [
         {
@@ -24,57 +24,19 @@ metadata:
             "installation_tag": "My Kiali",
             "istio_namespace": "istio-system",
             "deployment": {
-              "namespace": "istio-system",
+              "namespace": "default",
               "view_only_mode": false
-            },
-            "external_services": {
-              "grafana": {
-                "url": ""
-              },
-              "prometheus": {
-                "url": ""
-              },
-              "tracing": {
-                "url": ""
-              }
             },
             "server": {
               "web_root": "/mykiali"
             }
           }
-        },
-        {
-          "apiVersion": "monitoring.kiali.io/v1alpha1",
-          "kind": "MonitoringDashboard",
-          "metadata": {
-            "name": "myappdashboard"
-          },
-          "spec": {
-            "title": "My App Dashboard",
-            "items": [
-              {
-                "chart": {
-                  "name": "My App Processing Duration",
-                  "unit": "seconds",
-                  "spans": 6,
-                  "metricName": "my_app_duration_seconds",
-                  "dataType": "histogram",
-                  "aggregations": [
-                    {
-                      "label": "id",
-                      "displayName": "ID"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
         }
       ]
 spec:
-  version: 1.36.0
+  version: 1.37.0
   maturity: stable
-  replaces: kiali-operator.v1.35.0
+  replaces: kiali-operator.v1.36.0
   displayName: Kiali Operator
   description: |-
     ## About the managed application
@@ -209,19 +171,6 @@ spec:
         path: server.web_root
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:label'
-    - name: monitoringdashboards.monitoring.kiali.io
-      group: monitoring.kiali.io
-      description: A configuration file for defining an individual metric dashboard.
-      displayName: Monitoring Dashboard
-      kind: MonitoringDashboard
-      version: v1alpha1
-      resources: []
-      specDescriptors:
-      - displayName: Title
-        description: "The title of the dashboard."
-        path: title
-        x-descriptors:
-        - 'urn:alm:descriptor:com.tectonic.ui:label'
   apiservicedefinitions: {}
   install:
     strategy: deployment
@@ -240,9 +189,9 @@ spec:
                 app: kiali-operator
                 # required for the operator SDK metric service selector
                 name: kiali-operator
-                version: v1.36.0
+                version: v1.37.0
                 app.kubernetes.io/name: kiali-operator
-                app.kubernetes.io/version: v1.36.0
+                app.kubernetes.io/version: v1.37.0
                 app.kubernetes.io/part-of: kiali-operator
               annotations:
                 prometheus.io/scrape: "true"
@@ -250,7 +199,7 @@ spec:
               serviceAccountName: kiali-operator
               containers:
               - name: operator
-                image: quay.io/kiali/kiali-operator:v1.36.0
+                image: quay.io/kiali/kiali-operator:v1.37.0
                 imagePullPolicy: "IfNotPresent"
                 args:
                 - "--zap-log-level=info"
@@ -464,17 +413,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: ["monitoring.kiali.io"]
-          resources:
-          - monitoringdashboards
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
         # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
         - apiGroups: [""]
           resources:
@@ -575,12 +513,6 @@ spec:
           - routes
           verbs:
           - get
-        - apiGroups: ["monitoring.kiali.io"]
-          resources:
-          - monitoringdashboards
-          verbs:
-          - get
-          - list
         - apiGroups: ["iter8.tools"]
           resources:
           - experiments

--- a/manifests/kiali-upstream/1.37.0/metadata/annotations.yaml
+++ b/manifests/kiali-upstream/1.37.0/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kiali


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4089

Read that issue for the problem.

This PR puts the golden copy for 1.36.0 back to the way it existed when published and it also prepares the next 1.37.0 metadata which removes the monitoringdashboard CRD and related permissions (those are no longer needed or used).

Do NOT publish the 1.37.0 metadata until the 1.37 sprint ends and we release 1.37.