### PR TITLE
Mount the "kiali-cabundle" configmap, if present (Kubernetes)

### DIFF
--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -104,6 +104,8 @@ spec:
           mountPath: "/kiali-cert"
         - name: kiali-secret
           mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
 {% if kiali_vars.deployment.resources|length > 0 %}
         resources:
           {{ kiali_vars.deployment.resources | to_nice_yaml(indent=0) | trim | indent(10) }}
@@ -123,6 +125,10 @@ spec:
       - name: kiali-secret
         secret:
           secretName: {{ kiali_vars.deployment.secret_name }}
+          optional: true
+      - name: kiali-cabundle
+        configMap:
+          name: {{ kiali_vars.deployment.instance_name }}-cabundle
           optional: true
 {% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
       affinity:


### PR DESCRIPTION
Similarly to the OpenShift version of the deployment, this mounts under /kiali-cabundle the configmap with name "kiali-cabundle". The difference against the OpenShift template, is that this volume is optional.

This is to support custom CA certificates for OpenID.

Related helm-charts PR: https://github.com/kiali/helm-charts/pull/82
Related back-end PR: https://github.com/kiali/kiali/pull/4112

Related kiali/kiali#4050