### PR TITLE
Adding Jaeger (internal) integration basic test

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -26,6 +26,13 @@
     when:
     - is_maistra == True
 
+  - set_fact:
+      ossm_secret_password: "{{ ossm_secret_htpasswd_raw.resources[0].data.rawPassword | b64decode }}"
+    when:
+    - ossm_secret_htpasswd_raw is defined
+    - ossm_secret_htpasswd_raw.resources is defined
+    - ossm_secret_htpasswd_raw.resources | length == 1
+
   - name: Define url and auth for Prometheus for Service Mesh
     set_fact:
       prometheus_config:
@@ -34,11 +41,22 @@
           username: internal
           type: basic
           use_kiali_token: false
-          password: "{{ ossm_secret_htpasswd_raw.resources[0].data.rawPassword | b64decode }}"
+          password: "{{ ossm_secret_password }}"
     when:
-    - ossm_secret_htpasswd_raw is defined
-    - ossm_secret_htpasswd_raw.resources is defined
-    - ossm_secret_htpasswd_raw.resources | length == 1
+    - ossm_secret_password is defined
+
+  - name: Define url and auth for Tracing for Service Mesh
+    set_fact:
+      tracing_config:
+        in_cluster_url: "https://jaeger-query.{{ istio.control_plane_namespace }}.svc"
+        url: "https://jaeger-query.{{ istio.control_plane_namespace }}.svc"
+        auth:
+          username: internal
+          type: basic
+          use_kiali_token: false
+          password: "{{ ossm_secret_password }}"
+    when:
+    - ossm_secret_password is defined
 
   - name: Make sure the operator namespace exists
     k8s:
@@ -118,14 +136,14 @@
       namespace: "{{ cr_namespace }}"
       definition: "{{ lookup('template', cr_file_path) }}"
     when:
-    - prometheus_config is not defined
+    - ossm_secret_password is not defined
 
   - name: Create Kiali CR with specific prometheus config added
     k8s:
       namespace: "{{ cr_namespace }}"
-      definition: "{{ lookup('template', cr_file_path) | from_yaml | combine({'spec':{'external_services':{'prometheus': prometheus_config }}}, recursive=True) | to_yaml }}"
+      definition: "{{ lookup('template', cr_file_path) | from_yaml | combine({'spec':{'external_services':{'prometheus': prometheus_config, 'tracing': tracing_config }}}, recursive=True) | to_yaml }}"
     when:
-    - prometheus_config is defined
+    - ossm_secret_password is defined
 
   - name: Asserting that Kiali is Deployed
     vars:

--- a/molecule/jaeger-test/converge.yml
+++ b/molecule/jaeger-test/converge.yml
@@ -1,0 +1,65 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  
+  - name: Get statuses from Istio components
+    uri:
+      url: "{{ kiali_base_url }}/api/istio/status"
+      validate_certs: no
+      return_content: yes      
+    register: status_response
+  
+  - name: "Results: /api/istio/status"
+    debug:
+      msg: "{{ status_response.json }}"  
+
+  - name: Check if Jaeger status if present (if it is present it means error)
+    set_fact:
+      jaeger_status: "{{ item.status }}"     
+    loop: "{{ status_response.json }}"
+    when: "item.name == 'jaeger'"
+  
+  - name: Assert that Jaeger status if not in the response
+    assert:
+      that:
+      - jaeger_status is not defined
+
+  # Update Jaeger URL to a bad URL just to test a bad integration
+  - import_tasks: update-jaeger-url.yml
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  - name: Get statuses from Istio components
+    uri:
+      url: "{{ kiali_base_url }}/api/istio/status"
+      validate_certs: no
+      return_content: yes      
+    register: status_response
+  
+  - name: "Results: /api/istio/status"
+    debug:
+      msg: "{{ status_response.json }}"  
+
+  - set_fact:
+      current_kiali_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: Check if Jaeger status if present (presence means an error)
+    set_fact:
+      jaeger_status: "{{ item.status }}"     
+    loop: "{{ status_response.json }}"
+    when: "item.name == 'jaeger'"
+  
+  - name: Assert that Jaeger status is in the response
+    assert:
+      that:
+      - jaeger_status is defined

--- a/molecule/jaeger-test/converge.yml
+++ b/molecule/jaeger-test/converge.yml
@@ -21,16 +21,18 @@
     debug:
       msg: "{{ status_response.json }}"  
 
-  - name: Check if Jaeger status if present (if it is present it means error)
+  # IstioStatus API returns a statuses list of external components (Jaeger is one of them)
+  # If Jaeger is in the list, it means that there is an error (Unreacheable)
+  - name: Check if Jaeger status is present
     set_fact:
-      jaeger_status: "{{ item.status }}"     
+      jaeger_error: "{{ item.status }}"     
     loop: "{{ status_response.json }}"
     when: "item.name == 'jaeger'"
   
-  - name: Assert that Jaeger status if not in the response
+  - name: Assert that there is no error related to Jaeger
     assert:
       that:
-      - jaeger_status is not defined
+      - jaeger_error is not defined
 
   # Update Jaeger URL to a bad URL just to test a bad integration
   - import_tasks: update-jaeger-url.yml
@@ -53,13 +55,13 @@
   - set_fact:
       current_kiali_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"
 
-  - name: Check if Jaeger status if present (presence means an error)
+  - name: Check if Jaeger status is present
     set_fact:
-      jaeger_status: "{{ item.status }}"     
+      jaeger_error: "{{ item.status }}"     
     loop: "{{ status_response.json }}"
     when: "item.name == 'jaeger'"
   
-  - name: Assert that Jaeger status is in the response
+  - name: Assert that there is an error related to Jaeger
     assert:
       that:
-      - jaeger_status is defined
+      - jaeger_error is defined

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -1,0 +1,16 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+spec:
+  version: {{ kiali.spec_version }}
+  istio_namespace: {{ istio.control_plane_namespace }}
+  auth:
+    strategy: {{ kiali.auth_strategy }}
+  deployment:
+    namespace: {{ kiali.install_namespace }}
+    image_name: {{ kiali.image_name }}
+    image_pull_policy: {{ kiali.image_pull_policy }}
+    image_version: {{ kiali.image_version }}
+    accessible_namespaces: {{ kiali.accessible_namespaces }}
+    service_type: NodePort

--- a/molecule/jaeger-test/molecule.yml
+++ b/molecule/jaeger-test/molecule.yml
@@ -1,0 +1,46 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callback_whitelist: junit
+  playbooks:
+    destroy: ../default/destroy.yml
+    prepare: ../default/prepare.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/jaeger-test/kiali-cr.yaml"
+        cr_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR must go in control plane namespace
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          spec_version: "{{ lookup('env', 'MOLECULE_KIALI_CR_SPEC_VERSION') | default('default', True) }}"
+          install_namespace: istio-system
+          accessible_namespaces: ["**"]
+          auth_strategy: anonymous
+          operator_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}" # if external operator, assume operator is in OLM location
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: kiali-operator
+          operator_cluster_role_creator: "true"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
+          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+scenario:
+  name: jaeger-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/molecule/jaeger-test/update-jaeger-url.yml
+++ b/molecule/jaeger-test/update-jaeger-url.yml
@@ -1,0 +1,10 @@
+# Wait for the operator to finish any reconciliation currently ongoing
+- import_tasks: ../common/wait_for_kiali_cr_changes.yml
+
+- name: Update Jaeger URL
+  vars:
+    current_kiali_cr: "{{ kiali_cr_list.resources[0] }}"
+  set_fact:
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'external_services': {'tracing': {'in_cluster_url': 'http://wrong.url'}}}}, recursive=True) }}"
+
+- import_tasks: ../common/set_kiali_cr.yml


### PR DESCRIPTION
This PR adds a new test to validate that Kiali can communicate with the in cluster Jaeger instance. It does it with the Istio components statuses, if a Jaeger object in the list is present, it means an error.

Fixes kiali/kiali#3028

