### PR TITLE
turn on at least debug level on all molecule tests. auth related tests are at trace

### DIFF
--- a/molecule/accessible-namespaces-test/kiali-cr.yaml
+++ b/molecule/accessible-namespaces-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
+++ b/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     # Note that we start with no affinity or tolerations or resources sections,
     # so the first time through we just pick up the defaults.

--- a/molecule/api-test/kiali-cr.yaml
+++ b/molecule/api-test/kiali-cr.yaml
@@ -11,11 +11,11 @@ spec:
   custom_dashboards:
   - name: go
   deployment:
+    logger:
+      log_level: debug
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger: 
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/config-values-test/kiali-cr.yaml
+++ b/molecule/config-values-test/kiali-cr.yaml
@@ -7,6 +7,8 @@ spec:
   # this test will try to use as many defaults as we can
   istio_namespace: {{ istio.control_plane_namespace }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/default-namespace-test/kiali-cr.yaml
+++ b/molecule/default-namespace-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     # For this test, we do not define namespace.
     # It should default to the location where this CR lives
     # namespace:

--- a/molecule/header-auth-test/kiali-cr.yaml
+++ b/molecule/header-auth-test/kiali-cr.yaml
@@ -8,12 +8,12 @@ spec:
   auth:
     strategy: header
   deployment:
+    logger:
+      log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger:
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test

--- a/molecule/instance-name-test/kiali-cr.yaml
+++ b/molecule/instance-name-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/kiali-cr.yaml
+++ b/molecule/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/metrics-test/kiali-cr.yaml
+++ b/molecule/metrics-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/only-view-only-mode-test/kiali-cr.yaml
+++ b/molecule/only-view-only-mode-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -13,12 +13,12 @@ spec:
       issuer_uri: {{ openid.issuer_uri }}
       username_claim: {{ openid.username_claim }}
   deployment:
+    logger:
+      log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger:
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test

--- a/molecule/openshift-auth-test/kiali-cr.yaml
+++ b/molecule/openshift-auth-test/kiali-cr.yaml
@@ -8,11 +8,11 @@ spec:
   auth:
     strategy: openshift
   deployment:
+    logger:
+      log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger:
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/os-console-links-test/kiali-cr.yaml
+++ b/molecule/os-console-links-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/rolling-restart-test/kiali-cr.yaml
+++ b/molecule/rolling-restart-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/token-test/kiali-cr.yaml
+++ b/molecule/token-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}


### PR DESCRIPTION
this should be backported. The backport is going to require also backporting https://github.com/kiali/kiali-operator/pull/363

backport PR: https://github.com/kiali/kiali-operator/pull/377