### PR TITLE
[molecule] conditionals to check when reconciliation was done didn't work 100% of the time.

### DIFF
--- a/molecule/common/wait_for_kiali_cr_changes.yml
+++ b/molecule/common/wait_for_kiali_cr_changes.yml
@@ -1,4 +1,4 @@
-- name: Wait for changes to take effect
+- name: Wait for Kiali CR changes to take effect
   k8s_info:
     api_version: kiali.io/v1alpha1
     kind: Kiali
@@ -9,6 +9,7 @@
   - kiali_cr_list is success
   - kiali_cr_list.resources is defined
   - kiali_cr_list.resources | length > 0
-  - kiali_cr_list | json_query('resources[*].status.conditions[?reason==`Successful`].status') | flatten | join == 'True'
+  - kiali_cr_list | json_query('resources[*].status.conditions[?message==`Awaiting next reconciliation`].status') | flatten | join == 'True'
+  - kiali_cr_list | json_query('resources[*].status.conditions[?message==`Awaiting next reconciliation`].reason') | flatten | join == 'Successful'
   retries: "{{ wait_retries }}"
   delay: 5


### PR DESCRIPTION
These new conditionals should be more specific and should work.

The issue was there was multiple status condition blocks that had `reason=Successful` in them - which resulted on the json query string being "TrueTrue".

I changed the conditionals to look specifically for the conditional that indicates the reconciliation is complete.

