### PR TITLE
update the operator base image for each release

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,6 +2,10 @@ ARG OPERATOR_BASE_IMAGE_VERSION
 ARG OPERATOR_BASE_IMAGE_REPO
 FROM ${OPERATOR_BASE_IMAGE_REPO}:${OPERATOR_BASE_IMAGE_VERSION}
 
+USER root
+RUN yum update -y && yum clean all
+USER ${USER_UID}
+
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
 COPY watches.yaml ${HOME}/watches.yaml


### PR DESCRIPTION
Note that this is updating that's updating everything **In the base image**; the libraries and executables.

  This should pick up base image CVE fixes, which is the reason for the change.