### PR TITLE
[v1.36] Add skipRange to kiali-ossm CSV.

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -8,6 +8,7 @@ metadata:
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
   annotations:
+    olm.skipRange: '>=1.0.0 <${KIALI_OPERATOR_VERSION}'
     categories: Monitoring,Logging & Tracing
     certified: "false"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8-operator:${KIALI_OPERATOR_VERSION}


### PR DESCRIPTION
This is backporting the kiali-ossm manifest change found in https://github.com/kiali/kiali-operator/pull/492

This is going to help customers that are in a disconnected environment - they will not have to upgrade all the individual operator versions.

There needs to be some discussion before deciding to merge this. We may decide to hold off from doing this (in which case, just close this PR without merging).