### PR TITLE
fix 1.36 playbook to only hide kube- namespaces (not kube*)

### DIFF
--- a/roles/v1.36/kiali-deploy/defaults/main.yml
+++ b/roles/v1.36/kiali-deploy/defaults/main.yml
@@ -21,7 +21,7 @@ kiali_defaults:
     namespaces:
       exclude:
       - "istio-operator"
-      - "kube.*"
+      - "kube-.*"
       - "openshift.*"
       - "ibm.*"
       - "kiali-operator"
@@ -50,7 +50,7 @@ kiali_defaults:
   custom_dashboards: []
 
   deployment:
-    accessible_namespaces: ["^((?!(istio-operator|kube.*|openshift.*|ibm.*|kiali-operator)).)*$"]
+    accessible_namespaces: ["^((?!(istio-operator|kube-.*|openshift.*|ibm.*|kiali-operator)).)*$"]
     #additional_service_yaml:
     affinity:
       node: {}


### PR DESCRIPTION
part of https://github.com/kiali/kiali/issues/4162