### PR TITLE
[v1.36] only hide system namespaces that start with "kube-"

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -102,7 +102,7 @@ spec:
 #    namespaces:
 #      exclude:
 #      - "istio-operator"
-#      - "kube.*"
+#      - "kube-.*"
 #      - "openshift.*"
 #      - "ibm.*"
 #      - "kiali-operator"
@@ -189,7 +189,7 @@ spec:
 # Kiali to be given access to all namespaces via a single cluster role (if using this special value of "**",
 # you are required to have already granted the operator permissions to create cluster roles and cluster role bindings).
 #    ---
-#    accessible_namespaces: ["^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"]
+#    accessible_namespaces: ["^((?!(istio-operator|kube-.*|openshift.*|ibm.*|kiali-operator)).)*$"]
 #
 # Additional custom yaml to add to the service definition. This is used mainly to customize the service type.
 # For example, if the deployment.service_type is set to "LoadBalancer" and you want to set the loadBalancerIP,

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -21,7 +21,7 @@ kiali_defaults:
     namespaces:
       exclude:
       - "istio-operator"
-      - "kube.*"
+      - "kube-.*"
       - "openshift.*"
       - "ibm.*"
       - "kiali-operator"
@@ -50,7 +50,7 @@ kiali_defaults:
   custom_dashboards: []
 
   deployment:
-    accessible_namespaces: ["^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"]
+    accessible_namespaces: ["^((?!(istio-operator|kube-.*|openshift.*|ibm.*|kiali-operator)).)*$"]
     #additional_service_yaml:
     affinity:
       node: {}

--- a/roles/v1.36/kiali-deploy/defaults/main.yml
+++ b/roles/v1.36/kiali-deploy/defaults/main.yml
@@ -21,7 +21,7 @@ kiali_defaults:
     namespaces:
       exclude:
       - "istio-operator"
-      - "kube.*"
+      - "kube-.*"
       - "openshift.*"
       - "ibm.*"
       - "kiali-operator"
@@ -50,7 +50,7 @@ kiali_defaults:
   custom_dashboards: []
 
   deployment:
-    accessible_namespaces: ["^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"]
+    accessible_namespaces: ["^((?!(istio-operator|kube-.*|openshift.*|ibm.*|kiali-operator)).)*$"]
     #additional_service_yaml:
     affinity:
       node: {}


### PR DESCRIPTION
backport https://github.com/kiali/kiali-operator/pull/351
put changed in v1.36 playbook as well

part of https://github.com/kiali/kiali/issues/4162