### PR TITLE
Add configuration for IstioD pod monitoring port

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -610,6 +610,7 @@ spec:
 # istio_sidecar_annotation: The pod annotation used by Istio to identify the sidecar.
 # istio_sidecar_injector_config_map_name: The name of the istio-sidecar-injector config map.
 # istiod_deployment_name: The name of the istiod deployment.
+# istiod_pod_monitoring_port: The monitoring port of the IstioD pod (not the Service).
 # root_namespace: The namespace to treat as the administrative root namespace for Istio configuration.
 # url_service_version: The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint.
 #    ---
@@ -636,6 +637,7 @@ spec:
 #      istio_sidecar_annotation: "sidecar.istio.io/status"
 #      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
 #      istiod_deployment_name: "istiod"
+#      istiod_pod_monitoring_port: 15014
 #      root_namespace: ""
 #      url_service_version: ""
 #

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -175,6 +175,7 @@ kiali_defaults:
       istio_sidecar_annotation: "sidecar.istio.io/status"
       istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
       istiod_deployment_name: "istiod"
+      istiod_pod_monitoring_port: 15014
       root_namespace: ""
       url_service_version: ""
     prometheus:


### PR DESCRIPTION
Because sometimes people need to change the monitoring port on the IstioD pod when using host network mode.

Back-end PR: https://github.com/kiali/kiali/pull/4522
Related to kiali/kiali#4462