### PR TITLE
Add root namespace property into Kiali config map

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -579,6 +579,7 @@ spec:
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
 # istio_sidecar_injector_config_map_name: The name of the istio-sidecar-injector config map.
 # istiod_deployment_name: The name of the istiod deployment.
+# root_namespace: The namespace to treat as the administrative root namespace for Istio configuration.
 # url_service_version: The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.
 #    ---
 #    istio:
@@ -604,6 +605,7 @@ spec:
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
 #      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
 #      istiod_deployment_name: "istiod"
+#      root_namespace: ""
 #      url_service_version: ""
 #
 #

--- a/molecule/asserts/configmap_asserts.yml
+++ b/molecule/asserts/configmap_asserts.yml
@@ -18,12 +18,12 @@
 - name: Assert Kiali Configmap has the correct Istio Namespace
   assert:
     that:
-    - kiali_configmap.external_services.istio.root_namespace == istio.control_plane_namespace
+    - kiali_configmap.istio_namespace == istio.control_plane_namespace    
 
 - name: Assert Kiali Configmap has the correct Root Namespace
   assert:
     that:
-    - kiali_configmap.io_namespace == istio.control_plane_namespace    
+    - kiali_configmap.external_services.istio.root_namespace == istio.control_plane_namespace
 
 - name: Assert Kiali Configmap has the correct Prometheus Url for Upstream Istio installs
   assert:

--- a/molecule/asserts/configmap_asserts.yml
+++ b/molecule/asserts/configmap_asserts.yml
@@ -18,7 +18,12 @@
 - name: Assert Kiali Configmap has the correct Istio Namespace
   assert:
     that:
-    - kiali_configmap.istio_namespace == istio.control_plane_namespace
+    - kiali_configmap.external_services.istio.root_namespace == istio.control_plane_namespace
+
+- name: Assert Kiali Configmap has the correct Root Namespace
+  assert:
+    that:
+    - kiali_configmap.io_namespace == istio.control_plane_namespace    
 
 - name: Assert Kiali Configmap has the correct Prometheus Url for Upstream Istio installs
   assert:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -172,6 +172,7 @@ kiali_defaults:
       istio_sidecar_annotation: "sidecar.istio.io/status"
       istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
       istiod_deployment_name: "istiod"
+      root_namespace: ""
       url_service_version: ""
     prometheus:
       auth:

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -294,6 +294,12 @@
   when:
   - kiali_vars.istio_namespace == ""
 
+- name: Set default root namespace
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'external_services': {'istio': {'root_namespace': kiali_vars.istio_namespace}}}, recursive=True) }}"
+  when:
+  - kiali_vars.external_services.istio.root_namespace == ""
+
 - name: Set default Grafana in_cluster_url
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'external_services': {'grafana': {'in_cluster_url': 'http://grafana.' + kiali_vars.istio_namespace + ':3000'}}}, recursive=True) }}"


### PR DESCRIPTION
This PR adds a new property for Istio, the root namespace (https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/).

If it is not configured it defaults to the namespace where Kiali is installed (usually istio-system), same logic from istio_namespace property.