### PR TITLE
add 1.50.0 olm metadata

### DIFF
--- a/manifests/kiali-community/1.50.0/bundle.Dockerfile
+++ b/manifests/kiali-community/1.50.0/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=kiali
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/manifests/kiali-community/1.50.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-community/1.50.0/manifests/kiali.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-community/1.50.0/manifests/kiali.v1.50.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.50.0/manifests/kiali.v1.50.0.clusterserviceversion.yaml
@@ -1,0 +1,536 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.50.0
+  namespace: placeholder
+  annotations:
+    olm.skipRange: '>=1.0.0 <1.50.0'
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.50.0
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2022-04-29T15:25:09Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "istio-system",
+              "view_only_mode": false
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        }
+      ]
+spec:
+  version: 1.50.0
+  maturity: stable
+  replaces: kiali-operator.v1.49.0
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    The Kiali operator can expose the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see
+    [the kiali.io docs](https://kiali.io/docs/configuration/kialis.kiali.io/).
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio.
+    If you already have Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the installed Kiali first.
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `token`.
+
+    If you wish to use the `openid` authentication strategy, you must have an
+    OpenID Connect available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Installation Guide
+    url: https://www.kiali.io/docs/installation
+  - name: Features
+    url: https://www.kiali.io/docs/features
+  - name: Documentation Home
+    url: https://www.kiali.io
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  - name: Operator Source Code
+    url: https://github.com/kiali/kiali-operator
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                # required for the operator SDK metric service selector
+                name: kiali-operator
+                version: v1.50.0
+                app.kubernetes.io/name: kiali-operator
+                app.kubernetes.io/version: v1.50.0
+                app.kubernetes.io/part-of: kiali-operator
+              annotations:
+                prometheus.io/scrape: "true"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.50.0
+                imagePullPolicy: "IfNotPresent"
+                args:
+                - "--zap-log-level=info"
+                - "--leader-election-id=kiali-operator"
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  runAsNonRoot: true
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_KIALI_NAMESPACE
+                  value: "false"
+                - name: ALLOW_AD_HOC_KIALI_IMAGE
+                  value: "false"
+                - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
+                  value: "100"
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
+                  value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
+                ports:
+                - name: http-metrics
+                  containerPort: 8080
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - pods
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups: [""]
+          resourceNames:
+          - cacerts
+          - istio-ca-secret
+          resources:
+          - secrets
+          verbs:
+          - get
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["authorization.k8s.io"]
+          resources:
+          - selfsubjectaccessreviews
+          verbs:
+          - list
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "networking.k8s.io"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - pods/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          - pods
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - create
+          - post
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - config.istio.io
+          - networking.istio.io
+          - authentication.istio.io
+          - rbac.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["authentication.k8s.io"]
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        serviceAccountName: kiali-operator

--- a/manifests/kiali-community/1.50.0/metadata/annotations.yaml
+++ b/manifests/kiali-community/1.50.0/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kiali

--- a/manifests/kiali-upstream/1.50.0/bundle.Dockerfile
+++ b/manifests/kiali-upstream/1.50.0/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=kiali
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/manifests/kiali-upstream/1.50.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/1.50.0/manifests/kiali.crd.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kialis.kiali.io
+  labels:
+    app: kiali-operator
+spec:
+  group: kiali.io
+  names:
+    kind: Kiali
+    listKind: KialiList
+    plural: kialis
+    singular: kiali
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/manifests/kiali-upstream/1.50.0/manifests/kiali.v1.50.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.50.0/manifests/kiali.v1.50.0.clusterserviceversion.yaml
@@ -1,0 +1,536 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: kiali-operator.v1.50.0
+  namespace: placeholder
+  annotations:
+    olm.skipRange: '>=1.0.0 <1.50.0'
+    categories: Monitoring,Logging & Tracing
+    certified: "false"
+    containerImage: quay.io/kiali/kiali-operator:v1.50.0
+    capabilities: Deep Insights
+    support: Kiali
+    description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
+    repository: https://github.com/kiali/kiali
+    createdAt: 2022-04-29T15:25:13Z
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "kiali.io/v1alpha1",
+          "kind": "Kiali",
+          "metadata": {
+            "name": "kiali"
+          },
+          "spec": {
+            "installation_tag": "My Kiali",
+            "istio_namespace": "istio-system",
+            "deployment": {
+              "namespace": "default",
+              "view_only_mode": false
+            },
+            "server": {
+              "web_root": "/mykiali"
+            }
+          }
+        }
+      ]
+spec:
+  version: 1.50.0
+  maturity: stable
+  replaces: kiali-operator.v1.49.0
+  displayName: Kiali Operator
+  description: |-
+    ## About the managed application
+
+    A Microservice Architecture breaks up the monolith into many smaller pieces
+    that are composed together. Patterns to secure the communication between
+    services like fault tolerance (via timeout, retry, circuit breaking, etc.)
+    have come up as well as distributed tracing to be able to see where calls
+    are going.
+
+    A service mesh can now provide these services on a platform level and frees
+    the application writers from those tasks. Routing decisions are done at the
+    mesh level.
+
+    Kiali works with Istio, in OpenShift or Kubernetes, to visualize the service
+    mesh topology, to provide visibility into features like circuit breakers,
+    request rates and more. It offers insights about the mesh components at
+    different levels, from abstract Applications to Services and Workloads.
+
+    See [https://www.kiali.io](https://www.kiali.io) to read more.
+
+    ### Accessing the UI
+
+    The Kiali operator can expose the Kiali UI as a Route on OpenShift
+    or Ingress on Kubernetes.
+
+    On OpenShift, the default root context path is '/' and on Kubernetes it is
+    '/kiali' though you can change this by configuring the 'web_root' setting in
+    the Kiali CR.
+
+    ## About this Operator
+
+    ### Kiali Custom Resource Configuration Settings
+
+    For quick descriptions of all the settings you can configure in the Kiali
+    Custom Resource (CR), see
+    [the kiali.io docs](https://kiali.io/docs/configuration/kialis.kiali.io/).
+
+    Note that the Kiali operator can be told to restrict Kiali's access to
+    specific namespaces, or can provide to Kiali cluster-wide access to all
+    namespaces.
+
+    ## Prerequisites for enabling this Operator
+
+    Today Kiali works with Istio. So before you install Kiali, you must have
+    already installed Istio.
+    If you already have Kiali in your Istio environment and you want to
+    install Kiali via the Kiali Operator, uninstall the installed Kiali first.
+
+    When you install Kiali in a non-OpenShift Kubernetes environment, the
+    authentication strategy will default to `token`.
+
+    If you wish to use the `openid` authentication strategy, you must have an
+    OpenID Connect available and accessible to Kiali.
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+    mediatype: image/svg+xml
+  keywords: ['service-mesh', 'observability', 'monitoring', 'maistra', 'istio']
+  maintainers:
+  - name: Kiali Developers Google Group
+    email: kiali-dev@googlegroups.com
+  provider:
+    name: Kiali
+  labels:
+    name: kiali-operator
+  selector:
+    matchLabels:
+      name: kiali-operator
+  links:
+  - name: Installation Guide
+    url: https://www.kiali.io/docs/installation
+  - name: Features
+    url: https://www.kiali.io/docs/features
+  - name: Documentation Home
+    url: https://www.kiali.io
+  - name: Blogs and Articles
+    url: https://medium.com/kialiproject
+  - name: Server Source Code
+    url: https://github.com/kiali/kiali
+  - name: UI Source Code
+    url: https://github.com/kiali/kiali-ui
+  - name: Operator Source Code
+    url: https://github.com/kiali/kiali-operator
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  customresourcedefinitions:
+    owned:
+    - name: kialis.kiali.io
+      group: kiali.io
+      description: A configuration file for a Kiali installation.
+      displayName: Kiali
+      kind: Kiali
+      version: v1alpha1
+      resources:
+      - kind: Deployment
+        version: apps/v1
+      - kind: Pod
+        version: v1
+      - kind: Service
+        version: v1
+      - kind: ConfigMap
+        version: v1
+      - kind: OAuthClient
+        version: oauth.openshift.io/v1
+      - kind: Route
+        version: route.openshift.io/v1
+      specDescriptors:
+      - displayName: Authentication Strategy
+        description: "Determines how a user is to log into Kiali. Default: openshift (when deployed in OpenShift); token (when deployed in other Kubernetes clusters)"
+        path: auth.strategy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: Kiali Namespace
+        description: "The namespace where Kiali and its associated resources will be created. Default: istio-system"
+        path: deployment.namespace
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+      - displayName: View Only Mode
+        description: "When true, Kiali will be in 'view only' mode, allowing the user to view and retrieve management and monitoring data for the service mesh, but not allow the user to modify the service mesh. Default: false"
+        path: deployment.view_only_mode
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:booleanSwitch'
+      - displayName: Web Root
+        description: "Defines the root context path for the Kiali console, API endpoints and readiness/liveness probes. Default: / (when deployed on OpenShift; /kiali (when deployed on Kubernetes)"
+        path: server.web_root
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:label'
+  apiservicedefinitions: {}
+  install:
+    strategy: deployment
+    spec:
+      deployments:
+      - name: kiali-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: kiali-operator
+          template:
+            metadata:
+              name: kiali-operator
+              labels:
+                app: kiali-operator
+                # required for the operator SDK metric service selector
+                name: kiali-operator
+                version: v1.50.0
+                app.kubernetes.io/name: kiali-operator
+                app.kubernetes.io/version: v1.50.0
+                app.kubernetes.io/part-of: kiali-operator
+              annotations:
+                prometheus.io/scrape: "true"
+            spec:
+              serviceAccountName: kiali-operator
+              containers:
+              - name: operator
+                image: quay.io/kiali/kiali-operator:v1.50.0
+                imagePullPolicy: "IfNotPresent"
+                args:
+                - "--zap-log-level=info"
+                - "--leader-election-id=kiali-operator"
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  privileged: false
+                  runAsNonRoot: true
+                volumeMounts:
+                - mountPath: /tmp/ansible-operator/runner
+                  name: runner
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: ALLOW_AD_HOC_KIALI_NAMESPACE
+                  value: "false"
+                - name: ALLOW_AD_HOC_KIALI_IMAGE
+                  value: "false"
+                - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
+                  value: "100"
+                - name: ANSIBLE_DEBUG_LOGS
+                  value: "True"
+                - name: ANSIBLE_VERBOSITY_KIALI_KIALI_IO
+                  value: "1"
+                - name: ANSIBLE_CONFIG
+                  value: "/etc/ansible/ansible.cfg"
+                ports:
+                - name: http-metrics
+                  containerPort: 8080
+                resources:
+                  requests:
+                    cpu: "10m"
+                    memory: "64Mi"
+              volumes:
+              - name: runner
+                emptyDir: {}
+      clusterPermissions:
+      - rules:
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - pods
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - patch
+        - apiGroups: [""]
+          resources:
+          - secrets
+          verbs:
+          - create
+          - list
+          - watch
+        - apiGroups: [""]
+          resourceNames:
+          - cacerts
+          - istio-ca-secret
+          resources:
+          - secrets
+          verbs:
+          - get
+        - apiGroups: [""]
+          resourceNames:
+          - kiali-signing-key
+          resources:
+          - secrets
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apps"]
+          resources:
+          - deployments
+          - replicasets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["autoscaling"]
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["monitoring.coreos.com"]
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups: ["apps"]
+          resourceNames:
+          - kiali-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups: ["kiali.io"]
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["authorization.k8s.io"]
+          resources:
+          - selfsubjectaccessreviews
+          verbs:
+          - list
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["apiextensions.k8s.io"]
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: ["extensions", "networking.k8s.io"]
+          resources:
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["oauth.openshift.io"]
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resources:
+          - clusteroperators
+          verbs:
+          - list
+          - watch
+        - apiGroups: ["config.openshift.io"]
+          resourceNames:
+          - kube-apiserver
+          resources:
+          - clusteroperators
+          verbs:
+          - get
+        - apiGroups: ["console.openshift.io"]
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # The permissions below are for Kiali itself; operator needs these so it can escalate when creating Kiali's roles
+        - apiGroups: [""]
+          resources:
+          - configmaps
+          - endpoints
+          - pods/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups: [""]
+          resources:
+          - namespaces
+          - pods
+          - replicationcontrollers
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: [""]
+          resources:
+          - pods/portforward
+          verbs:
+          - create
+          - post
+        - apiGroups: ["extensions", "apps"]
+          resources:
+          - daemonsets
+          - deployments
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["batch"]
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - config.istio.io
+          - networking.istio.io
+          - authentication.istio.io
+          - rbac.istio.io
+          - security.istio.io
+          resources: ["*"]
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["authentication.maistra.io"]
+          resources:
+          - servicemeshpolicies
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["rbac.maistra.io"]
+          resources:
+          - servicemeshrbacconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["apps.openshift.io"]
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - patch
+        - apiGroups: ["project.openshift.io"]
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups: ["route.openshift.io"]
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups: ["authentication.k8s.io"]
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        serviceAccountName: kiali-operator

--- a/manifests/kiali-upstream/1.50.0/metadata/annotations.yaml
+++ b/manifests/kiali-upstream/1.50.0/metadata/annotations.yaml
@@ -1,0 +1,7 @@
+annotations:
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.bundle.manifests.v1: manifests/
+  operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+  operators.operatorframework.io.bundle.metadata.v1: metadata/
+  operators.operatorframework.io.bundle.package.v1: kiali


### PR DESCRIPTION
side note: we should probably get our new github action workflows to prepare these metadata files if they dont' already exist.
We forgot to add them prior to releasing 1.50.0. Not horrible, we'll just add them now and we can use these to publish to operatorhub.io, but it would be nice to automate the creation of these (or, perhaps after release, we create the metadata for the upcoming release - that would be the best thing to do.) I'll create another github issue for this.