### PR TITLE
use_grpc by default. health_check_url removal from tracing

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -627,7 +627,6 @@ spec:
 #       and auth.token config is ignored then.
 #   username: Username to be used when making requests to Jaeger, for basic authentication. User only requires viewer permissions.
 # enabled: When true, connections to Jaeger are enabled. "in_cluster_url" and/or "url" need to be provided.
-# health_check_url: Used in the Components health feature. This is the url which kiali will ping to determine whether the component is reachable or not. It defaults to `in_cluster_url` when not provided.
 # in_cluster_url: Set URL for in-cluster access, which enables further integration between Kiali and Jaeger.
 #      When not provided, Kiali will only show external links using the "url" config.
 #      Note: Jaeger v1.20+ has separated ports for GRPC(16685) and HTTP(16686) requests. Make sure you use the appropriate port according to the "use_grpc" value.
@@ -652,7 +651,6 @@ spec:
 #        use_kiali_token: false
 #        username: ""
 #      enabled: true
-#      health_check_url: ""
 #      in_cluster_url: ""
 #      is_core: false
 #      namespace_selector: true

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -186,12 +186,11 @@ kiali_defaults:
         use_kiali_token: false
         username: ""
       enabled: true
-      health_check_url: ""
       in_cluster_url: ""
       is_core: false
       namespace_selector: true
       url: ""
-      #use_grpc:
+      use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
 
   health_config:


### PR DESCRIPTION
needs https://github.com/kiali/kiali/pull/4249

1. `use_grpc` is by default true. It was before, now it is explicitly set to true.
2. removing the `health_check_url` from tracing config. We use actual jaeger API to check availability. So no need to add an extra url.

I assume that we don't need to change any yaml from the helm, am I right @jmazzitelli ?