### PR TITLE
[v1.36] turn on at least debug level on all molecule tests. auth related tests are at trace

### DIFF
--- a/molecule/accessible-namespaces-test/kiali-cr.yaml
+++ b/molecule/accessible-namespaces-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/accessible-namespaces-test/kiali-cr.yaml
+++ b/molecule/accessible-namespaces-test/kiali-cr.yaml
@@ -13,4 +13,4 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
+++ b/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
@@ -18,4 +18,4 @@ spec:
     # while we are here, make sure the additional service yaml retains camelCase
     additional_service_yaml:
       externalName: my.kiali.example.com
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
+++ b/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     # Note that we start with no affinity or tolerations or resources sections,
     # so the first time through we just pick up the defaults.

--- a/molecule/api-test/kiali-cr.yaml
+++ b/molecule/api-test/kiali-cr.yaml
@@ -11,11 +11,11 @@ spec:
   custom_dashboards:
   - name: go
   deployment:
+    logger:
+      log_level: debug
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger: 
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/api-test/kiali-cr.yaml
+++ b/molecule/api-test/kiali-cr.yaml
@@ -18,4 +18,4 @@ spec:
     logger: 
       log_level: "trace"
     namespace: {{ kiali.install_namespace }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/common/query-prometheus.yml
+++ b/molecule/common/query-prometheus.yml
@@ -2,7 +2,7 @@
   debug:
     msg: "If a metric test fails, run this to ensure the clock is reset: minikube ssh -- sudo date -u $(date -u +%m%d%H%M%Y.%S)"
   when:
-  - is_k8s == True
+  - is_minikube == True
 
 - name: Query Prometheus from Kiali Pod
   k8s_exec:

--- a/molecule/common/tasks.yml
+++ b/molecule/common/tasks.yml
@@ -5,6 +5,8 @@
   set_fact:
     is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
     is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+    is_minikube: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'minikube' else False }}"
+    is_kind: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'kind' else False }}"
 - name: Determine the Istio implementation
   set_fact:
     is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"
@@ -109,5 +111,10 @@
   set_fact:
     kiali_base_url: "https://{{ lookup('env', 'MOLECULE_MINIKUBE_IP') }}{{ web_root }}"
   when:
-  - is_k8s == True
+  - is_minikube == True
 
+- name: Determine the Kiali Ingress URL on kind
+  set_fact:
+    kiali_base_url: "http://{{ kiali_service.resources[0].status.loadBalancer.ingress[0].ip }}:20001/kiali"
+  when:
+  - is_kind == True

--- a/molecule/config-values-test/kiali-cr.yaml
+++ b/molecule/config-values-test/kiali-cr.yaml
@@ -7,6 +7,8 @@ spec:
   # this test will try to use as many defaults as we can
   istio_namespace: {{ istio.control_plane_namespace }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/config-values-test/kiali-cr.yaml
+++ b/molecule/config-values-test/kiali-cr.yaml
@@ -11,4 +11,4 @@ spec:
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/default-namespace-test/kiali-cr.yaml
+++ b/molecule/default-namespace-test/kiali-cr.yaml
@@ -15,3 +15,4 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/default-namespace-test/kiali-cr.yaml
+++ b/molecule/default-namespace-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     # For this test, we do not define namespace.
     # It should default to the location where this CR lives
     # namespace:

--- a/molecule/default/destroy.yml
+++ b/molecule/default/destroy.yml
@@ -8,6 +8,12 @@
   - name: Get information about the cluster
     set_fact:
       api_groups: "{{ lookup('kubernetes.core.k8s', cluster_info='api_groups') }}"
+  - name: Determine the cluster type
+    set_fact:
+      is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+      is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+      is_minikube: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'minikube' else False }}"
+      is_kind: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'kind' else False }}"
   - name: Determine the Istio implementation
     set_fact:
       is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,6 +8,12 @@
   - name: Get information about the cluster
     set_fact:
       api_groups: "{{ lookup('kubernetes.core.k8s', cluster_info='api_groups') }}"
+  - name: Determine the cluster type
+    set_fact:
+      is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+      is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+      is_minikube: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'minikube' else False }}"
+      is_kind: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'kind' else False }}"
   - name: Determine the Istio implementation
     set_fact:
       is_maistra: "{{ True if 'maistra.io' in api_groups else False }}"

--- a/molecule/header-auth-test/kiali-cr.yaml
+++ b/molecule/header-auth-test/kiali-cr.yaml
@@ -15,7 +15,7 @@ spec:
     logger:
       log_level: "trace"
     namespace: {{ kiali.install_namespace }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test
   login_token:
     signing_key: "abc12345"

--- a/molecule/header-auth-test/kiali-cr.yaml
+++ b/molecule/header-auth-test/kiali-cr.yaml
@@ -8,12 +8,12 @@ spec:
   auth:
     strategy: header
   deployment:
+    logger:
+      log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger:
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test

--- a/molecule/instance-name-test/kiali-cr.yaml
+++ b/molecule/instance-name-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/instance-name-test/kiali-cr.yaml
+++ b/molecule/instance-name-test/kiali-cr.yaml
@@ -13,7 +13,7 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
     instance_name: {{ kiali.instance_name }}
   server:
     web_root: /{{ kiali.instance_name }}

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -13,4 +13,4 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/kiali-cr.yaml
+++ b/molecule/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/kiali-cr.yaml
+++ b/molecule/kiali-cr.yaml
@@ -13,4 +13,4 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/metrics-test/kiali-cr.yaml
+++ b/molecule/metrics-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/metrics-test/kiali-cr.yaml
+++ b/molecule/metrics-test/kiali-cr.yaml
@@ -13,7 +13,7 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   server:
     # start the test off with metrics disabled
     metrics_enabled: false

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -50,7 +50,7 @@ spec:
     resources: null
     secret_name: null
     service_annotations: null
-    service_type: null
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
     tolerations: null
     version_label: null
     view_only_mode: null

--- a/molecule/only-view-only-mode-test/kiali-cr.yaml
+++ b/molecule/only-view-only-mode-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/only-view-only-mode-test/kiali-cr.yaml
+++ b/molecule/only-view-only-mode-test/kiali-cr.yaml
@@ -13,6 +13,6 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
     # the operator is only given permission to deploy Kiali in view_only_mode
     view_only_mode: true

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -13,12 +13,12 @@ spec:
       issuer_uri: {{ openid.issuer_uri }}
       username_claim: {{ openid.username_claim }}
   deployment:
+    logger:
+      log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger:
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -20,7 +20,7 @@ spec:
     logger:
       log_level: "trace"
     namespace: {{ kiali.install_namespace }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test
   login_token:
     signing_key: "abc12345"

--- a/molecule/openshift-auth-test/kiali-cr.yaml
+++ b/molecule/openshift-auth-test/kiali-cr.yaml
@@ -15,4 +15,4 @@ spec:
     logger:
       log_level: "trace"
     namespace: {{ kiali.install_namespace }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/openshift-auth-test/kiali-cr.yaml
+++ b/molecule/openshift-auth-test/kiali-cr.yaml
@@ -8,11 +8,11 @@ spec:
   auth:
     strategy: openshift
   deployment:
+    logger:
+      log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
-    logger:
-      log_level: "trace"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/os-console-links-test/kiali-cr.yaml
+++ b/molecule/os-console-links-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/os-console-links-test/kiali-cr.yaml
+++ b/molecule/os-console-links-test/kiali-cr.yaml
@@ -13,6 +13,6 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   server:
     web_root: {{ kiali.server_web_root }}

--- a/molecule/rolling-restart-test/kiali-cr.yaml
+++ b/molecule/rolling-restart-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/rolling-restart-test/kiali-cr.yaml
+++ b/molecule/rolling-restart-test/kiali-cr.yaml
@@ -13,4 +13,4 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/token-test/kiali-cr.yaml
+++ b/molecule/token-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    logger:
+      log_level: debug
     namespace: {{ kiali.install_namespace }}
     image_name: {{ kiali.image_name }}
     image_pull_policy: {{ kiali.image_pull_policy }}

--- a/molecule/token-test/kiali-cr.yaml
+++ b/molecule/token-test/kiali-cr.yaml
@@ -13,6 +13,6 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_version: {{ kiali.image_version }}
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    service_type: NodePort
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   login_token:
     expiration_seconds: 15


### PR DESCRIPTION
This required to include https://github.com/kiali/kiali-operator/pull/363 which is fine - it will allow us to run this branch's tests on Kind.