### PR TITLE
Add OLM annotation that upstream repo added to kiali metadata.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,10 @@ endif
 validate: .ensure-operator-sdk-exists
 	@printf "==========\nValidating kiali-ossm metadata\n==========\n"
 	@mkdir -p ${OUTDIR}/kiali-ossm && rm -rf ${OUTDIR}/kiali-ossm/* && cp -R ./manifests/kiali-ossm ${OUTDIR} && cat ./manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml | KIALI_OPERATOR_VERSION="2.0.0" KIALI_OLD_OPERATOR_VERSION="1.0.0" KIALI_OPERATOR_TAG=":2.0.0" KIALI_1_24_TAG=":1.24.0" KIALI_1_12_TAG=":1.12.0" KIALI_1_0_TAG=":1.0.0" CREATED_AT="2021-01-01T00:00:00Z" envsubst > ${OUTDIR}/kiali-ossm/manifests/kiali.clusterserviceversion.yaml && ${OP_SDK} bundle validate --verbose ${OUTDIR}/kiali-ossm
-	@printf "==========\nValidating kiali-community metadata\n==========\n"
-	@for d in $$(ls -1d manifests/kiali-community/* | sort -V | tail -n 1); do ${OP_SDK} bundle --verbose validate $$d; done
-	@printf "==========\nValidating kiali-upstream metadata\n==========\n"
-	@for d in $$(ls -1d manifests/kiali-upstream/* | sort -V | tail -n 1); do ${OP_SDK} bundle --verbose validate $$d; done
+	@printf "==========\nValidating the latest version of kiali-community metadata\n==========\n"
+	@for d in $$(ls -1d manifests/kiali-community/* | sort -V | grep -v ci.yaml | tail -n 1); do ${OP_SDK} bundle --verbose validate $$d; done
+	@printf "==========\nValidating the latest version of kiali-upstream metadata\n==========\n"
+	@for d in $$(ls -1d manifests/kiali-upstream/* | sort -V | grep -v ci.yaml | tail -n 1); do ${OP_SDK} bundle --verbose validate $$d; done
 
 # Ensure "docker buildx" is available and enabled. For more details, see: https://github.com/docker/buildx/blob/master/README.md
 # This does a few things:

--- a/manifests/kiali-community/0.18.1/metadata/annotations.yaml
+++ b/manifests/kiali-community/0.18.1/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.1.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.1.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.10.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.10.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.11.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.11.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.13.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.13.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.15.1/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.15.1/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.19.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.19.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.22.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.22.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.24.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.24.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.25.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.25.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.26.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.26.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.27.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.27.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.28.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.28.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.29.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.29.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.3.1/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.3.1/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.4.2/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.4.2/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.6.1/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.6.1/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.7.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.7.0/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/1.9.1/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.9.1/metadata/annotations.yaml
@@ -5,3 +5,11 @@ annotations:
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kiali
+
+  # Adding com.redhat.openshift.versions programmatically
+  # This annotation was added because was possible to identify that this distribution uses API(s),
+  # which were removed in the k8s version 1.22 and OpenShift version OCP 4.9. Then, it will prevent the bundle from being distributed on 4.9.
+  # Please, ensure that your project is no longer using these API(s) and that you start to
+  # distribute solutions which is compatible with OpenShift 4.9.
+  # For further information, see: https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/138
+  com.redhat.openshift.versions: "v4.6-v4.8"

--- a/manifests/kiali-community/ci.yaml
+++ b/manifests/kiali-community/ci.yaml
@@ -1,0 +1,5 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode
+reviewers:
+- jmazzitelli

--- a/manifests/kiali-upstream/ci.yaml
+++ b/manifests/kiali-upstream/ci.yaml
@@ -1,0 +1,5 @@
+---
+# Use `replaces-mode` or `semver-mode`. Once you switch to `semver-mode`, there is no easy way back.
+updateGraph: replaces-mode
+reviewers:
+- jmazzitelli


### PR DESCRIPTION
These were added to our metadata upstream by the OLM folks due to the CSV v1 update/OpenShift 4.9 requirements.
This is just ensuring our golden copies are exactly the same as upstream.

This also adds the ci.yaml files that upstream also wants in order to automatically merge our upstream PRs.