### PR TITLE
explicitly enable ingress in all molecule tests

### DIFF
--- a/molecule/accessible-namespaces-test/kiali-cr.yaml
+++ b/molecule/accessible-namespaces-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
+++ b/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/api-test/kiali-cr.yaml
+++ b/molecule/api-test/kiali-cr.yaml
@@ -11,6 +11,8 @@ spec:
   custom_dashboards:
   - name: go
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     accessible_namespaces: {{ kiali.accessible_namespaces }}

--- a/molecule/config-values-test/kiali-cr.yaml
+++ b/molecule/config-values-test/kiali-cr.yaml
@@ -7,6 +7,8 @@ spec:
   # this test will try to use as many defaults as we can
   istio_namespace: {{ istio.control_plane_namespace }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/default-namespace-test/kiali-cr.yaml
+++ b/molecule/default-namespace-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     # For this test, we do not define namespace.

--- a/molecule/grafana-test/kiali-cr.yaml
+++ b/molecule/grafana-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/header-auth-test/kiali-cr.yaml
+++ b/molecule/header-auth-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: header
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}

--- a/molecule/instance-name-test/kiali-cr.yaml
+++ b/molecule/instance-name-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/kiali-cr.yaml
+++ b/molecule/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/metrics-test/kiali-cr.yaml
+++ b/molecule/metrics-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -17,7 +17,6 @@
       - kiali_configmap.installation_tag == ""
       - kiali_configmap.additional_display_details | length == 1
       - kiali_configmap.custom_dashboards | length == 0
-      - kiali_configmap.deployment.ingress.enabled == (True if is_openshift else False)
       - kiali_configmap.deployment.replicas == 1
       - kiali_configmap.deployment.secret_name == "kiali"
       - kiali_configmap.deployment.logger.log_format == "text"

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -36,7 +36,7 @@ spec:
     image_version: "{{ kiali.image_version }}"
     ingress:
       class_name: null
-      enabled: null
+      enabled: true
       override_yaml: null
     logger:
       log_format: null

--- a/molecule/only-view-only-mode-test/kiali-cr.yaml
+++ b/molecule/only-view-only-mode-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -13,6 +13,8 @@ spec:
       issuer_uri: {{ openid.issuer_uri }}
       username_claim: {{ openid.username_claim }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}

--- a/molecule/openshift-auth-test/kiali-cr.yaml
+++ b/molecule/openshift-auth-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: openshift
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: trace
     accessible_namespaces: {{ kiali.accessible_namespaces }}

--- a/molecule/os-console-links-test/kiali-cr.yaml
+++ b/molecule/os-console-links-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/read-certs-secrets-test/kiali-cr.yaml
+++ b/molecule/read-certs-secrets-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/rolling-restart-test/kiali-cr.yaml
+++ b/molecule/rolling-restart-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}

--- a/molecule/token-test/kiali-cr.yaml
+++ b/molecule/token-test/kiali-cr.yaml
@@ -8,6 +8,8 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    ingress:
+      enabled: true
     logger:
       log_level: debug
     namespace: {{ kiali.install_namespace }}


### PR DESCRIPTION
The Ingress is no longer enabled by default on kubernetes clusters, and when testing via minikube we need the ingress for the tests to pass