### PR TITLE
add status to crd schema

### DIFF
--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -20,6 +20,10 @@ spec:
       openAPIV3Schema:
         type: object
         properties:
+          status:
+            description: "The processing status of this CR as reported by the Kiali operator."
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
           spec:
             description: "This is the CRD for the resources called Kiali CRs. The Kiali Operator will watch for resources of this type and when it detects a Kiali CR has been added, deleted, or modified, it will install, uninstall, and update the associated Kiali Server installation. The settings here will configure the Kiali Server as well as the Kiali Operator. All of these settings will be stored in the Kiali ConfigMap. Do not modify the ConfigMap; it will be managed by the Kiali Operator. Only modify the Kiali CR when you want to change a configuration setting."
             type: object


### PR DESCRIPTION
When validating existing Kiali CR objects that have been reconciled by the Kiali operator, they will have a `status` field added to them - we need to add this status field to the schema. Otherwise, this will result:

```
error: error validating "STDIN": error validating data: ValidationError(TestKiali): unknown field
"status" in io.kiali.v1alpha1.TestKiali; if you choose to ignore these errors, turn
validation off with --validate=false
```

To test: install a Kiali CR and have the operator process/reconcile it (i.e. install Kiali server). Then validate the existing CR (this assumes the Kiali CR named `kiali` is in the namespace `kiali-operator` - change these values according to your set up):

```
./crd-docs/bin/validate-kiali-cr.sh -kcn kiali -n kiali-operator
```

This should succeed with the validation. You should see this:

```
Kiali CR [kiali] in namespace [kiali-operator] is valid.
```