### PR TITLE
[molecule] get tests to pass again

### DIFF
--- a/molecule/accessible-namespaces-test/converge.yml
+++ b/molecule/accessible-namespaces-test/converge.yml
@@ -51,12 +51,11 @@
       that:
       - kiali_configmap.api.namespaces.label_selector == "kiali.io/member-of={{ istio.control_plane_namespace }}"
 
-  # TODO kubernetes.core.k8s behaves oddly - query doesn't return a list, but should; lookup returns a list but shouldn't.
-  #      For now, just use lookup since it returns the list which is what we want
   - name: Make sure the new label exists, but didn't overwrite any existing labels
     vars:
-      namespacesWithCustomLabel: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='customLabel=test') }}"
-      namespacesWithKialiLabel: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector=kiali_configmap.api.namespaces.label_selector) }}"
+      # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
+      namespacesWithCustomLabel: "{{ query('kubernetes.core.k8s', kind='Namespace', label_selector='customLabel=test') }}"
+      namespacesWithKialiLabel: "{{ query('kubernetes.core.k8s', kind='Namespace', label_selector=kiali_configmap.api.namespaces.label_selector) }}"
     assert:
       that:
       - namespacesWithCustomLabel | length == 1

--- a/molecule/common/purge-prometheus-data.yml
+++ b/molecule/common/purge-prometheus-data.yml
@@ -6,7 +6,7 @@
     namespace: "{{ k8s_item.metadata.namespace }}"
     name: "{{ k8s_item.metadata.name }}"
   with_items:
-  - "{{ lookup('kubernetes.core.k8s', namespace=istio.control_plane_namespace, kind='Pod', label_selector='app=prometheus', api_version='v1') }}" # TODO this assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  - "{{ query('kubernetes.core.k8s', namespace=istio.control_plane_namespace, kind='Pod', label_selector='app=prometheus', api_version='v1') }}"
   loop_control:
     loop_var: k8s_item
 

--- a/molecule/common/query-prometheus.yml
+++ b/molecule/common/query-prometheus.yml
@@ -10,13 +10,16 @@
     pod: "{{ kiali_pod.resources[0].metadata.name}}"
     command: "curl -skL {{ credentials_arg }} -d query={{ prometheus_request.query}} -d time={{ prometheus_request.time }} {{ url }}"
   register: prometheus_query_results_raw
+  ignore_errors: yes # TODO why is this returning a rc=3? We are getting back good results
   vars:
     credentials_arg: "{{ ('-u ' + kiali_configmap.external_services.prometheus.auth.username + ':' + kiali_configmap.external_services.prometheus.auth.password) if kiali_configmap.external_services.prometheus.auth.username != '' else '' }}"
     url: "{{ kiali_configmap.external_services.prometheus.url }}/api/v1/query }}"
 
 - name: Raw Prometheus query results
+  vars:
+    url: "{{ kiali_configmap.external_services.prometheus.url }}/api/v1/query }}"
   debug:
-    msg: "Request: {{ prometheus_request }}; Results: {{ prometheus_query_results_raw }}"
+    msg: "URL: {{ url }}; Request: {{ prometheus_request }}; Results: {{ prometheus_query_results_raw }}"
 
 - set_fact:
     prometheus_query_results:

--- a/molecule/instance-name-test/converge.yml
+++ b/molecule/instance-name-test/converge.yml
@@ -14,10 +14,10 @@
     vars:
       namespace_list: [ 'instancenametest' ]
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: Make sure the one new namespace label exists
     vars:
-      namespacesWithLabel: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      namespacesWithLabel: "{{ query('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
     assert:
       that:
       - namespacesWithLabel | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 1
@@ -39,13 +39,13 @@
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: Make sure the two new namespace labels exists and the two labels on the signing key exist
     vars:
-      namespacesWithLabel1: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
-      namespacesWithLabel2: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
-      signingKeyWithLabel1: "{{ lookup('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
-      signingKeyWithLabel2: "{{ lookup('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+      namespacesWithLabel1: "{{ query('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      namespacesWithLabel2: "{{ query('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel1: "{{ query('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel2: "{{ query('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
     assert:
       that:
       - namespacesWithLabel1 | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 1
@@ -74,34 +74,34 @@
       - lookup('kubernetes.core.k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable
       - lookup('kubernetes.core.k8s', kind='Ingress', api_version='networking.k8s.io/v1_INVALID', errors='ignore') is not iterable
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: Kubernetes - Make sure we have the basic resources we expect, with the labels we expect
     assert:
       that:
-      - lookup('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     - app.kubernetes.io/instance=kialitwo
     when:
     - is_k8s == True
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: OpenShift - Make sure we have the basic resources we expect, with the labels we expect
     assert:
       that:
-      - lookup('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     - app.kubernetes.io/instance=kialitwo
@@ -123,13 +123,13 @@
       name: "{{ custom_resource.metadata.name }}"
       namespace: "{{ cr_namespace }}"
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: Make sure the first namespace label exists but the second one is gone, same with the signing key
     vars:
-      namespacesWithLabel1: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
-      namespacesWithLabel2: "{{ lookup('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
-      signingKeyWithLabel1: "{{ lookup('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
-      signingKeyWithLabel2: "{{ lookup('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+      namespacesWithLabel1: "{{ query('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      namespacesWithLabel2: "{{ query('kubernetes.core.k8s', kind='Namespace', label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel1: "{{ query('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/member-of=' + istio.control_plane_namespace) }}"
+      signingKeyWithLabel2: "{{ query('kubernetes.core.k8s', kind='Secret',    label_selector='kiali.io/kialitwo.member-of=' + istio.control_plane_namespace) }}"
     assert:
       that:
       - namespacesWithLabel1 | selectattr('metadata.name', 'equalto', 'instancenametest') | length == 1
@@ -139,33 +139,33 @@
 
   # Check that the resources for the remaining instance still exist
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: Kubernetes - Make sure we have the basic resources we expect, with the labels we expect for the remaining instance
     assert:
       that:
-      - lookup('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     when:
     - is_k8s == True
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: OpenShift - Make sure we have the basic resources we expect, with the labels we expect for the remaining instance
     assert:
       that:
-      - lookup('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
-      - lookup('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
-      - lookup('kubernetes.core.k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 2
+      - query('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 1
+      - query('kubernetes.core.k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 1
     loop:
     - app.kubernetes.io/instance=kiali
     when:
@@ -173,33 +173,33 @@
 
   # Check that the resources for the deleted instance have been removed
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: Kubernetes - Confirm we have no more resources for the deleted instance
     assert:
       that:
-      - lookup('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=item) | length == 0
     loop:
     - app.kubernetes.io/instance=kialitwo
     when:
     - is_k8s == True
 
-  # TODO the k8s lookup below assumes faulty behavior - may need to change in the future. See: https://github.com/ansible-collections/kubernetes.core/issues/147
+  # Use query - it is the only way to ensure a list is returned; for some reason, lookup/wantList=true is not working
   - name: OpenShift - Confirm we have no more resources for the deleted instance
     assert:
       that:
-      - lookup('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 0
-      - lookup('kubernetes.core.k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Role',           namespace=queryNamespace, api_version=apiRole, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='RoleBinding',    namespace=queryNamespace, api_version=apiRoBi, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=item) | length == 0
+      - query('kubernetes.core.k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=item) | length == 0
     loop:
     - app.kubernetes.io/instance=kialitwo
     when:

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -25,9 +25,6 @@
       - kiali_configmap.deployment.logger.time_field_format == "2006-01-02T15:04:05Z07:00"
       - kiali_configmap.deployment.logger.sampler_rate == "1"
       - kiali_configmap.external_services.custom_dashboards.prometheus.custom_headers | length == 0
-      - kiali_configmap.external_services.grafana.auth.password == ""
-      - kiali_configmap.external_services.grafana.auth.type == "none"
-      - kiali_configmap.external_services.grafana.url == ""
       - kiali_configmap.external_services.istio.istio_identity_domain == "svc.cluster.local"
       - kiali_configmap.external_services.istio.istio_sidecar_annotation == "sidecar.istio.io/status"
       - kiali_configmap.external_services.prometheus.url != ""
@@ -40,4 +37,3 @@
       - kiali_configmap.kubernetes_config.excluded_workloads | length > 0
       - kiali_configmap.login_token.signing_key | length > 0
       - kiali_configmap.server.metrics_port == 9090
-


### PR DESCRIPTION
Part of the behavior change appears to be due to ansible query/lookup changes which I believe is due to https://github.com/ansible-collections/kubernetes.core/issues/147

Get these tests to work again.

part of: https://github.com/kiali/kiali/issues/4417