### PR TITLE
[v1.48] [molecule] fix metrics-test

### DIFF
--- a/molecule/metrics-test/converge.yml
+++ b/molecule/metrics-test/converge.yml
@@ -21,9 +21,8 @@
       test_start_time: "{{ ansible_date_time.iso8601 }}"
 
   - set_fact:
-      prom_namespace_label: namespace
-      # This used to be needed for OSSM 2.0 but no longer for 2.1
-      #prom_namespace_label: "{{ 'namespace' if is_maistra == True else 'kubernetes_namespace' }}"
+      # OSSM 2.2 uses Prometheus 2.23.0. Upstream Istio Prometheus addon uses something >2.31.0. The label is different for each.
+      prom_namespace_label: "{{ 'kubernetes_namespace' if is_maistra == True else 'namespace' }}"
 
   # Operator metrics are always enabled - make sure we have them
   # NOTE: Service Mesh/Maistra does NOT collect these metrics, so do not test when running in Maistra env.


### PR DESCRIPTION
OSSM 2.2 still uses "kubernetes_namespace"
Upstream Istio Prom addon uses "namespace"
Related to kiali/kiali#4778

This now fixes all the molecules tests when running on OSSM 2.2.

Cherry pick of https://github.com/kiali/kiali-operator/pull/534