### PR TITLE
add new custom headers setting to prometheus config.

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -466,7 +466,12 @@ spec:
 #          type: "none"
 #          use_kiali_token: false
 #          username: ""
+#        cache_duration: 10
+#        cache_enabled: true
+#        cache_expiration: 300
+#        custom_headers: {}
 #        health_check_url: ""
+#        is_core: true
 #        url: ""
 #
 # **Grafana-specific settings:
@@ -597,6 +602,7 @@ spec:
 # cache_duration: Prometheus caching duration expressed in seconds
 # cache_enabled: Enable/disable Prometheus caching used for Health services
 # cache_expiration: Prometheus caching expiration expressed in seconds
+# custom_headers: A set of name/value settings that will be passed as headers when requests are sent to Prometheus.
 # health_check_url: Used in the Components health feature. This is the url which kiali will ping to determine whether the component is reachable or not. It defaults to `url` when not provided.
 # is_core: Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning.
 # url: The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod.
@@ -614,6 +620,7 @@ spec:
 #      cache_duration: 10
 #      cache_enabled: true
 #      cache_expiration: 300
+#      custom_headers: {}
 #      health_check_url: ""
 #      is_core: true
 #      url: ""

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -24,12 +24,14 @@
       - kiali_configmap.deployment.logger.log_level == "info"
       - kiali_configmap.deployment.logger.time_field_format == "2006-01-02T15:04:05Z07:00"
       - kiali_configmap.deployment.logger.sampler_rate == "1"
+      - kiali_configmap.external_services.custom_dashboards.prometheus.custom_headers | length == 0
       - kiali_configmap.external_services.grafana.auth.password == ""
       - kiali_configmap.external_services.grafana.auth.type == "none"
       - kiali_configmap.external_services.grafana.url == ""
       - kiali_configmap.external_services.istio.istio_identity_domain == "svc.cluster.local"
       - kiali_configmap.external_services.istio.istio_sidecar_annotation == "sidecar.istio.io/status"
       - kiali_configmap.external_services.prometheus.url != ""
+      - kiali_configmap.external_services.prometheus.custom_headers | length == 0
       - kiali_configmap.identity.cert_file is defined
       - kiali_configmap.identity.private_key_file is defined
       - kiali_configmap.istio_labels.app_label_name == "app"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -105,7 +105,12 @@ kiali_defaults:
           type: "none"
           use_kiali_token: false
           username: ""
+        cache_duration: 7
+        cache_enabled: true
+        cache_expiration: 300
+        custom_headers: {}
         health_check_url: ""
+        is_core: true
         url: ""
     grafana:
       auth:
@@ -173,6 +178,7 @@ kiali_defaults:
       cache_duration: 7
       cache_enabled: true
       cache_expiration: 300
+      custom_headers: {}
       health_check_url: ""
       is_core: true
       url: ""

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -194,6 +194,24 @@
   - kiali_vars.deployment.node_selector is defined
   - kiali_vars.deployment.node_selector | length > 0
 
+- name: Replace snake_case with camelCase in external_services.custom_dashboards.prometheus.custom_headers
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['external_services']['custom_dashboards']['prometheus'].pop('custom_headers') %}
+      {{ kiali_vars | combine({'external_services': {'custom_dashboards': {'prometheus': {'custom_headers': current_cr.spec.external_services.custom_dashboards.prometheus.custom_headers }}}}, recursive=True) }}
+  when:
+  - kiali_vars.external_services.custom_dashboards.prometheus.custom_headers is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus.custom_headers | length > 0
+
+- name: Replace snake_case with camelCase in external_services.prometheus.custom_headers
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['external_services']['prometheus'].pop('custom_headers') %}
+      {{ kiali_vars | combine({'external_services': {'prometheus': {'custom_headers': current_cr.spec.external_services.prometheus.custom_headers }}}, recursive=True) }}
+  when:
+  - kiali_vars.external_services.prometheus.custom_headers is defined
+  - kiali_vars.external_services.prometheus.custom_headers | length > 0
+
 - name: Print some debug information
   vars:
     msg: |


### PR DESCRIPTION
side note: this also makes sure the prom config is the same for custom_dashboards.prometheus since that follows the identical config schema as the external_services.prometheus config.

part of: https://github.com/kiali/kiali/issues/4323