### PR TITLE
update for the new HPA v2 (v2beta2 has been deprecated and removed in newer k8s

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -102,12 +102,18 @@ spec:
       mount: "/a-custom-secret-path"
       optional: true
     hpa:
-      api_version: "autoscaling/v2beta2"
+      api_version: "autoscaling/v2"
       # default: spec is empty
       spec:
         maxReplicas: 2
         minReplicas: 1
-        targetCPUUtilizationPercentage: 80
+        metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 50
     # default: host_aliases is an empty list
     host_aliases:
     - ip: "192.168.1.100"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -276,11 +276,17 @@ spec:
                       A typical way to configure HPA for Kiali is,
                       ```
                       hpa:
-                        api_version: "autoscaling/v2beta2"
+                        api_version: "autoscaling/v2"
                         spec:
                           maxReplicas: 2
                           minReplicas: 1
-                          targetCPUUtilizationPercentage: 80
+                          metrics:
+                          - type: Resource
+                            resource:
+                              name: cpu
+                              target:
+                                type: Utilization
+                                averageUtilization: 50
                       ```
                     type: object
                     properties:
@@ -394,7 +400,7 @@ spec:
                                     backend:
                                       service
                                         name: "kiali"
-                                        port: 
+                                        port:
                                           number: 20001
                           ```
                         type: object

--- a/molecule/affinity-tolerations-resources-test/converge.yml
+++ b/molecule/affinity-tolerations-resources-test/converge.yml
@@ -64,7 +64,7 @@
       new_pod_labels:
         some.test.label/labelKeepCamelCaseFOO: labelCamelCaseValueFOO
       new_hpa:
-        api_version: autoscaling/v1
+        api_version: autoscaling/v2
         spec:
           minReplicas: 1
           maxReplicas: 1
@@ -123,7 +123,7 @@
 
   - name: Get the HPA resource that should now exist
     k8s_info:
-      api_version: autoscaling/v1
+      api_version: autoscaling/v2
       kind: HorizontalPodAutoscaler
       namespace: "{{ kiali.install_namespace }}"
       name: kiali
@@ -174,7 +174,7 @@
 
   - name: Try to obtain the HPA which should have been removed
     k8s_info:
-      api_version: autoscaling/v1
+      api_version: autoscaling/v2
       kind: HorizontalPodAutoscaler
       namespace: "{{ kiali.install_namespace }}"
       name: kiali

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -61,7 +61,7 @@ kiali_defaults:
     custom_secrets: []
     host_aliases: []
     hpa:
-      api_version: "autoscaling/v2beta2"
+      api_version: "autoscaling/v2"
       spec: {}
     image_digest: ""
     image_name: ""

--- a/roles/default/kiali-remove/defaults/main.yml
+++ b/roles/default/kiali-remove/defaults/main.yml
@@ -4,7 +4,7 @@ kiali_defaults:
   deployment:
     accessible_namespaces: []
     hpa:
-      api_version: "autoscaling/v2beta2"
+      api_version: "autoscaling/v2"
     instance_name: "kiali"
 
 # Will be auto-detected, but for debugging purposes you can force one of these to true


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/5022