### PR TITLE
conform to the correct route syntax for target port

### DIFF
--- a/roles/default/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/route.yaml
@@ -16,6 +16,7 @@ spec:
     insecureEdgeTerminationPolicy: Redirect
   to:
     kind: Service
-    targetPort: {{ kiali_vars.server.port }}
     name: {{ kiali_vars.deployment.instance_name }}
+  port:
+    targetPort: {{ kiali_vars.server.port }}
 {% endif %}

--- a/roles/v1.36/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/v1.36/kiali-deploy/templates/openshift/route.yaml
@@ -16,6 +16,7 @@ spec:
     insecureEdgeTerminationPolicy: Redirect
   to:
     kind: Service
-    targetPort: {{ kiali_vars.server.port }}
     name: {{ kiali_vars.deployment.instance_name }}
+  port:
+    targetPort: {{ kiali_vars.server.port }}
 {% endif %}


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4255

This is very easy to test:

1. Install using the operator in OpenShift (`make operator-create kiali-create` is enough)
2. See that you have port.targetPort in the route spec:
```
$ oc get route kiali -n istio-system -o jsonpath={.spec.port.targetPort}
20001
```
3. Make sure you can access Kiali via the route:
```
$ curl -k --head https://$(oc get route kiali -n istio-system -o jsonpath={.spec.host})
HTTP/1.1 200 OK
```