### PR TITLE
don't look at tracing settings - molecule framework overrides it if on service mesh

### DIFF
--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -30,9 +30,6 @@
       - kiali_configmap.external_services.istio.istio_identity_domain == "svc.cluster.local"
       - kiali_configmap.external_services.istio.istio_sidecar_annotation == "sidecar.istio.io/status"
       - kiali_configmap.external_services.prometheus.url != ""
-      - kiali_configmap.external_services.tracing.auth.password == ""
-      - kiali_configmap.external_services.tracing.auth.type == "none"
-      - kiali_configmap.external_services.tracing.url == ""
       - kiali_configmap.identity.cert_file is defined
       - kiali_configmap.identity.private_key_file is defined
       - kiali_configmap.istio_labels.app_label_name == "app"


### PR DESCRIPTION
this is a side effect of https://github.com/kiali/kiali-operator/pull/357