### PR TITLE
Get custom_secrets to work with identity settings

### DIFF
--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -258,10 +258,10 @@ spec:
                       type: object
                       properties:
                         name:
-                          description: "The name of the secret that is to be mounted to the Kiali pod's file system."
+                          description: "The name of the secret that is to be mounted to the Kiali pod's file system. The name of the custom secret must not be the same name as one created by the operator. Names such as `kiali`, `kiali-cert-secret`, and `kiali-cabundle` should not be used as a custom secret name because the operator may want to create one with one of those names."
                           type: string
                         mount:
-                          description: "The file path location where the secret content will be mounted."
+                          description: "The file path location where the secret content will be mounted. The custom secret cannot be mounted on a path that the operator will use to mount its secrets. Make sure you set your custom secret mount path to a unique, unused path. Paths such as `/kiali-configuration`, `/kiali-cert`, `/kiali-cabundle`, and `/kiali-secret` should not be used as mount paths for custom secrets because the operator may want to use one of those paths."
                           type: string
                         optional:
                           description: "Indicates if the secret may or may not exist at the time the Kiali pod starts. This will default to 'false' if not specified."

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -408,12 +408,12 @@
   - kiali_vars.server.web_history_mode != 'browser'
   - kiali_vars.server.web_history_mode != 'hash'
 
-- name: Set default identity cert_file based on cluster type
+- name: Set default identity cert_file based on cluster type (non-OpenShift clusters do not get a default identity)
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'identity': {'cert_file': '/kiali-cert/tls.crt' if is_openshift else ''}}, recursive=True) }}"
   when:
   - kiali_vars.identity.cert_file is not defined
-- name: Set default identity private_key_file based on cluster type
+- name: Set default identity private_key_file based on cluster type (non-OpenShift clusters do not get a default identity)
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'identity': {'private_key_file': '/kiali-cert/tls.key' if is_openshift else ''}}, recursive=True) }}"
   when:

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -104,8 +104,6 @@ spec:
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
-        - name: kiali-cert
-          mountPath: "/kiali-cert"
         - name: kiali-secret
           mountPath: "/kiali-secret"
         - name: kiali-cabundle
@@ -124,12 +122,6 @@ spec:
       - name: kiali-configuration
         configMap:
           name: {{ kiali_vars.deployment.instance_name }}
-      - name: kiali-cert
-        secret:
-          secretName: "istio.{{ kiali_vars.deployment.instance_name }}-service-account"
-{% if kiali_vars.identity.cert_file == "" %}
-          optional: true
-{% endif %}
       - name: kiali-secret
         secret:
           secretName: {{ kiali_vars.deployment.secret_name }}
@@ -142,7 +134,9 @@ spec:
       - name: {{ secret.name }}
         secret:
           secretName: {{ secret.name }}
+{% if secret.optional is defined %}
           optional: {{ secret.optional }}
+{% endif %}
 {% endfor %}
 {% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
       affinity:

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -104,8 +104,10 @@ spec:
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
+{% if kiali_vars.identity.cert_file == "/kiali-cert/tls.crt" %}
         - name: kiali-cert
           mountPath: "/kiali-cert"
+{% endif %}
         - name: kiali-secret
           mountPath: "/kiali-secret"
         - name: kiali-cabundle
@@ -124,11 +126,10 @@ spec:
       - name: kiali-configuration
         configMap:
           name: {{ kiali_vars.deployment.instance_name }}
+{% if kiali_vars.identity.cert_file == "/kiali-cert/tls.crt" %}
       - name: kiali-cert
         secret:
           secretName: {{ kiali_vars.deployment.instance_name }}-cert-secret
-{% if kiali_vars.identity.cert_file == "" %}
-          optional: true
 {% endif %}
       - name: kiali-secret
         secret:
@@ -141,7 +142,9 @@ spec:
       - name: {{ secret.name }}
         secret:
           secretName: {{ secret.name }}
+{% if secret.optional is defined %}
           optional: {{ secret.optional }}
+{% endif %}
 {% endfor %}
 {% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
       affinity:


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/4761

When creating a custom secret for Kiali identity, make sure this doesn't conflict with other secrets the operator creates