### PR TITLE
[molecule] move to another ansible quay repo to run molecule

### DIFF
--- a/molecule/docker/Dockerfile
+++ b/molecule/docker/Dockerfile
@@ -1,13 +1,8 @@
-FROM quay.io/ansible/toolset:3.5.0
+FROM quay.io/ansible/creator-ee:v0.5.2
 ENV PACKAGES="\
-gettext \
-gcc \
-libc-dev \
-curl \
-bash \
 openssl \
 "
-RUN apt-get update && apt-get install -y ${PACKAGES}
-RUN pip install openshift junit-xml jmespath docker kubernetes
-RUN ansible-galaxy collection install kubernetes.core
+RUN dnf install -y ${PACKAGES}
+RUN pip install jmespath
+RUN ansible-galaxy collection install community.general kubernetes.core
 RUN curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash && helm version

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -1,6 +1,6 @@
 # Project requirements
 # 'pip install -r requirements.txt'
-# In addition to these, you must also exec "ansible-galaxy collection install kubernetes.core"
+# In addition to these, you must also exec "ansible-galaxy collection install community.general kubernetes.core"
 molecule
 openshift
 jmespath


### PR DESCRIPTION
See: https://github.com/ansible-community/molecule/discussions/3206
I have not tested this yet. But to test it, this should work:
`make -e FORCE_MOLECULE_BUILD=true molecule-build molecule-test`