### PR TITLE
upstream added this max-k8s-version annotation - put it in our golden copies

### DIFF
--- a/manifests/kiali-upstream/0.18.1/manifests/kiali.v0.18.1.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/0.18.1/manifests/kiali.v0.18.1.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v0.18.1
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v0.18.1

--- a/manifests/kiali-upstream/1.1.0/manifests/kiali.v1.1.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.1.0/manifests/kiali.v1.1.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.1.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.1.0

--- a/manifests/kiali-upstream/1.10.0/manifests/kiali.v1.10.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.10.0/manifests/kiali.v1.10.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.10.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.10.0

--- a/manifests/kiali-upstream/1.11.0/manifests/kiali.v1.11.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.11.0/manifests/kiali.v1.11.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.11.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.11.0

--- a/manifests/kiali-upstream/1.13.0/manifests/kiali.v1.13.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.13.0/manifests/kiali.v1.13.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.13.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.13.0

--- a/manifests/kiali-upstream/1.15.1/manifests/kiali.v1.15.1.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.15.1/manifests/kiali.v1.15.1.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.15.1
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.15.1

--- a/manifests/kiali-upstream/1.19.0/manifests/kiali.v1.19.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.19.0/manifests/kiali.v1.19.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.19.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.19.0

--- a/manifests/kiali-upstream/1.22.0/manifests/kiali.v1.22.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.22.0/manifests/kiali.v1.22.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.22.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.22.0

--- a/manifests/kiali-upstream/1.24.0/manifests/kiali.v1.24.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.24.0/manifests/kiali.v1.24.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.24.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.24.0

--- a/manifests/kiali-upstream/1.25.0/manifests/kiali.v1.25.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.25.0/manifests/kiali.v1.25.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.25.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.25.0

--- a/manifests/kiali-upstream/1.26.0/manifests/kiali.v1.26.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.26.0/manifests/kiali.v1.26.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.26.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.26.0

--- a/manifests/kiali-upstream/1.27.0/manifests/kiali.v1.27.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.27.0/manifests/kiali.v1.27.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.27.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.27.0

--- a/manifests/kiali-upstream/1.28.0/manifests/kiali.v1.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.28.0/manifests/kiali.v1.28.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.28.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.28.0

--- a/manifests/kiali-upstream/1.29.0/manifests/kiali.v1.29.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.29.0/manifests/kiali.v1.29.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.29.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.29.0

--- a/manifests/kiali-upstream/1.3.1/manifests/kiali.v1.3.1.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.3.1/manifests/kiali.v1.3.1.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.3.1
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.3.1

--- a/manifests/kiali-upstream/1.4.2/manifests/kiali.v1.4.2.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.4.2/manifests/kiali.v1.4.2.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.4.2
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.4.2

--- a/manifests/kiali-upstream/1.6.1/manifests/kiali.v1.6.1.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.6.1/manifests/kiali.v1.6.1.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.6.1
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.6.1

--- a/manifests/kiali-upstream/1.7.0/manifests/kiali.v1.7.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.7.0/manifests/kiali.v1.7.0.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.7.0
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.7.0

--- a/manifests/kiali-upstream/1.9.1/manifests/kiali.v1.9.1.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.9.1/manifests/kiali.v1.9.1.clusterserviceversion.yaml
@@ -4,6 +4,12 @@ metadata:
   name: kiali-operator.v1.9.1
   namespace: placeholder
   annotations:
+    # Setting operatorhub.io/ui-metadata-max-k8s-version annotation automatically
+    # The following is an informative annotation to let its users know that this distribution
+    # uses removed APIs in 1.22 and will not work on K8S clusters 1.22+.
+    # Following the findings for this distribution:
+    # this bundle is using APIs which were deprecated and removed in v1.22. More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22. Migrate the API(s) for CRD: (["kialis.kiali.io" "monitoringdashboards.monitoring.kiali.io"])
+    operatorhub.io/ui-metadata-max-k8s-version: "1.21"
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: quay.io/kiali/kiali-operator:v1.9.1


### PR DESCRIPTION
Upstream changed our metadata files. We need to pull them down into our golden copies.

These are the commits they did to us: 
* https://github.com/k8s-operatorhub/community-operators/commit/b747f9ea8db5cf4f59cbfdc91f1ef47445e28a19#diff-d18a40e1176c47e12866e4fa1f2c8622ed74ac2f6f877b7061596559f0fc1c92
* https://github.com/k8s-operatorhub/community-operators/commit/404e320db0f135a4b4384991934826944c30cc54#diff-d18a40e1176c47e12866e4fa1f2c8622ed74ac2f6f877b7061596559f0fc1c92

This PR moves those changes into our golden copies so we avoid conflicts like what happened [here](https://github.com/k8s-operatorhub/community-operators/pull/720).