### PR TITLE
related_images should refer to 1.36

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -270,9 +270,9 @@ spec:
                 - name: ANSIBLE_CONFIG
                   value: "/etc/ansible/ansible.cfg"
                 - name: RELATED_IMAGE_kiali_default
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_33_TAG}"
-                - name: RELATED_IMAGE_kiali_v1_33
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_33_TAG}"
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_36_TAG}"
+                - name: RELATED_IMAGE_kiali_v1_36
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_36_TAG}"
                 - name: RELATED_IMAGE_kiali_v1_24
                   value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_24_TAG}"
                 - name: RELATED_IMAGE_kiali_v1_12


### PR DESCRIPTION
fixes: MAISTRA-2470

now that we are using 1.36, need to make sure the metadata reflects this.

backport: https://github.com/kiali/kiali-operator/pull/346