### PR TITLE
Nightly pipeline and refinements to Kiali operator release pipeline

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,71 @@
+name: Nightly
+
+on:
+  schedule:
+  # Every night at 04:00 (UTC)
+  - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: Branch to release
+        required: true
+        default: master
+        type: string
+      quay_repository:
+        description: Quay repository
+        type: string
+        default: quay.io/kiali/kiali-operator
+        required: true
+
+jobs:
+  initialize:
+    name: Initialize
+    runs-on: ubuntu-20.04
+    outputs:
+      target_branch: ${{ github.ref_name }}
+      quay_tag: ${{ steps.quay_tag.outputs.quay_tag }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.release_branch || github.ref_name }}
+
+    - name: Determine Quay tag
+      id: quay_tag
+      run: |
+        if [ -z ${{ github.event.inputs.quay_repository }} ];
+        then
+          QUAY_REPO="quay.io/kiali/kiali-operator"
+        else
+          QUAY_REPO="${{ github.event.inputs.quay_repository }}"
+        fi
+        
+        QUAY_TAG="$QUAY_REPO:latest"
+
+        echo "::set-output name=quay_tag::$QUAY_TAG"
+
+    - name: Log information
+      run: |
+        echo "Release type: latest"
+
+        echo "Quay tag": ${{ steps.quay_tag.outputs.quay_tag }}
+
+  push:
+    name: Push latest
+    # Avoid schedule workflows from forks to push images
+    if: ${{ (github.event_name == 'schedule' && github.repository == 'kiali/kiali-operator') || github.event_name != 'schedule' }}
+    runs-on: ubuntu-20.04
+    needs: [initialize]
+    env:
+      OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.inputs.release_branch }}  
+        
+    - name: Build and push image
+      run: |              
+        docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
+        
+        make -e DOCKER_CLI_EXPERIMENTAL=enabled container-multi-arch-push-kiali-operator-quay    

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,18 @@
 name: Release
 
 on:
+  schedule:
+    # Every Friday at 19:00 (UTC)
+    - cron: '00 19 * * FRI'
   workflow_dispatch:
     inputs:
       release_type:
         description: 'Release type'     
         required: true
-        default: 'auto' 
         type: choice
         options:
-        - auto
-        - edge
         - minor
         - patch
-        - snapshot.0
-        - snapshot.1
-        - snapshot.2
-        - snapshot.3
       release_branch:
         description: Branch to release
         required: true
@@ -42,7 +38,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.release_branch }}       
+        ref: ${{ github.event.inputs.release_branch }}
 
     - name: Prepare scripts
       run: |
@@ -66,51 +62,39 @@ jobs:
         print('.'.join(['v' + str(major), str(minor), str(patch)]))
         EOF
         
-        cat <<'EOF' > release_type.sh
-        BASE_DATE=${BASE_DATE:-$(date -d '2021-12-03' '+%s')} # Use last day of Sprint #66 as the base date for calcs
-        NOW_DATE=${NOW_DATE:-$(date -d 'now' '+%s')}
-        # Transitional calculations
-        DATE_DIFF=$(( $NOW_DATE - $BASE_DATE ))
-        DAYS_ELAPSED=$(( $DATE_DIFF / (24*60*60) ))
-        WEEKS_ELAPSED=$(( $DAYS_ELAPSED / 7))
-        # This value will be used to determine the type of the release
-        WEEKS_MOD3=$(( $WEEKS_ELAPSED % 3 ))
-        # Between Dec 23th 2021 and Jan 14th 2022, use Mod6 (six-week sprint)
-        if [ $NOW_DATE -ge $(date -d '2021-12-23' '+%s') ] && [ $NOW_DATE -lt $(date -d '2022-01-14' '+%s') ];
-        then
-        WEEKS_MOD3=$(( $WEEKS_ELAPSED % 6 ))
-        fi
-        case $WEEKS_MOD3 in
-        0)
-            RELEASE_TYPE='minor' ;;
-        1)
-            RELEASE_TYPE='snapshot.0' ;;
-        2)
-            RELEASE_TYPE='snapshot.1' ;;
-        3)
-            RELEASE_TYPE='snapshot.2' ;;
-        4)
-            RELEASE_TYPE='snapshot.3' ;;
-        5)
-            RELEASE_TYPE='snapshot.4' ;;
-        esac
-        # Print the determined type
-        echo $RELEASE_TYPE
-        EOF      
+        cat <<-EOF > minor.py
+        import datetime
 
-        chmod +x release_type.sh
+        base = int(datetime.datetime.strptime("24/04/2022", "%d/%m/%Y").timestamp())
+        now = int(datetime.datetime.now().timestamp())
+
+        diff = now - base
+
+        days_elapsed = int(diff / (24*60*60))
+        weeks_elapsed = int(days_elapsed / 7)
+        weeks_mod3 = int(weeks_elapsed % 3)
+
+        print(weeks_mod3)
+        EOF     
 
     - name: Determine release type
-      id: release_type        
+      id: release_type
       run: |
-        if [[ ${{ github.event.inputs.release_type }} == "auto" ]];
+        if [ -z ${{ github.event.inputs.release_type }} ];
         then
-          echo "::set-output name=release_type::$(sh release_type.sh)"
+          DO_RELEASE=$(python minor.py)
+          if [[ $DO_RELEASE == "0" ]]
+          then
+            echo "::set-output name=release_type::minor"
+          else
+            echo "::set-output name=release_type::skip"
+          fi
         else
           echo "::set-output name=release_type::${{ github.event.inputs.release_type }}"
         fi
     
     - name: Determine release version
+      if: ${{ steps.release_type.outputs.release_type != 'skip' }}
       env:
         RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
       id: release_version
@@ -123,68 +107,64 @@ jobs:
         if [[ $RELEASE_TYPE == "patch" ]]
         then
           RELEASE_VERSION=$(python bump.py $RELEASE_TYPE $RELEASE_VERSION)
-        elif [[ $RELEASE_TYPE == *"snapshot"* ]]
-        then
-          RELEASE_VERSION="$RELEASE_VERSION-$RELEASE_TYPE"
         elif [[ $RELEASE_TYPE == "minor" ]]
         then
           RELEASE_VERSION=$RELEASE_VERSION
-        elif [[ $RELEASE_TYPE == "edge" ]]
-        then
-          RELEASE_VERSION=latest
         fi
 
-        echo "::set-output name=release_version::$RELEASE_VERSION"      
+        echo "::set-output name=release_version::$RELEASE_VERSION"
     
     - name: Determine next version
+      if: ${{ steps.release_type.outputs.release_type != 'skip' }}
       env:
         RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
         RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
       id: next_version
-      if: ${{ steps.release_type.outputs.release_type == 'patch' || steps.release_type.outputs.release_type == 'minor' }}
       run: |
         if [[ $RELEASE_TYPE == "patch" ]]
         then
             NEXT_VERSION=$(python bump.py $RELEASE_TYPE $RELEASE_VERSION)
         elif [[ $RELEASE_TYPE == "minor" ]]
         then 
-            NEXT_VERSION=$(python bump.py $RELEASE_TYPE $RELEASE_VERSION)          
+            NEXT_VERSION=$(python bump.py $RELEASE_TYPE $RELEASE_VERSION)
         fi
 
         echo "::set-output name=next_version::$NEXT_VERSION"
 
     - name: Determine branch version
+      if: ${{ steps.release_type.outputs.release_type != 'skip' }}
       env:
-        RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}      
+        RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
       id: branch_version
-      if: ${{ steps.release_type.outputs.release_type != 'edge' && !contains(steps.release_type.outputs.release_type, 'snapshot') }}
-      run: echo "::set-output name=branch_version::$(echo $RELEASE_VERSION | sed 's/\.[0-9]*\+$//')"      
+      run: echo "::set-output name=branch_version::$(echo $RELEASE_VERSION | sed 's/\.[0-9]*\+$//')"
 
     - name: Determine Quay tag
+      if: ${{ steps.release_type.outputs.release_type != 'skip' }}
       env:
-        RELEASE_TYPE: ${{ steps.release_type.outputs.release_type }}
         RELEASE_VERSION: ${{ steps.release_version.outputs.release_version }}
         BRANCH_VERSION: ${{ steps.branch_version.outputs.branch_version }}
       id: quay_tag
       run: |
-        QUAY_TAG="${{ github.event.inputs.quay_repository }}:$RELEASE_VERSION"
-        
-        if [[ $RELEASE_TYPE == "minor" ]] || [ $RELEASE_TYPE == "patch" ]]
+        if [ -z ${{ github.event.inputs.quay_repository }} ];
         then
-          QUAY_TAG="$QUAY_TAG ${{ github.event.inputs.quay_repository }}:$BRANCH_VERSION"
+          QUAY_REPO="quay.io/kiali/kiali-operator"
+        else
+          QUAY_REPO="${{ github.event.inputs.quay_repository }}"
         fi
 
+        QUAY_TAG="$QUAY_REPO:$RELEASE_VERSION $QUAY_REPO:$BRANCH_VERSION"
+        
         echo "::set-output name=quay_tag::$QUAY_TAG"
     
     - name: Cleanup
-      run: rm bump.py release_type.sh
+      run: rm bump.py minor.py
 
     - name: Log information
       run: |
         echo "Release type: ${{ steps.release_type.outputs.release_type }}"
       
         echo "Release version: ${{ steps.release_version.outputs.release_version }}"
-                  
+     
         echo "Next version: ${{ steps.next_version.outputs.next_version }}"
 
         echo "Branch version: ${{ steps.branch_version.outputs.branch_version }}"
@@ -193,13 +173,14 @@ jobs:
 
   release:
     name: Release
+    if: ${{ needs.initialize.outputs.release_type != 'skip' && ((github.event_name == 'schedule' && github.repository == 'kiali/kiali-operator') || github.event_name != 'schedule') }}
     runs-on: ubuntu-20.04
     needs: [initialize]
     env:
-      RELEASE_TYPE: ${{ needs.initialize.outputs.release_type }}      
+      RELEASE_TYPE: ${{ needs.initialize.outputs.release_type }}
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
-      NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}      
+      NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
       RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}
       OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
@@ -212,7 +193,7 @@ jobs:
       run: sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
 
     - name: Build and push image
-      run: |              
+      run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
         
         make -e DOCKER_CLI_EXPERIMENTAL=enabled container-multi-arch-push-kiali-operator-quay
@@ -223,8 +204,7 @@ jobs:
         
         git config user.name 'kiali-bot'
 
-    - name: Create tag 
-      if: ${{ needs.initialize.outputs.release_type != 'edge' }}
+    - name: Create tag
       run: |
         git add Makefile
         
@@ -233,17 +213,18 @@ jobs:
         git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
         
     - name: Create release
-      if: ${{ needs.initialize.outputs.release_type != 'edge' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [[ $RELEASE_TYPE == *"snapshot"* ]]; then export PRERELEASE="-p"; fi
-
-        gh release create $RELEASE_VERSION $PRERELEASE -t "Kiali $RELEASE_VERSION"
+        gh release create $RELEASE_VERSION -t "Kiali $RELEASE_VERSION"
     
     - name: Create or update version branch      
-      if: ${{ needs.initialize.outputs.release_type != 'edge' && !contains(needs.initialize.outputs.release_type, 'snapshot') }}
       run: git push origin $(git rev-parse HEAD):refs/heads/$BRANCH_VERSION
+
+    - name: Configure Operator SDK
+      if: ${{ needs.initialize.outputs.release_type == 'minor' }}
+      run: |
+        make get-operator-sdk
 
     - name: Create a PR to prepare for next version
       env:
@@ -251,10 +232,16 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: ${{ needs.initialize.outputs.release_type == 'minor' }}
       run: |
-        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile
+        export PATH="$PATH:$GITHUB_WORKSPACE/_output/operator-sdk-install"
+
+        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile      
         
-        git add Makefile
-        
+        # Using versions without the prefix 'v'        
+        ./manifests/create-new-version.sh -nv ${NEXT_VERSION:1} -ov ${RELEASE_VERSION:1} -om kiali-upstream/
+        ./manifests/create-new-version.sh -nv ${NEXT_VERSION:1} -ov ${RELEASE_VERSION:1} -om kiali-community/
+
+        git add Makefile manifests/
+
         git commit -m "Prepare for next version"
         
         git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  schedule:
-    # Every Friday at 19:00 (UTC)
-    - cron: '00 19 * * FRI'
+  # schedule:
+  #   # Every Friday at 19:00 (UTC)
+  #   - cron: '00 19 * * FRI'
   workflow_dispatch:
     inputs:
       release_type:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
         cat <<-EOF > minor.py
         import datetime
 
+        # The base date can be any end of sprint from the past
         base = int(datetime.datetime.strptime("24/04/2022", "%d/%m/%Y").timestamp())
         now = int(datetime.datetime.now().timestamp())
 


### PR DESCRIPTION
This PR contains the following:

- Adds a nightly build pipeline to generate a latest image every weekday at 04:00 UTC.
- Removes the snapshots so a release pipeline only has "minor" and "patches" options (latest is left for the nightly, that can also be started manually)
- Adds metadata generation

Resolves: https://github.com/kiali/kiali/issues/5025.