### PR TITLE
Enable ingress by default on dev CR

### DIFF
--- a/deploy/kiali/kiali_cr_dev.yaml
+++ b/deploy/kiali/kiali_cr_dev.yaml
@@ -22,6 +22,8 @@ spec:
     image_name: $KIALI_IMAGE_NAME
     image_pull_policy: $KIALI_IMAGE_PULL_POLICY
     image_version: $KIALI_IMAGE_VERSION
+    ingress:
+      enabled: true
     namespace: $NAMESPACE
     service_type: $SERVICE_TYPE
     logger:


### PR DESCRIPTION
Ingress used to be created by default but now must be explicitly added. It's useful having it for dev testing by default.