### PR TITLE
[molecule] test with default server image

### DIFF
--- a/molecule/accessible-namespaces-test/kiali-cr.yaml
+++ b/molecule/accessible-namespaces-test/kiali-cr.yaml
@@ -11,8 +11,8 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/accessible-namespaces-test/molecule.yml
+++ b/molecule/accessible-namespaces-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
+++ b/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
@@ -13,9 +13,9 @@ spec:
     namespace: {{ kiali.install_namespace }}
     # Note that we start with no affinity or tolerations or resources sections,
     # so the first time through we just pick up the defaults.
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     # while we are here, make sure the additional service yaml retains camelCase
     additional_service_yaml:

--- a/molecule/affinity-tolerations-resources-test/molecule.yml
+++ b/molecule/affinity-tolerations-resources-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/api-test/dashboards.test.yaml
+++ b/molecule/api-test/dashboards.test.yaml
@@ -62,7 +62,7 @@
   vars:
     param_namespace: "{{ kiali.install_namespace }}"
     param_dashboard: "kiali"
-    param_version: "{{ kiali.image_version }}"
+    param_version: "{{ kiali.image_version if kiali.image_version != '' else kiali_configmap.deployment.image_version }}"
   uri:
     url: "{{ kiali_base_url }}/api/namespaces/{{ param_namespace }}/customdashboard/{{ param_dashboard }}?labelsFilter=app:kiali,version:{{ param_version }}"
     return_content: yes

--- a/molecule/api-test/kiali-cr.yaml
+++ b/molecule/api-test/kiali-cr.yaml
@@ -14,8 +14,8 @@ spec:
     logger:
       log_level: debug
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/api-test/molecule.yml
+++ b/molecule/api-test/molecule.yml
@@ -35,8 +35,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/asserts/configmap_asserts.yml
+++ b/molecule/asserts/configmap_asserts.yml
@@ -3,10 +3,12 @@
     that:
     - kiali_configmap.auth.strategy == kiali.auth_strategy
 
-- name: Assert Kiali Configmap has the correct Image Version
+- name: Assert Kiali Configmap has the correct Image Version if we know what the version should be
   assert:
     that:
     - kiali_configmap.deployment.image_version ==  kiali.image_version
+  when:
+  - kiali.image_version != ""
 
 - name: Assert Kiali Configmap has the correct Image Pull Policy
   assert:

--- a/molecule/config-values-test/kiali-cr.yaml
+++ b/molecule/config-values-test/kiali-cr.yaml
@@ -10,7 +10,7 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/config-values-test/molecule.yml
+++ b/molecule/config-values-test/molecule.yml
@@ -32,8 +32,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/default-namespace-test/kiali-cr.yaml
+++ b/molecule/default-namespace-test/kiali-cr.yaml
@@ -13,8 +13,8 @@ spec:
     # For this test, we do not define namespace.
     # It should default to the location where this CR lives
     # namespace:
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/default-namespace-test/molecule.yml
+++ b/molecule/default-namespace-test/molecule.yml
@@ -38,8 +38,8 @@ provisioner:
           # and thus will determine where to install Kiali.
           operator_watch_namespace: anothernamespace
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -35,8 +35,8 @@ provisioner:
           operator_cluster_role_creator: "true"
           operator_only_view_only_mode: "false"
           auth_strategy: anonymous
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           label_selector: ""
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"

--- a/molecule/grafana-test/kiali-cr.yaml
+++ b/molecule/grafana-test/kiali-cr.yaml
@@ -11,8 +11,8 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/grafana-test/molecule.yml
+++ b/molecule/grafana-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/header-auth-test/kiali-cr.yaml
+++ b/molecule/header-auth-test/kiali-cr.yaml
@@ -11,9 +11,9 @@ spec:
     logger:
       log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test

--- a/molecule/header-auth-test/molecule.yml
+++ b/molecule/header-auth-test/molecule.yml
@@ -37,8 +37,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/instance-name-test/kiali-cr.yaml
+++ b/molecule/instance-name-test/kiali-cr.yaml
@@ -11,9 +11,9 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
     instance_name: {{ kiali.instance_name }}

--- a/molecule/instance-name-test/molecule.yml
+++ b/molecule/instance-name-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
           instance_name: "kiali" # we start by installing the default instance - we'll later install one with a different instance name

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -11,8 +11,8 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/jaeger-test/molecule.yml
+++ b/molecule/jaeger-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/kiali-cr.yaml
+++ b/molecule/kiali-cr.yaml
@@ -11,8 +11,8 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/metrics-test/kiali-cr.yaml
+++ b/molecule/metrics-test/kiali-cr.yaml
@@ -11,9 +11,9 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   server:

--- a/molecule/metrics-test/molecule.yml
+++ b/molecule/metrics-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -30,10 +30,10 @@ spec:
       node: null
       pod: null
       pod_anti: null
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_pull_secrets: null
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     ingress_enabled: null
     logger:
       log_format: null

--- a/molecule/null-cr-values-test/molecule.yml
+++ b/molecule/null-cr-values-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/only-view-only-mode-test/kiali-cr.yaml
+++ b/molecule/only-view-only-mode-test/kiali-cr.yaml
@@ -11,9 +11,9 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
     # the operator is only given permission to deploy Kiali in view_only_mode

--- a/molecule/only-view-only-mode-test/molecule.yml
+++ b/molecule/only-view-only-mode-test/molecule.yml
@@ -36,8 +36,8 @@ provisioner:
           operator_cluster_role_creator: "true"
           # This test will not enable create/delete/patch permissions for the operator - it can only support view-only-mode
           operator_only_view_only_mode: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -16,9 +16,9 @@ spec:
     logger:
       log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   # if signing key is not 16, 24, or 32 chars, then openid "implicit flow" is used and what we test

--- a/molecule/openid-test/molecule.yml
+++ b/molecule/openid-test/molecule.yml
@@ -39,8 +39,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/openshift-auth-test/kiali-cr.yaml
+++ b/molecule/openshift-auth-test/kiali-cr.yaml
@@ -11,8 +11,8 @@ spec:
     logger:
       log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     namespace: {{ kiali.install_namespace }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/openshift-auth-test/molecule.yml
+++ b/molecule/openshift-auth-test/molecule.yml
@@ -36,8 +36,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/os-console-links-test/kiali-cr.yaml
+++ b/molecule/os-console-links-test/kiali-cr.yaml
@@ -11,9 +11,9 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   server:

--- a/molecule/os-console-links-test/molecule.yml
+++ b/molecule/os-console-links-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
           server_web_root: "/"

--- a/molecule/read-certs-secrets-test/kiali-cr.yaml
+++ b/molecule/read-certs-secrets-test/kiali-cr.yaml
@@ -11,8 +11,8 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/read-certs-secrets-test/molecule.yml
+++ b/molecule/read-certs-secrets-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/roles-test/molecule.yml
+++ b/molecule/roles-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/rolling-restart-test/kiali-cr.yaml
+++ b/molecule/rolling-restart-test/kiali-cr.yaml
@@ -11,8 +11,8 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}

--- a/molecule/rolling-restart-test/molecule.yml
+++ b/molecule/rolling-restart-test/molecule.yml
@@ -34,8 +34,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:

--- a/molecule/token-test/kiali-cr.yaml
+++ b/molecule/token-test/kiali-cr.yaml
@@ -11,9 +11,9 @@ spec:
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}
-    image_name: {{ kiali.image_name }}
+    image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
-    image_version: {{ kiali.image_version }}
+    image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   login_token:

--- a/molecule/token-test/molecule.yml
+++ b/molecule/token-test/molecule.yml
@@ -36,8 +36,8 @@ provisioner:
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
           operator_watch_namespace: kiali-operator
           operator_cluster_role_creator: "true"
-          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')|default('quay.io/kiali/kiali', True)) }}"
-          image_version: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION')|default('latest', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
           image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
           operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
 scenario:


### PR DESCRIPTION
this is needed in case we want the operator to install the default server image.
Useful when testing with OLM and OSSM.

Server PR: https://github.com/kiali/kiali/pull/4414
Backport PR: https://github.com/kiali/kiali-operator/pull/434