### PR TITLE
[v1.36] operator does not need perms for event and pvc resources

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -289,8 +289,6 @@ spec:
           resources:
           - configmaps
           - endpoints
-          - events
-          - persistentvolumeclaims
           - pods
           - serviceaccounts
           - services


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4290

this is a partial cherry pick of https://github.com/kiali/kiali-operator/pull/403 (we just bring over the kiali-ossm metadata - we don't need the 1.40 metadata in this branch)