### PR TITLE
Bump up to 4.8 operator SDK.

### DIFF
--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -52,14 +52,15 @@ Sometimes you made simple changes to the operator playbook and roles that can be
 
 In order to use this `run-operator-playbook` target, you must have Python3 in your PATH (having an alias is not enough).
 
-You also must make sure your local environment matches as closely as possible to the environment of the Kiali operator. To find out the different versions of software within the Kiali operator image, run the following:
+You also must make sure your local Python and Ansible environment matches as closely as possible to the environment of the Kiali operator. To find out the different versions of software within the Kiali operator image, run the following:
 
 * To get the Python version: `docker run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest python3 --version`
 * To get the Python libraries (`openshift` and `kubernetes` are important ones to look at): `docker run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest pip3 list`
 * To get the Ansible version: `docker run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest ansible --version`
 
-To get started, try to run `python -m pip install --user --upgrade -r operator/molecule/requirements.txt` to get Python3 libraries installed.
-_(as of 06/24/2021, you need very specific versions of kubernetes and openshift libraries via `python -m pip install --user openshift==0.11.2 kubernetes==11.0.0`)_
+To get started, try to run `python -m pip install --user --upgrade -r operator/molecule/requirements.txt` to get Python3 libraries installed. If you need to, you can install specific versions of the libraries like this: `python -m pip install --user openshift==0.12.1 kubernetes==12.0.1`.
+
+You also must get the required Ansible collections installed. To install these, run `ansible-galaxy collection install -r operator/requirements.yml --force-with-deps`
 
 ### Running the Operator With the Ansible Profiler
 

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ OPERATOR_QUAY_TAG ?= ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
 DORP ?= docker
 
 # The version of the SDK this Makefile will download if needed, and the corresponding base image
-OPERATOR_SDK_VERSION ?= 1.3.0
-OPERATOR_BASE_IMAGE_VERSION ?= 4.7.0
+OPERATOR_SDK_VERSION ?= 1.8.0
+OPERATOR_BASE_IMAGE_VERSION ?= 4.8
 
 .PHONY: help
 help: Makefile

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,27 @@
+# This is the Ansible Galaxy requirements that need to be installed locally to be able to run
+# the operator Ansible playbook locally.
+#
+# To install these into your local Ansible environment:
+#   ansible-galaxy collection install -r requirements.yml --force-with-deps
+#
+# Make sure these collections match that which is inside the Ansible Operator SDK base image.
+# You can determine what collections are installed by looking in the base image like this:
+#
+# podman run \
+#   -it --rm --entrypoint '' \
+#   quay.io/openshift/origin-ansible-operator:4.8 \
+#   ls /opt/ansible/.ansible/collections/ansible_collections
+#
+# To determine the version of a specific collection, look at the MANIFEST.json:
+#
+# podman run \
+#   -it --rm --entrypoint '' \
+#   quay.io/openshift/origin-ansible-operator:4.8 \
+#   cat /opt/ansible/.ansible/collections/ansible_collections/community/kubernetes/MANIFEST.json | grep version
+
 collections:
-- community.kubernetes
-- operator_sdk.util
+- name: community.kubernetes
+  version: 1.2.1
+- name: operator_sdk.util
+  version: 0.2.0
+

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -52,7 +52,7 @@
 - name: Delete Ingress on Kubernetes if disabled
   k8s:
     state: absent
-    api_version: "networking.k8s.io/{{ 'v1' if (lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
+    api_version: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
     kind: "Ingress"
     namespace: "{{ kiali_vars.deployment.namespace }}"
     name: "{{ kiali_vars.deployment.instance_name }}"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -1,3 +1,6 @@
+- set_fact:
+    k8s_plugin: community.kubernetes.k8s
+
 - name: Get the original CR as-is for the camelCase keys and so we can update its status field
   set_fact:
     current_cr: "{{ _kiali_io_kiali }}"
@@ -11,7 +14,7 @@
 
 - name: Get information about the cluster
   set_fact:
-    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
   when:
   - is_openshift == False
   - is_k8s == False
@@ -35,12 +38,12 @@
 
 - name: Determine the Kubernetes version
   set_fact:
-    k8s_version: "{{ lookup('k8s', cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
+    k8s_version: "{{ lookup(k8s_plugin, cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
   ignore_errors: yes
 
 - name: Determine the OpenShift version
   vars:
-    kube_apiserver_cluster_op_raw: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
+    kube_apiserver_cluster_op_raw: "{{ lookup(k8s_plugin, api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
     ri_query: "status.versions[?name == 'raw-internal'].version"
   set_fact:
     openshift_version: "{{ kube_apiserver_cluster_op_raw | json_query(ri_query) | join }}"
@@ -531,7 +534,7 @@
 
 - name: Find all namespaces (this is limited to what the operator has permission to see)
   set_fact:
-    all_namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
+    all_namespaces: "{{ lookup(k8s_plugin, api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
 
 - name: Determine all accessible namespaces, expanding regex expressions to matched namespaces
   set_fact:
@@ -684,7 +687,7 @@
 
 - name: Find current configmap, if it exists
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 
 - name: Find some current configuration settings
   set_fact:
@@ -822,7 +825,7 @@
 # that requires a pod restart - in which case we update this timestamp.
 - name: Find current deployment, if it exists
   set_fact:
-    current_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+    current_deployment: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
 
 - name: Get current deployment last-updated annotation timestamp from existing deployment
   set_fact:
@@ -861,7 +864,7 @@
 # If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
 - name: Force the Kiali pod to restart if necessary
   vars:
-    updated_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+    updated_deployment: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
   k8s:
     state: "present"
     definition: "{{ updated_deployment }}"

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -125,7 +125,7 @@
     definition: "{{ lookup('template', 'templates/openshift/console-links.yaml') }}"
   vars:
     # When accessible_namespaces=**, the kiali.io/member-of label is not set, but maistra.io/member-of are always present
-    namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace', label_selector=('maistra.io/member-of=' + kiali_vars.istio_namespace)) | default({}) | json_query('[].metadata.name') if '**' in all_accessible_namespaces else all_accessible_namespaces }}"
+    namespaces: "{{ lookup(k8s_plugin, api_version='v1', kind='Namespace', label_selector=('maistra.io/member-of=' + kiali_vars.istio_namespace)) | default({}) | json_query('[].metadata.name') if '**' in all_accessible_namespaces else all_accessible_namespaces }}"
   when:
   - is_openshift == True
   - openshift_version is version('4.3', '>=')

--- a/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: "networking.k8s.io/{{ 'v1' if (lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
+apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
 kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
@@ -22,7 +22,7 @@ spec:
   - http:
       paths:
       - path: {{ kiali_vars.server.web_root }}
-{% if lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable %}
+{% if lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable %}
         pathType: Prefix
         backend:
           service:

--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -25,7 +25,7 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
-{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+{% if query(k8s_plugin, kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
     app: null
     version: null
 {% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -23,7 +23,7 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
-{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+{% if query(k8s_plugin, kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
     app: null
     version: null
 {% endif %}

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -5,6 +5,10 @@
 # the user will never be able to delete the Kiali CR - in fact, the delete will hang indefinitely
 # and the user will need to do an ugly hack to fix it.
 
+- ignore_errors: yes
+  set_fact:
+    k8s_plugin: community.kubernetes.k8s
+
 - name: Get the original CR that was deleted
   ignore_errors: yes
   set_fact:
@@ -13,7 +17,7 @@
 - name: Get information about the cluster
   ignore_errors: yes
   set_fact:
-    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
   when:
   - is_openshift == False
   - is_k8s == False
@@ -74,7 +78,7 @@
 - name: Find all namespaces (this is limited to what the operator has permission to see)
   ignore_errors: yes
   set_fact:
-    all_namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
+    all_namespaces: "{{ lookup(k8s_plugin, api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
 
 # When the Operator installed Kiali, the configmap has accessible_namespaces set.
 # There are no regexes in the configmap; they are all full namespace names.
@@ -85,7 +89,7 @@
 - name: Find current configmap, if it exists
   ignore_errors: yes
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 - name: Find currently accessible namespaces
   ignore_errors: yes
   set_fact:
@@ -188,19 +192,19 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name=kiali_vars.deployment.instance_name, api_version=kiali_vars.deployment.hpa.api_version) }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name=kiali_vars.deployment.instance_name, api_version='networking.k8s.io/' + ('v1' if (lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1')) }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name=kiali_vars.deployment.instance_name, api_version='apps/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name=kiali_vars.deployment.instance_name + '-service-account', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name=kiali_vars.deployment.instance_name, api_version=kiali_vars.deployment.hpa.api_version) }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name=kiali_vars.deployment.instance_name, api_version='networking.k8s.io/' + ('v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1')) }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name=kiali_vars.deployment.instance_name, api_version='apps/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Service', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name=kiali_vars.deployment.instance_name + '-service-account', api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item
 
@@ -219,14 +223,14 @@
         labels:
           {{ doomed_label }}: null
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
   loop_control:
     loop_var: k8s_item
 
 - name: Delete the signing key secret if no other Kiali installation is using it
   ignore_errors: yes
   vars:
-    signing_key_secret_labels: "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') | default({}) | json_query('metadata.labels') }}"
+    signing_key_secret_labels: "{{ lookup(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') | default({}) | json_query('metadata.labels') }}"
   k8s:
     state: absent
     definition:
@@ -258,9 +262,9 @@
   - os_item.metadata is defined
   - os_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='OAuthClient', resource_name=kiali_vars.deployment.instance_name + '-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name=kiali_vars.deployment.instance_name, api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name + '-cabundle', api_version='v1') if is_openshift == True else [] }}"
+  - "{{ query(k8s_plugin, kind='OAuthClient', resource_name=kiali_vars.deployment.instance_name + '-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Route', resource_name=kiali_vars.deployment.instance_name, api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name + '-cabundle', api_version='v1') if is_openshift == True else [] }}"
   loop_control:
     loop_var: os_item
 
@@ -269,7 +273,7 @@
   k8s:
     state: absent
     definition: |
-      {% for cl in query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + kiali_vars.deployment.namespace) %}
+      {% for cl in query(k8s_plugin, kind='ConsoleLink', label_selector='kiali.io/home=' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + kiali_vars.deployment.namespace) %}
       ---
       apiVersion: "{{ cl.apiVersion }}"
       kind: "{{ cl.kind }}"

--- a/roles/default/kiali-remove/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-remove/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/v1.36/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/v1.36/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -52,7 +52,7 @@
 - name: Delete Ingress on Kubernetes if disabled
   k8s:
     state: absent
-    api_version: "networking.k8s.io/{{ 'v1' if (lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
+    api_version: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
     kind: "Ingress"
     namespace: "{{ kiali_vars.deployment.namespace }}"
     name: "{{ kiali_vars.deployment.instance_name }}"

--- a/roles/v1.36/kiali-deploy/tasks/main.yml
+++ b/roles/v1.36/kiali-deploy/tasks/main.yml
@@ -1,3 +1,6 @@
+- set_fact:
+    k8s_plugin: community.kubernetes.k8s
+
 - name: Get the original CR as-is for the camelCase keys and so we can update its status field
   set_fact:
     current_cr: "{{ _kiali_io_kiali }}"
@@ -11,7 +14,7 @@
 
 - name: Get information about the cluster
   set_fact:
-    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
   when:
   - is_openshift == False
   - is_k8s == False
@@ -35,12 +38,12 @@
 
 - name: Determine the Kubernetes version
   set_fact:
-    k8s_version: "{{ lookup('k8s', cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
+    k8s_version: "{{ lookup(k8s_plugin, cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
   ignore_errors: yes
 
 - name: Determine the OpenShift version
   vars:
-    kube_apiserver_cluster_op_raw: "{{ lookup('k8s', api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
+    kube_apiserver_cluster_op_raw: "{{ lookup(k8s_plugin, api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
     ri_query: "status.versions[?name == 'raw-internal'].version"
   set_fact:
     openshift_version: "{{ kube_apiserver_cluster_op_raw | json_query(ri_query) | join }}"
@@ -520,7 +523,7 @@
 
 - name: Find all namespaces (this is limited to what the operator has permission to see)
   set_fact:
-    all_namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
+    all_namespaces: "{{ lookup(k8s_plugin, api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
 
 - name: Determine all accessible namespaces, expanding regex expressions to matched namespaces
   set_fact:
@@ -673,7 +676,7 @@
 
 - name: Find current configmap, if it exists
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 
 - name: Find some current configuration settings
   set_fact:
@@ -811,7 +814,7 @@
 # that requires a pod restart - in which case we update this timestamp.
 - name: Find current deployment, if it exists
   set_fact:
-    current_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+    current_deployment: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
 
 - name: Get current deployment last-updated annotation timestamp from existing deployment
   set_fact:
@@ -850,7 +853,7 @@
 # If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
 - name: Force the Kiali pod to restart if necessary
   vars:
-    updated_deployment: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+    updated_deployment: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
   k8s:
     state: "present"
     definition: "{{ updated_deployment }}"

--- a/roles/v1.36/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/v1.36/kiali-deploy/tasks/openshift/os-main.yml
@@ -125,7 +125,7 @@
     definition: "{{ lookup('template', 'templates/openshift/console-links.yaml') }}"
   vars:
     # When accessible_namespaces=**, the kiali.io/member-of label is not set, but maistra.io/member-of are always present
-    namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace', label_selector=('maistra.io/member-of=' + kiali_vars.istio_namespace)) | default({}) | json_query('[].metadata.name') if '**' in all_accessible_namespaces else all_accessible_namespaces }}"
+    namespaces: "{{ lookup(k8s_plugin, api_version='v1', kind='Namespace', label_selector=('maistra.io/member-of=' + kiali_vars.istio_namespace)) | default({}) | json_query('[].metadata.name') if '**' in all_accessible_namespaces else all_accessible_namespaces }}"
   when:
   - is_openshift == True
   - openshift_version is version('4.3', '>=')

--- a/roles/v1.36/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/v1.36/kiali-deploy/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item

--- a/roles/v1.36/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/v1.36/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: "networking.k8s.io/{{ 'v1' if (lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
+apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
 kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
@@ -22,7 +22,7 @@ spec:
   - http:
       paths:
       - path: {{ kiali_vars.server.web_root }}
-{% if lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable %}
+{% if lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable %}
         pathType: Prefix
         backend:
           service:

--- a/roles/v1.36/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v1.36/kiali-deploy/templates/kubernetes/service.yaml
@@ -25,7 +25,7 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
-{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+{% if query(k8s_plugin, kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
     app: null
     version: null
 {% endif %}

--- a/roles/v1.36/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.36/kiali-deploy/templates/openshift/service.yaml
@@ -23,7 +23,7 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
-{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+{% if query(k8s_plugin, kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
     app: null
     version: null
 {% endif %}

--- a/roles/v1.36/kiali-remove/tasks/main.yml
+++ b/roles/v1.36/kiali-remove/tasks/main.yml
@@ -5,6 +5,10 @@
 # the user will never be able to delete the Kiali CR - in fact, the delete will hang indefinitely
 # and the user will need to do an ugly hack to fix it.
 
+- ignore_errors: yes
+  set_fact:
+    k8s_plugin: community.kubernetes.k8s
+
 - name: Get the original CR that was deleted
   ignore_errors: yes
   set_fact:
@@ -13,7 +17,7 @@
 - name: Get information about the cluster
   ignore_errors: yes
   set_fact:
-    api_groups: "{{ lookup('k8s', cluster_info='api_groups') }}"
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
   when:
   - is_openshift == False
   - is_k8s == False
@@ -74,7 +78,7 @@
 - name: Find all namespaces (this is limited to what the operator has permission to see)
   ignore_errors: yes
   set_fact:
-    all_namespaces: "{{ lookup('k8s', api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
+    all_namespaces: "{{ lookup(k8s_plugin, api_version='v1', kind='Namespace') | default({}) | json_query('[].metadata.name') }}"
 
 # When the Operator installed Kiali, the configmap has accessible_namespaces set.
 # There are no regexes in the configmap; they are all full namespace names.
@@ -85,7 +89,7 @@
 - name: Find current configmap, if it exists
   ignore_errors: yes
   set_fact:
-    current_configmap: "{{ lookup('k8s', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+    current_configmap: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
 - name: Find currently accessible namespaces
   ignore_errors: yes
   set_fact:
@@ -188,19 +192,19 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name=kiali_vars.deployment.instance_name, api_version=kiali_vars.deployment.hpa.api_version) }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name=kiali_vars.deployment.instance_name, api_version='networking.k8s.io/' + ('v1' if (lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1')) }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name=kiali_vars.deployment.instance_name, api_version='apps/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Service', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name=kiali_vars.deployment.instance_name + '-service-account', api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='HorizontalPodAutoscaler', resource_name=kiali_vars.deployment.instance_name, api_version=kiali_vars.deployment.hpa.api_version) }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Ingress', resource_name=kiali_vars.deployment.instance_name, api_version='networking.k8s.io/' + ('v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1')) }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Deployment', resource_name=kiali_vars.deployment.instance_name, api_version='apps/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ReplicaSet', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Pod', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Service', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ServiceAccount', resource_name=kiali_vars.deployment.instance_name + '-service-account', api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name, api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.istio_namespace, kind='RoleBinding', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.istio_namespace, kind='Role', resource_name=kiali_vars.deployment.instance_name + '-controlplane', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item
 
@@ -219,14 +223,14 @@
         labels:
           {{ doomed_label }}: null
   with_items:
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') }}"
   loop_control:
     loop_var: k8s_item
 
 - name: Delete the signing key secret if no other Kiali installation is using it
   ignore_errors: yes
   vars:
-    signing_key_secret_labels: "{{ lookup('k8s', namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') | default({}) | json_query('metadata.labels') }}"
+    signing_key_secret_labels: "{{ lookup(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') | default({}) | json_query('metadata.labels') }}"
   k8s:
     state: absent
     definition:
@@ -258,9 +262,9 @@
   - os_item.metadata is defined
   - os_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='OAuthClient', resource_name=kiali_vars.deployment.instance_name + '-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='Route', resource_name=kiali_vars.deployment.instance_name, api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
-  - "{{ query('k8s', namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name + '-cabundle', api_version='v1') if is_openshift == True else [] }}"
+  - "{{ query(k8s_plugin, kind='OAuthClient', resource_name=kiali_vars.deployment.instance_name + '-' + kiali_vars.deployment.namespace, api_version='oauth.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='Route', resource_name=kiali_vars.deployment.instance_name, api_version='route.openshift.io/v1') if is_openshift == True else [] }}"
+  - "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, kind='ConfigMap', resource_name=kiali_vars.deployment.instance_name + '-cabundle', api_version='v1') if is_openshift == True else [] }}"
   loop_control:
     loop_var: os_item
 
@@ -269,7 +273,7 @@
   k8s:
     state: absent
     definition: |
-      {% for cl in query('k8s', kind='ConsoleLink', label_selector='kiali.io/home=' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + kiali_vars.deployment.namespace) %}
+      {% for cl in query(k8s_plugin, kind='ConsoleLink', label_selector='kiali.io/home=' + ((kiali_vars.deployment.instance_name + '.') if kiali_vars.deployment.instance_name != 'kiali' else '') + kiali_vars.deployment.namespace) %}
       ---
       apiVersion: "{{ cl.apiVersion }}"
       kind: "{{ cl.kind }}"

--- a/roles/v1.36/kiali-remove/tasks/remove-clusterroles.yml
+++ b/roles/v1.36/kiali-remove/tasks/remove-clusterroles.yml
@@ -17,8 +17,8 @@
   - k8s_item.metadata is defined
   - k8s_item.metadata.name is defined
   with_items:
-  - "{{ query('k8s', kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query('k8s', kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
+  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
   loop_control:
     loop_var: k8s_item


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4094
backport PR: https://github.com/kiali/kiali-operator/pull/375

Note that while we can move our images to 4.9, we cannot introduce any code that uses anything not also backward compatible with 4.7 because any downstream builds are still going to be on 4.7 (that's the latest downstream version we have available as of today).

I'm going to only bump to 4.8. since that is most likely going to be the next downstream build that will be available. Seems better to remain as close as possible. No sense jumping 2 minor versions here.

I also question if we even should do this now. Since downstream is still only at 4.7, we might want to hold off on merging this until downstream has 4.8. I will leave this as a "draft" PR because of this.