### PR TITLE
Add a new CR setting.

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -437,6 +437,7 @@ spec:
         collector_url: "http://jaeger-collector.istio-system:14268/api/traces"
         enabled: false
     port: 20001
+    redirect_path: ""
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1178,6 +1178,9 @@ spec:
                   port:
                     description: "The port that the server will bind to in order to receive console and API requests."
                     type: integer
+                  redirect_path:
+                    description: "Defines the path where the Kiali UI is accessible to external browsers. This setting is mainly to support proxies that are in front of Kiali. It will enable browsers to be redirected to the proxy path that provides access to the Kiali UI. This setting is ignored if it is not set or is an empty string. Note that the `web_root` setting is still used to determine things like the root context path for liveness and readiness probes"
+                    type: string  
                   web_fqdn:
                     description: "Defines the public domain where Kiali is being served. This is the 'domain' part of the URL (usually it's a fully-qualified domain name). For example, `kiali.example.org`. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup."
                     type: string

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -319,6 +319,7 @@ kiali_defaults:
         collector_url: http://jaeger-collector.istio-system:14268/api/traces
         enabled: false
     port: 20001
+    redirect_path: ""
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""


### PR DESCRIPTION
Adding a new config which can be used as in-memory replace in env.js file and using `server.web_root` as default if the value of new config is not specified.

Liked issue:
https://github.com/kiali/kiali/issues/4459

**Linked PRs:**
kiali: https://github.com/kiali/kiali/pull/4914
helm-charts: https://github.com/kiali/helm-charts/pull/131