### PR TITLE
support ingressClassName; turn off ingress by default when on k8s

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -285,10 +285,49 @@ spec:
 #    ---
 #    image_version: ""
 #
+# The ingress section configures if/how the Kiali endpoint should be exposed externally.
+#    ---
+#    ingress:
+#
+# If class_name is a non-empty string, it will be used as the spec.ingressClassName
+# in the created Kubernetes Ingress resource. This setting is ignored if on OpenShift.
+# This is also ignored if override_yaml.spec is defined (i.e. you must define the
+# ingressClassName directly in your override yaml).
+#      ---
+#      class_name: "nginx"
+#
 # Determines if the Kiali endpoint should be exposed externally.
 # If true, an Ingress will be created if on Kubernetes or a Route if on OpenShift.
-#    ---
-#    ingress_enabled: true
+# If left undefined, will be false on Kubernetes and true on OpenShift.
+#      ---
+#      #enabled
+#
+# Because an ingress into a cluster can vary wildly in its desired configuration,
+# this setting provides a way to override complete portions of the ingress resource
+# configuration (Ingress on Kubernetes and Route on OpenShift). It is up to the user
+# to ensure this override YAML configuration is valid and supports the cluster environment
+# since the operator will blindly copy this custom configuration into the resource it
+# creates.
+# This setting is not used if deployment.ingress.enabled is set to 'false'.
+# Note that only 'metadata.annotations' and 'spec' is valid and only they will
+# be used to override those same sections in the created resource. You can define
+# either one or both.
+# Example:
+#      override_yaml:
+#        metadata:
+#          annotations:
+#            nginx.ingress.kubernetes.io/secure-backends: "true"
+#            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+#        spec:
+#          rules:
+#          - http:
+#              paths:
+#              - path: /kiali
+#                backend:
+#                  serviceName: kiali
+#                  servicePort: 20001
+#      ---
+#      #override_yaml:
 #
 # The instance name of this Kiali installation. This instance name will be the prefix
 # prepended to the names of all Kiali resources created by the operator and will be used
@@ -328,33 +367,6 @@ spec:
 # A set of node labels that dictate onto which node the Kiali pod will be deployed.
 #    ---
 #    node_selector: {}
-#
-# Because an ingress into a cluster can vary wildly in its desired configuration,
-# this setting provides a way to override complete portions of the ingress resource
-# configuration (Ingress on Kubernetes and Route on OpenShift). It is up to the user
-# to ensure this override YAML configuration is valid and supports the cluster environment
-# since the operator will blindly copy this custom configuration into the resource it
-# creates.
-# This setting is not used if deployment.ingress_enabled is set to 'false'.
-# Note that only 'metadata.annotations' and 'spec' is valid and only they will
-# be used to override those same sections in the created resource. You can define
-# either one or both.
-# Example:
-#   override_ingress_yaml:
-#     metadata:
-#       annotations:
-#         nginx.ingress.kubernetes.io/secure-backends: "true"
-#         nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-#     spec:
-#       rules:
-#       - http:
-#           paths:
-#           - path: /kiali
-#             backend:
-#               serviceName: kiali
-#               servicePort: 20001
-#    ---
-#    #override_ingress_yaml:
 #
 # Custom annotations to be created on the Kiali pod.
 #    ---

--- a/deploy/kiali/kiali_cr_dev_servicemesh.yaml
+++ b/deploy/kiali/kiali_cr_dev_servicemesh.yaml
@@ -14,7 +14,8 @@ spec:
     image_name: "${KIALI_IMAGE_NAME}"
     image_pull_policy: "${KIALI_IMAGE_PULL_POLICY}"
     image_version: "${KIALI_IMAGE_VERSION}"
-    ingress_enabled: true
+    ingress:
+      enabled: true
     namespace: "${NAMESPACE}"
     service_type: "${SERVICE_TYPE}"
     logger:

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -17,7 +17,7 @@
       - kiali_configmap.installation_tag == ""
       - kiali_configmap.additional_display_details | length == 1
       - kiali_configmap.custom_dashboards | length == 0
-      - kiali_configmap.deployment.ingress_enabled == True
+      - kiali_configmap.deployment.ingress.enabled == (True if is_openshift else False)
       - kiali_configmap.deployment.replicas == 1
       - kiali_configmap.deployment.secret_name == "kiali"
       - kiali_configmap.deployment.logger.log_format == "text"

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -34,7 +34,10 @@ spec:
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_pull_secrets: null
     image_version: "{{ kiali.image_version }}"
-    ingress_enabled: null
+    ingress:
+      class_name: null
+      enabled: null
+      override_yaml: null
     logger:
       log_format: null
       log_level: null
@@ -42,7 +45,6 @@ spec:
       time_field_format: null
     namespace: {{ kiali.install_namespace }}
     node_selector: null
-    override_ingress_yaml: null
     pod_annotations: null
     pod_labels: null
     priority_class_name: null

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -66,7 +66,10 @@ kiali_defaults:
     image_pull_policy: "IfNotPresent"
     image_pull_secrets: []
     image_version: ""
-    ingress_enabled: true
+    ingress:
+      class_name: "nginx"
+      #enabled:
+      #override_yaml:
     instance_name: "kiali"
     logger:
       log_format: "text"
@@ -75,7 +78,6 @@ kiali_defaults:
       time_field_format: "2006-01-02T15:04:05Z07:00"
     namespace: ""
     node_selector: {}
-    #override_ingress_yaml:
     pod_annotations: {}
     pod_labels: {}
     priority_class_name: ""

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -47,7 +47,7 @@
     loop_var: process_resource_item
   when:
   - is_k8s == True
-  - kiali_vars.deployment.ingress_enabled|bool == True
+  - kiali_vars.deployment.ingress.enabled|bool == True
 
 - name: Delete Ingress on Kubernetes if disabled
   k8s:
@@ -58,7 +58,7 @@
     name: "{{ kiali_vars.deployment.instance_name }}"
   when:
   - is_k8s == True
-  - kiali_vars.deployment.ingress_enabled|bool == False
+  - kiali_vars.deployment.ingress.enabled|bool == False
 
 - include_tasks: update-status-progress.yml
   vars:

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -139,14 +139,14 @@
   - kiali_vars.deployment.resources is defined
   - kiali_vars.deployment.resources | length > 0
 
-- name: Replace snake_case with camelCase in deployment.override_ingress_yaml
+- name: Replace snake_case with camelCase in deployment.ingress.override_yaml
   set_fact:
     kiali_vars: |
-      {% set a=kiali_vars['deployment'].pop('override_ingress_yaml') %}
-      {{ kiali_vars | combine({'deployment': {'override_ingress_yaml': current_cr.spec.deployment.override_ingress_yaml }}, recursive=True) }}
+      {% set a=kiali_vars['deployment']['ingress'].pop('override_yaml') %}
+      {{ kiali_vars | combine({'deployment': {'ingress': {'override_yaml': current_cr.spec.deployment.ingress.override_yaml }}}, recursive=True) }}
   when:
-  - kiali_vars.deployment.override_ingress_yaml is defined
-  - kiali_vars.deployment.override_ingress_yaml | length > 0
+  - kiali_vars.deployment.ingress.override_yaml is defined
+  - kiali_vars.deployment.ingress.override_yaml | length > 0
 
 - name: Replace snake_case with camelCase in deployment.pod_annotations
   set_fact:
@@ -343,6 +343,12 @@
 
 # Determine some more defaults.
 
+- name: Set default deployment.ingress.enabled based on cluster type (disable on k8s; enable on OpenShift)
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'ingress': {'enabled': true if is_openshift else false }}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.ingress.enabled is not defined or kiali_vars.deployment.ingress.enabled == ""
+
 - name: Set default tracing use_grpc setting
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'external_services': {'tracing': { 'use_grpc': False if is_maistra else True }}}, recursive=True) }}"
@@ -483,10 +489,10 @@
 # requires OAuth Client which requires a Route. So ingress must be enabled if strategy is openshift.
 - name: Ensure Ingress is Enabled if Auth Strategy is openshift
   fail:
-    msg: "The auth.strategy is 'openshift' which requires a Route, but deployment.ingress_enabled is false. Aborting."
+    msg: "The auth.strategy is 'openshift' which requires a Route, but deployment.ingress.enabled is false. Aborting."
   when:
   - kiali_vars.auth.strategy == "openshift"
-  - kiali_vars.deployment.ingress_enabled|bool == False
+  - kiali_vars.deployment.ingress.enabled|bool == False
 
 - name: Confirm the cluster can access github.com when it needs to determine the last release of Kiali
   uri:

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -48,7 +48,7 @@
     loop_var: process_resource_item
   when:
   - is_openshift == True
-  - kiali_vars.deployment.ingress_enabled|bool == True
+  - kiali_vars.deployment.ingress.enabled|bool == True
 
 - name: Delete Route on OpenShift if disabled
   k8s:
@@ -59,7 +59,7 @@
     name: "{{ kiali_vars.deployment.instance_name }}"
   when:
   - is_openshift == True
-  - kiali_vars.deployment.ingress_enabled|bool == False
+  - kiali_vars.deployment.ingress.enabled|bool == False
 
 - include_tasks: update-status-progress.yml
   vars:

--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
-{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
-  {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% else %}
   annotations:
     # For ingress-nginx versions older than 0.20.0
@@ -15,9 +15,12 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "{{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}"
 {% endif %}
 spec:
-{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.spec is defined %}
-  {{ kiali_vars.deployment.override_ingress_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.spec is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% else %}
+{% if kiali_vars.deployment.ingress.class_name != "" %}
+  ingressClassName: {{ kiali_vars.deployment.ingress.class_name }}
+{% endif %}
   rules:
   - http:
       paths:

--- a/roles/default/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/route.yaml
@@ -4,12 +4,12 @@ metadata:
   name: {{ kiali_vars.deployment.instance_name }}
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
-{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.metadata is defined and kiali_vars.deployment.override_ingress_yaml.metadata.annotations is defined %}
-  {{ kiali_vars.deployment.override_ingress_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% endif %}
 spec:
-{% if kiali_vars.deployment.override_ingress_yaml is defined and kiali_vars.deployment.override_ingress_yaml.spec is defined %}
-  {{ kiali_vars.deployment.override_ingress_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.spec is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
 {% else %}
   tls:
     termination: reencrypt


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4342
helm chart PR: https://github.com/kiali/helm-charts/pull/113
docs PR: https://github.com/kiali/kiali.io/pull/466

Please see the description of that helm chart PR for more details - we are changing the way the Ingress is configured and we are disabling the Ingress by default on non-OpenShift Kubernetes.

We will need to call these changes out in the release notes for the next release.