### PR TITLE
Add new query_scope support to prom config

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -202,6 +202,10 @@ spec:
           customHeader1: "customHeader1Value"
         health_check_url: ""
         is_core: true
+        # default: query_scope is empty
+        query_scope:
+          mesh_id: "mesh-1"
+          cluster: "cluster-east"
         thanos_proxy:
           enabled: false
           retention_period: "7d"
@@ -279,6 +283,10 @@ spec:
         customHeader1: "customHeader1Value"
       health_check_url: ""
       is_core: true
+      # default: query_scope is empty
+      query_scope:
+        mesh_id: "mesh-1"
+        cluster: "cluster-east"
       thanos_proxy:
         enabled: false
         retention_period: "7d"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -583,6 +583,10 @@ spec:
                           is_core:
                             description: "Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning."
                             type: boolean
+                          query_scope:
+                            description: "A set of labelName/labelValue settings applied to every Prometheus query. Used to narrow unified metrics to only those scoped to the Kiali instance."
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
                           thanos_proxy:
                             description: "Define this section if Prometheus is to be queried through a Thanos proxy. Kiali will still use the `url` setting to query for Prometheus metrics so make sure that is set appropriately."
                             type: object
@@ -784,6 +788,10 @@ spec:
                       is_core:
                         description: "Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning."
                         type: boolean
+                      query_scope:
+                        description: "A set of labelName/labelValue settings applied to every Prometheus query. Used to narrow unified metrics to only those scoped to the Kiali instance."
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       thanos_proxy:
                         description: "Define this section if Prometheus is to be queried through a Thanos proxy. Kiali will still use the `url` setting to query for Prometheus metrics so make sure that is set appropriately."
                         type: object

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -28,10 +28,12 @@
       - kiali_configmap.deployment.resources.requests.memory == "64Mi"
       - kiali_configmap.deployment.resources.limits.memory == "1Gi"
       - kiali_configmap.external_services.custom_dashboards.prometheus.custom_headers | length == 0
+      - kiali_configmap.external_services.custom_dashboards.prometheus.query_scope | length == 0
       - kiali_configmap.external_services.istio.istio_identity_domain == "svc.cluster.local"
       - kiali_configmap.external_services.istio.istio_sidecar_annotation == "sidecar.istio.io/status"
       - kiali_configmap.external_services.prometheus.url != ""
       - kiali_configmap.external_services.prometheus.custom_headers | length == 0
+      - kiali_configmap.external_services.prometheus.query_scope | length == 0
       - kiali_configmap.identity.cert_file is defined
       - kiali_configmap.identity.private_key_file is defined
       - kiali_configmap.istio_labels.app_label_name == "app"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -114,6 +114,7 @@ kiali_defaults:
         custom_headers: {}
         health_check_url: ""
         is_core: true
+        query_scope: {}
         thanos_proxy:
           enabled: false
           retention_period: "7d"
@@ -190,6 +191,7 @@ kiali_defaults:
       custom_headers: {}
       health_check_url: ""
       is_core: true
+      query_scope: {}
       thanos_proxy:
         enabled: false
         retention_period: "7d"

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -215,6 +215,15 @@
   - kiali_vars.external_services.custom_dashboards.prometheus.custom_headers is defined
   - kiali_vars.external_services.custom_dashboards.prometheus.custom_headers | length > 0
 
+- name: Replace snake_case with camelCase in external_services.custom_dashboards.prometheus.query_scope
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['external_services']['custom_dashboards']['prometheus'].pop('query_scope') %}
+      {{ kiali_vars | combine({'external_services': {'custom_dashboards': {'prometheus': {'query_scope': current_cr.spec.external_services.custom_dashboards.prometheus.query_scope }}}}, recursive=True) }}
+  when:
+  - kiali_vars.external_services.custom_dashboards.prometheus.query_scope is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus.query_scope | length > 0
+
 - name: Replace snake_case with camelCase in external_services.prometheus.custom_headers
   set_fact:
     kiali_vars: |
@@ -223,6 +232,15 @@
   when:
   - kiali_vars.external_services.prometheus.custom_headers is defined
   - kiali_vars.external_services.prometheus.custom_headers | length > 0
+
+- name: Replace snake_case with camelCase in external_services.prometheus.query_scope
+  set_fact:
+    kiali_vars: |
+      {% set a=kiali_vars['external_services']['prometheus'].pop('query_scope') %}
+      {{ kiali_vars | combine({'external_services': {'prometheus': {'query_scope': current_cr.spec.external_services.prometheus.query_scope }}}, recursive=True) }}
+  when:
+  - kiali_vars.external_services.prometheus.query_scope is defined
+  - kiali_vars.external_services.prometheus.query_scope | length > 0
 
 - name: Print some debug information
   vars:


### PR DESCRIPTION
PartOf https://github.com/kiali/kiali/issues/4664

This depends on server PR https://github.com/kiali/kiali/pull/473

@Xunzhuo , this is another PR required for the issue.   You should link it to your server PR and also add the "requires operator pr" to the server pr.