### PR TITLE
Do not define secret-bound env var if the external service isn't enabled

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -707,24 +707,28 @@
   set_fact:
     kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_PASSWORD': {'secret_name': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
+  - kiali_vars.external_services.tracing.enabled == True
   - kiali_vars.external_services.tracing.auth.password | regex_search('secret:.+:.+')
 
 - name: Prepare environment variable for tracing token
   set_fact:
     kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_TOKEN': {'secret_name': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
+  - kiali_vars.external_services.tracing.enabled == True
   - kiali_vars.external_services.tracing.auth.token | regex_search('secret:.+:.+')
 
 - name: Prepare environment variable for grafana password
   set_fact:
     kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_PASSWORD': {'secret_name': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
+  - kiali_vars.external_services.grafana.enabled == True
   - kiali_vars.external_services.grafana.auth.password | regex_search('secret:.+:.+')
 
 - name: Prepare environment variable for grafana token
   set_fact:
     kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_TOKEN': {'secret_name': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
+  - kiali_vars.external_services.grafana.enabled == True
   - kiali_vars.external_services.grafana.auth.token | regex_search('secret:.+:.+')
 
 - name: Prepare environment variable for login token signing key


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4298