### PR TITLE
Add feature flag for clustering/federation features

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -716,6 +716,10 @@ spec:
 #  ---
 #  kiali_feature_flags:
 #
+# Flag to indicate Kiali to enable/disable clustering and federation related features.
+#    ---
+#    clustering: true
+#
 # Flag to indicate Kiali to enable/disable an Action to label a namespace for automatic Istio Sidecar injection.
 #    ---
 #    istio_injection_action: true

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -207,6 +207,7 @@ kiali_defaults:
     version_label_name: "version"
 
   kiali_feature_flags:
+    clustering: true
     istio_injection_action: true
     istio_upgrade_action: false
     ui_defaults:

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -4,6 +4,29 @@
   when:
   - is_k8s == True
 
+- name: Process kiali-controlplane Role on Kubernetes
+  k8s:
+    state: "{{ 'present' if kiali_vars.kiali_feature_flags.clustering|bool == True else 'absent' }}"
+    definition: "{{ lookup('template', 'templates/kubernetes/role-controlplane.yaml') }}"
+  register: process_resource_result
+  until:
+  - process_resource_result.error is not defined
+  - process_resource_result.result is defined
+  - process_resource_result.result.metadata is defined
+  retries: 6
+
+- name: Process kiali-controlplane RoleBinding on Kubernetes
+  k8s:
+    state: "{{ 'present' if kiali_vars.kiali_feature_flags.clustering|bool == True else 'absent' }}"
+    definition: "{{ lookup('template', 'templates/kubernetes/rolebinding-controlplane.yaml') }}"
+  register: process_resource_result
+  until:
+  - process_resource_result.error is not defined
+  - process_resource_result.result is defined
+  - process_resource_result.result.metadata is defined
+  retries: 6
+  delay: 10
+
 - name: Create Kiali objects on Kubernetes
   include_tasks: process-resource.yml
   vars:
@@ -13,9 +36,7 @@
   - serviceaccount
   - configmap
   - "{{ 'role-viewer' if kiali_vars.deployment.view_only_mode|bool == True else 'role' }}"
-  - role-controlplane
   - rolebinding
-  - rolebinding-controlplane
   - deployment
   - service
   - "{{ 'hpa' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -4,6 +4,29 @@
   when:
   - is_openshift == True
 
+- name: Process kiali-controlplane Role on OpenShift
+  k8s:
+    state: "{{ 'present' if kiali_vars.kiali_feature_flags.clustering|bool == True else 'absent' }}"
+    definition: "{{ lookup('template', 'templates/openshift/role-controlplane.yaml') }}"
+  register: process_resource_result
+  until:
+  - process_resource_result.error is not defined
+  - process_resource_result.result is defined
+  - process_resource_result.result.metadata is defined
+  retries: 6
+
+- name: Process kiali-controlplane RoleBinding on OpenShift
+  k8s:
+    state: "{{ 'present' if kiali_vars.kiali_feature_flags.clustering|bool == True else 'absent' }}"
+    definition: "{{ lookup('template', 'templates/openshift/rolebinding-controlplane.yaml') }}"
+  register: process_resource_result
+  until:
+  - process_resource_result.error is not defined
+  - process_resource_result.result is defined
+  - process_resource_result.result.metadata is defined
+  retries: 6
+  delay: 10
+
 - name: Create Kiali objects on OpenShift
   include_tasks: process-resource.yml
   vars:
@@ -14,9 +37,7 @@
   - configmap
   - cabundle
   - "{{ 'role-viewer' if kiali_vars.deployment.view_only_mode|bool == True else 'role' }}"
-  - role-controlplane
   - rolebinding
-  - rolebinding-controlplane
   - deployment
   - service
   - "{{ 'hpa' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"


### PR DESCRIPTION
For now, this flag is only allowing or preventing creation of a role and a rolebinding that grants privileges for reading some secrets in the Istio namespace. There is no effect on Kiali server side, because it is failing gracefully. In case it's needed later, this flag is being passed to Kiali in its ConfigMap.

Default value is `true` for backwards compatibility.

Related kiali/kiali#4147.