### PR TITLE
operator installmodes - only support AllNamespaces

### DIFF
--- a/manifests/kiali-community/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
@@ -122,9 +122,9 @@ spec:
     url: https://github.com/kiali/kiali-operator
   installModes:
   - type: OwnNamespace
-    supported: true
+    supported: false
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces

--- a/manifests/kiali-upstream/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.37.0/manifests/kiali.v1.37.0.clusterserviceversion.yaml
@@ -122,9 +122,9 @@ spec:
     url: https://github.com/kiali/kiali-operator
   installModes:
   - type: OwnNamespace
-    supported: true
+    supported: false
   - type: SingleNamespace
-    supported: true
+    supported: false
   - type: MultiNamespace
     supported: false
   - type: AllNamespaces


### PR DESCRIPTION
OLM is going to deprecate all install modes except "AllNamespaces" (at least, currently, they are telling operator authors to move away from the others now).