### PR TITLE
Support being able to reliably load dev images from the internal OpenShift image registry

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -100,6 +100,8 @@
       - "--set"
       - "image.pullPolicy={{ kiali.operator_image_pull_policy }}"
       - "--set"
+      - "image.pullSecrets={{ '{' + lookup('env', 'OPERATOR_IMAGE_PULL_SECRET_NAME') + '}' }}"
+      - "--set"
       - "watchNamespace={{ kiali.operator_watch_namespace }}"
       - "--set"
       - "clusterRoleCreator={{ kiali.operator_cluster_role_creator | default('true') }}"


### PR DESCRIPTION
This is for when running molecule tests and you want to test with dev images that are pushed directly into the OpenShift internal registry.

Requires kiali repo changes that go with this.

fixes: https://github.com/kiali/kiali/issues/4691