### PR TITLE
fix typo in description doc

### DIFF
--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -506,7 +506,7 @@ spec:
               external_services:
                 description: |
                   These external service configuration settings define how to connect to the external services
-                  like Prometheus, Grafana, and Jaoeger.
+                  like Prometheus, Grafana, and Jaeger.
 
                   Regarding sensitive values in the external_services 'auth' sections:
                   Some external services configured below support an 'auth' sub-section in order to tell Kiali


### PR DESCRIPTION
Someone wanted to fix this but edited the wrong file. See https://github.com/kiali/kiali.io/pull/522

This fixes the typo correctly.