### PR TITLE
fix molecule test - use the new observability section

### DIFF
--- a/deploy/kiali/kiali_cr.yaml
+++ b/deploy/kiali/kiali_cr.yaml
@@ -1016,14 +1016,16 @@ spec:
 #    ---
 #    gzip_enabled: true
 #
-# When true, the metrics endpoint will be available for Prometheus to scrape.
+# Observability section defines how you can observe Kiali itself. Metrics section defines how Prometheus
+# is to scrape the Kiali endpoint. Tracing defines how Kiali emits its own tracing data.
 #    ---
-#    metrics_enabled: true
-#
-# The port that the server will bind to in order to receive metric requests.
-# This is the port Prometheus will need to scrape when collecting metrics from Kiali.
-#    ---
-#    metrics_port: 9090
+#    observability:
+#      metrics:
+#        enabled: true
+#        port: 9090
+#      tracing:
+#        collector_url: "http://jaeger-collector.istio-system:14268/api/traces"
+#        enabled: false
 #
 # The port that the server will bind to in order to receive console and API requests.
 #    ---

--- a/molecule/metrics-test/enable-metrics.yml
+++ b/molecule/metrics-test/enable-metrics.yml
@@ -5,6 +5,6 @@
   vars:
     current_kiali_cr: "{{ kiali_cr_list.resources[0] }}"
   set_fact:
-    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'server': {'metrics_enabled': true }}}, recursive=True) }}"
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'server': {'observability': {'metrics': {'enabled': true }}}}}, recursive=True) }}"
 
 - import_tasks: ../common/set_kiali_cr.yml

--- a/molecule/metrics-test/kiali-cr.yaml
+++ b/molecule/metrics-test/kiali-cr.yaml
@@ -20,4 +20,6 @@ spec:
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   server:
     # start the test off with metrics disabled
-    metrics_enabled: false
+    observability:
+      metrics:
+        enabled: false

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -39,4 +39,6 @@
       - kiali_configmap.kubernetes_config.burst == 200
       - kiali_configmap.kubernetes_config.excluded_workloads | length > 0
       - kiali_configmap.login_token.signing_key | length > 0
-      - kiali_configmap.server.metrics_port == 9090
+      - kiali_configmap.server.observability.metrics.port == 9090
+      - kiali_configmap.server.observability.metrics.enabled == true
+      - kiali_configmap.server.observability.tracing.enabled == false

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -137,8 +137,13 @@ spec:
     audit_log: null
     cors_allow_all: null
     gzip_enabled: null
-    metrics_enabled: null
-    metrics_port: null
+    observability:
+      metrics:
+        enabled: null
+        port: null
+      tracing:
+        collector_url: null
+        enabled: null
     port: null
     web_fqdn: null
     web_history_mode: null


### PR DESCRIPTION
The null-cr-values-test molecule test broke due to https://github.com/kiali/kiali/pull/4532
This PR fixes the test, also updates example CR.
This also fixes the metrics-test which also fails due to the new observability section.

How to test this PR:

```
hack/run-molecule-tests.sh --cluster-type minikube --client-exe $(which kubectl) -at "null-cr-values-test"
```

should result in:

```
=====================
=== TEST RESULTS: ===
=====================

                     null-cr-values-test... success [2m 6s]
```

You should also see if the metrics-test is fixed, too;

```
hack/run-molecule-tests.sh --cluster-type minikube --client-exe $(which kubectl) -at "metrics-test"
```

should result in:

```
=====================
=== TEST RESULTS: ===
=====================

                            metrics-test... success [8m 49s]
```

I tried these tests on both minikube and openshift and all pass for me.