### PR TITLE
api.namespaces.exclude defaults should have "starts with" regexes

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -19,11 +19,11 @@ spec:
   api:
     namespaces:
       exclude:
-      - "istio-operator"
-      - "kube-.*"
-      - "openshift.*"
-      - "ibm.*"
-      - "kiali-operator"
+      - "^istio-operator"
+      - "^kube-.*"
+      - "^openshift.*"
+      - "^ibm.*"
+      - "^kiali-operator"
       # default: label_selector is undefined
       label_selector: "kiali.io/member-of=istio-system"
 

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -20,11 +20,11 @@ kiali_defaults:
   api:
     namespaces:
       exclude:
-      - "istio-operator"
-      - "kube-.*"
-      - "openshift.*"
-      - "ibm.*"
-      - "kiali-operator"
+      - "^istio-operator"
+      - "^kube-.*"
+      - "^openshift.*"
+      - "^ibm.*"
+      - "^kiali-operator"
       #label_selector:
 
   auth:


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4714