### PR TITLE
remove app and version fields from service selector

### DIFF
--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -25,6 +25,10 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
+{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+    app: null
+    version: null
+{% endif %}
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -23,6 +23,10 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
+{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+    app: null
+    version: null
+{% endif %}
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/v1.36/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v1.36/kiali-deploy/templates/kubernetes/service.yaml
@@ -25,6 +25,10 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
+{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+    app: null
+    version: null
+{% endif %}
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/v1.36/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.36/kiali-deploy/templates/openshift/service.yaml
@@ -23,6 +23,10 @@ spec:
     port: {{ kiali_vars.server.metrics_port }}
 {% endif %}
   selector:
+{% if query('k8s', kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+    app: null
+    version: null
+{% endif %}
     app.kubernetes.io/name: kiali
     app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
   {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}


### PR DESCRIPTION
When upgrading from pre-v1.35 to 1.35-and-later, we have to make sure we remove app and version fields from the service selector, otherwise, upgrades are broken.

When we no longer support operator v1.34 and below, we can remove these two null fields.

fixes: https://github.com/kiali/kiali/issues/4143
backport PR: https://github.com/kiali/kiali-operator/pull/349

Note: this doesn't work due to what appears to be a bug in the `k8s` ansible task. Unless this is fixed or we can workaround it, I don't see how we can fix this issue -- https://github.com/ansible-collections/kubernetes.core/issues/161 (UPDATE: I added an `{% if...endif %}` to workaround that ansible issue - so this should work now).