### PR TITLE
Change default grpc port for tracing when grpc is enabled

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -630,7 +630,8 @@ spec:
 # health_check_url: Used in the Components health feature. This is the url which kiali will ping to determine whether the component is reachable or not. It defaults to `in_cluster_url` when not provided.
 # in_cluster_url: Set URL for in-cluster access, which enables further integration between Kiali and Jaeger.
 #      When not provided, Kiali will only show external links using the "url" config.
-#      Example: "http://tracing.istio-system".
+#      Note: Jaeger v1.20+ has separated ports for GRPC(16685) and HTTP(16686) requests. Make sure you use the appropriate port according to the "use_grpc" value.
+#      Example: "http://tracing.istio-system:16685".
 # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
 # namespace_selector: Kiali use this boolean to look traces with namespace selector : service.namespace. Default: true
 # url: External URL that will be used to generate links to Jaeger. It must be accessible to clients external to

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -285,11 +285,22 @@
   when:
     kiali_vars.external_services.tracing.in_cluster_url == "" and is_maistra
 
-- name: Set default Tracing in_cluster_url
+- name: Set default Tracing in_cluster_url for grpc consumption
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'in_cluster_url': 'http://tracing.' + kiali_vars.istio_namespace + ':16685/jaeger'}}}, recursive=True) }}"
+  when:
+  - is_maistra == False
+  - kiali_vars.external_services.tracing.in_cluster_url == ""
+  - kiali_vars.external_services.tracing.use_grpc is not defined or kiali_vars.external_services.tracing.use_grpc == True
+
+- name: Set default Tracing in_cluster_url for http consumption
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': {'in_cluster_url': 'http://tracing.' + kiali_vars.istio_namespace + '/jaeger'}}}, recursive=True) }}"
   when:
-    kiali_vars.external_services.tracing.in_cluster_url == "" and is_maistra == False
+  - is_maistra == False
+  - kiali_vars.external_services.tracing.in_cluster_url == ""
+  - kiali_vars.external_services.tracing.use_grpc is defined
+  - kiali_vars.external_services.tracing.use_grpc == False
 
 - name: Set default Istio service that provides version info (istiod service that was introduced in Istio 1.6)
   set_fact:


### PR DESCRIPTION
fix https://github.com/kiali/kiali/issues/4207

When grpc is enabled for Jaeger, use the exclusive port for gRPC traffic that the service has.
