### PR TITLE
Set release branch correctly when the pipeline is scheduled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.release_branch }}
+        ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
     - name: Prepare scripts
       run: |
@@ -182,13 +182,13 @@ jobs:
       RELEASE_VERSION: ${{ needs.initialize.outputs.release_version }}
       BRANCH_VERSION: ${{ needs.initialize.outputs.branch_version }}
       NEXT_VERSION: ${{ needs.initialize.outputs.next_version }}
-      RELEASE_BRANCH: ${{ github.event.inputs.release_branch }}
+      RELEASE_BRANCH: ${{ github.event.inputs.release_branch || github.ref_name }}
       OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
       with:
-        ref: ${{ github.event.inputs.release_branch }}  
+        ref: ${{ github.event.inputs.release_branch || github.ref_name }}
     
     - name: Set version to release
       run: sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile


### PR DESCRIPTION
This is an addition that is already present on the Kiali server pipeline. 

This wasn't an issue on the last release as the last scheduled release failed because of another problem, making me to push the button manually (avoiding this bug).

Today, the pipeline failed because of this when creating the PR, on the last step, because of a missing value on the RELEASE_BRANCH env var. I created the PR and merge it so for today, it's fixed. 

The branch value is also used in the checkout's ref parameter, which was set right because "master" is the default branch to fetch in the absence of a ref value.

For the next time, it's better to have the ref parameter properly set. 