### PR TITLE
[molecule] wait for test namespace to be actually deleted

### DIFF
--- a/molecule/api-test/delete-simple-mesh.yml
+++ b/molecule/api-test/delete-simple-mesh.yml
@@ -13,3 +13,4 @@
     api_version: v1
     kind: Namespace
     name: "{{ simple_mesh_namespace }}"
+    wait: yes


### PR DESCRIPTION
Saw this superfluous error in molecule test on minikube -

`Failed to create object: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"namespaces \\\\\"simple-mesh\\\\\" not found\",\"reason\":\"NotFound\",\"details\":{\"name\":\"simple-mesh\",\"kind\":\"namespaces\"},\"code\":404}`

This happened in `config-values-test.log`. The test before this one (`api-test`) was supposed to have deleted that namespace, but it didn't wait... so that namespace remained when this `config-values-test` ran. This causes a failure because the kiali pod wants to add this namespace to accessible-namespaces but it eventually disappears once the cluster actually got around to deleting the namespace.

The solution should be simple - just have the `api-test` wait for its "simple-mesh" namespace to fully get deleted before continuing. That's what this PR does.