### PR TITLE
Fix molecule test because of the OIDC auth refactor

### DIFF
--- a/molecule/openid-test/converge.yml
+++ b/molecule/openid-test/converge.yml
@@ -167,7 +167,7 @@
     register: kiali_output
 
   - set_fact:
-      new_kiali_cookie: "{{ kiali_output.set_cookie | regex_replace('.*(kiali-token=[^;]+).*', '\\1') }}"
+      new_kiali_cookie: "{{ kiali_output.set_cookie | regex_replace('.*(kiali-token-aes=[^;]+).*', '\\1') }}"
 
   - name: With the updated login cookie, make a request that requires authentication (should now return 200)
     uri:


### PR DESCRIPTION
Now, OIDC is always using encrypted cookies. Molecules should now look for the encrypted kiali-token-aes cookie, rather than the JWT kiali-token cookie when validating credentials.

Related to kiali/kiali#4669