### PR TITLE
upticking image to fix vulnerability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ OPERATOR_QUAY_TAG ?= ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
 DORP ?= docker
 
 # The version of the SDK this Makefile will download if needed, and the corresponding base image
-OPERATOR_SDK_VERSION ?= 1.10.1
+OPERATOR_SDK_VERSION ?= 1.18.0
 OPERATOR_BASE_IMAGE_VERSION ?= v${OPERATOR_SDK_VERSION}
 OPERATOR_BASE_IMAGE_REPO ?= quay.io/operator-framework/ansible-operator
 # These are what we really want - but origin-ansible-operator does not support multiarch today.


### PR DESCRIPTION
Present base image contains following vulnerability https://access.redhat.com/errata/RHSA-2021:4358 which is not present in 1.18.0 version.