### PR TITLE
fix source repo url to the kiali org repo

### DIFF
--- a/crd-docs/config/apigen-config.yaml
+++ b/crd-docs/config/apigen-config.yaml
@@ -1,7 +1,7 @@
 template_path: ./apigen-crd.template
 
 source_repositories:
-- url: https://github.com/jmazzitelli/kiali-operator
+- url: https://github.com/kiali/kiali-operator
   organization: kiali
   short_name: kiali-operator
   commit_reference: master


### PR DESCRIPTION
I knew I was going to screw this up :) This fixes https://github.com/kiali/kiali-operator/pull/470