### PR TITLE
Ignore workload validation by default

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -373,8 +373,7 @@ spec:
       namespaces: ["istio-system"]
       refresh_interval: "15s"
     validations:
-      # default: ignore is an empty list
-      ignore: ["KIA0101"]
+      ignore: ["KIA1201"]
 
   kubernetes_config:
     burst: 200

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -269,7 +269,7 @@ kiali_defaults:
       namespaces: []
       refresh_interval: "15s"
     validations:
-      ignore: []
+      ignore: ["KIA1201"]
 
   kubernetes_config:
     burst: 200


### PR DESCRIPTION
Ignoring by default KIA1201 that relates to workload not covered by any auth policy. 

This is for [#4409](https://github.com/kiali/kiali/pull/4409).

The motivation for this is that is pretty common for some workloads to not have an Authorization Policy associated with them. So to avoid filling the UI with errors, we decided to make this validation optional.

![missing_ap_list](https://user-images.githubusercontent.com/1286393/145991421-b21087b2-fc9c-4b77-9c7d-ca01e2925a5d.png)

