### PR TITLE
[v1.36] fix molecule tests to pass when running with OSSM

### DIFF
--- a/molecule/api-test/create-simple-mesh.yml
+++ b/molecule/api-test/create-simple-mesh.yml
@@ -43,12 +43,12 @@
       spec:
         controlPlaneRef:
           namespace: "{{ istio.control_plane_namespace }}"
-          name: full
+          name: "{{ maistra_smcp.metadata.name }}"
   when:
   - is_openshift == True
   - is_maistra == True
 
-- name: Create NAD so CNI works, only if on OpenShift
+- name: Create NAD so CNI works, only if on OpenShift but not running Maistra
   k8s:
     state: present
     definition:
@@ -59,6 +59,7 @@
         name: istio-cni
   when:
   - is_openshift == True
+  - is_maistra == False
 
 - name: Create simple-sa service account
   k8s:

--- a/molecule/common/tasks.yml
+++ b/molecule/common/tasks.yml
@@ -9,6 +9,21 @@
   set_fact:
     is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
 
+- name: Get SMCP if running in Maistra environment
+  k8s_info:
+    api_version: maistra.io/v2
+    kind: ServiceMeshControlPlane
+    namespace: "{{ istio.control_plane_namespace }}"
+  register: maistra_smcp
+  when:
+  - is_maistra == True
+
+- name: There must one and only one SMCP already installed in the control plane
+  set_fact:
+    maistra_smcp: "{{ maistra_smcp.resources[0] }}"
+  when:
+  - is_maistra == True
+
 - name: Get Kiali CR if present
   set_fact:
     kiali_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='Kiali', namespace=cr_namespace, resource_name=custom_resource.metadata.name) }}"

--- a/molecule/metrics-test/converge.yml
+++ b/molecule/metrics-test/converge.yml
@@ -21,7 +21,9 @@
       test_start_time: "{{ ansible_date_time.iso8601 }}"
 
   - set_fact:
-      prom_namespace_label: "{{ 'namespace' if is_maistra == True else 'kubernetes_namespace' }}"
+      prom_namespace_label: kubernetes_namespace
+      # This used to be needed for OSSM 2.0 but no longer for 2.1
+      #prom_namespace_label: "{{ 'namespace' if is_maistra == True else 'kubernetes_namespace' }}"
 
   # Operator metrics are always enabled - make sure we have them
   # NOTE: Service Mesh/Maistra does NOT collect these metrics, so do not test when running in Maistra env.


### PR DESCRIPTION
* determine the name of the SMCP at runtime to avoid hardcoding it - some environments might not name the SMCP the same

* looks like OSSM 2.1 changed the metric labels - metrics test now passes but only for OSSM 2.1 now