### PR TITLE
[v1.36][molecule] wait for test namespace to be actually deleted

### DIFF
--- a/molecule/api-test/delete-simple-mesh.yml
+++ b/molecule/api-test/delete-simple-mesh.yml
@@ -13,3 +13,4 @@
     api_version: v1
     kind: Namespace
     name: "{{ simple_mesh_namespace }}"
+    wait: yes


### PR DESCRIPTION
cherry pick of https://github.com/kiali/kiali-operator/pull/343

Want to cherry pick this so we can be assured the molecule tests can still run when using the v1.36 branch.