### PR TITLE
[molecule] ossm 2.2 and below require use_grpc set to false

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -151,6 +151,7 @@
       tracing_config:
         in_cluster_url: "https://jaeger-query.{{ istio.control_plane_namespace }}.svc"
         url: "https://jaeger-query.{{ istio.control_plane_namespace }}.svc"
+        use_grpc: false # today, OSSM 2.2 and under cannot use gRPC
         auth:
           username: internal
           type: basic


### PR DESCRIPTION
This is required for the jaeger-test to pass when running in OSSM environment.
backport PR: https://github.com/kiali/kiali-operator/pull/530