### PR TITLE
Enforce specific lengths for signing key

### DIFF
--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1111,7 +1111,7 @@ spec:
                     description: "A user's login token expiration specified in seconds. This is applicable to token and header auth strategies only."
                     type: integer
                   signing_key:
-                    description: "The signing key used to generate tokens for user authentication. Because this is potentially sensitive, you have the option to store this value in a secret. If you store this signing key value in a secret, you must indicate what key in what secret by setting this value to a string in the form of `secret:<secretName>:<secretKey>`. If left as an empty string, a secret with a random signing key will be generated for you."
+                    description: "The signing key used to generate tokens for user authentication. Because this is potentially sensitive, you have the option to store this value in a secret. If you store this signing key value in a secret, you must indicate what key in what secret by setting this value to a string in the form of `secret:<secretName>:<secretKey>`. If left as an empty string, a secret with a random signing key will be generated for you. The signing key must be 16, 24 or 32 byte long."
                     type: string
 
               server:

--- a/molecule/config-values-test/converge.yml
+++ b/molecule/config-values-test/converge.yml
@@ -95,6 +95,10 @@
     set_fact:
       current_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'resources': {}}}}, recursive=True) }}"
 
+  - name: Set a signing key of 16 characters length
+    set_fact:
+      current_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'login_token': {'signing_key': 'qazxsw0123456789'}}}, recursive=True) }}"
+
   - name: The new Kiali CR to be tested
     debug:
       msg: "{{ current_kiali_cr }}"
@@ -173,3 +177,8 @@
       that:
       - kiali_configmap.deployment.resources | length == 0
       - kiali_pod_spec.containers[0].resources | length == 0
+
+  - name: Test the signing key is set
+    assert:
+      that:
+        - kiali_configmap.login_token.signing_key == 'qazxsw0123456789'

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -680,6 +680,19 @@
   # this regex is not 100% accurate, but we want to at least catch obvious errors
   - kiali_vars.api.namespaces.label_selector is not regex('^[a-zA-Z0-9/_.-]+=[a-zA-Z0-9_.-]+$')
 
+# If the signing key is not empty string, and is not of the special value secret:name:key,
+# do some validation on it's length
+- name: Validate signing key, if it is set in the CR
+  fail:
+    msg: "Signing key must be 16, 24 or 32 byte length"
+  when:
+    - kiali_vars.auth.strategy != 'anonymous'
+    - kiali_vars.login_token.signing_key != ""
+    - not(kiali_vars.login_token.signing_key | regex_search('secret:.+:.+'))
+    - kiali_vars.login_token.signing_key | length != 16
+    - kiali_vars.login_token.signing_key | length != 24
+    - kiali_vars.login_token.signing_key | length != 32
+
 # If the signing key is empty string, we need to ensure a signing key secret exists. If one does not exist, we need to generate one.
 # Note that to avoid granting to the operator the very powerful permission to CRUD all secrets in all namespaces, we always generate
 # a signing key secret with the name "kiali-signing-key" regardless of the value of kiali_vars.deployment.instance_name.


### PR DESCRIPTION
This is to support sessions with AES-GCM encryption.

Related to kiali/kiali#4542