### PR TITLE
use relative paths for the location of the playbooks

### DIFF
--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -52,7 +52,7 @@ To remove the operator (and the Kiali CR that may have also been created), run `
 
 If you have a cluster with OLM installed (e.g. OpenShift), you can test the Kiali OLM metadata by installing the Kiali operator using OLM via make.
 
-If you do not have OLM installed, you can easily install it. First determine what link:https://github.com/operator-framework/operator-lifecycle-manager/releases[OLM release] you want to install. Then simply run the command `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh | bash -s ${OLM_VERSION}`. If you are running minikube, all you need to do it execute the command `hack/k8s-minikube.sh olm` and the hack script will install the latest OLM for you.
+If you do not have OLM installed, you can easily install it. First determine what link:https://github.com/operator-framework/operator-lifecycle-manager/releases[OLM release] you want to install. Then simply run the command `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh | bash -s ${OLM_VERSION}`. If you are running minikube, all you need to do is execute the command `hack/k8s-minikube.sh olm` and the hack script will install the latest OLM for you.
 
 Once OLM is installed, you can install the Kiali Operator (and all the required resources such as the OLM catalog source and subscription) via `make olm-operator-create`.
 

--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -52,7 +52,7 @@ To remove the operator (and the Kiali CR that may have also been created), run `
 
 If you have a cluster with OLM installed (e.g. OpenShift), you can test the Kiali OLM metadata by installing the Kiali operator using OLM via make.
 
-If you do not have OLM installed, you can easily install it. First determine what link:https://github.com/operator-framework/operator-lifecycle-manager/releases[OLM release] you want to install. Then simply run the command `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh | bash -s ${OLM_VERSION}`
+If you do not have OLM installed, you can easily install it. First determine what link:https://github.com/operator-framework/operator-lifecycle-manager/releases[OLM release] you want to install. Then simply run the command `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh | bash -s ${OLM_VERSION}`. If you are running minikube, all you need to do it execute the command `hack/k8s-minikube.sh olm` and the hack script will install the latest OLM for you.
 
 Once OLM is installed, you can install the Kiali Operator (and all the required resources such as the OLM catalog source and subscription) via `make olm-operator-create`.
 

--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -40,11 +40,25 @@ If, however, a developer needs to make changes to the operator, because the Kial
 
 ## Running the Kiali Operator
 
-### Installing the Operator in a Cluster
+### Installing the Operator in a Cluster Using The Helm Charts
 
 The link:https://github.com/kiali/kiali[Kiali git repo] has a link:https://github.com/kiali/kiali/blob/master/Makefile[Makefile] and a set of link:https://github.com/kiali/kiali/blob/master/make[Makefile targets] that are used in conjunction with the Kiali Operator so you can install and run the operator built from your local git clones. They use the Kiali Operator helm chart to install the operator, so you must link:https://github.com/kiali/kiali#building[clone the helm-chart git repo in the proper place as well].
 
 To install the operator that contains your local changes, run `make operator-create`. If you are using minikube, you will need to set the environment variable `CLUSTER_TYPE=minikube` and you need to also set `MINIKUBE_PROFILE` if your minikube profile name is not `minikube`. At this point you can create your own Kiali CR to trigger the operator to install Kiali, or use `make kiali-create` to install a sample Kiali CR for you.
+
+To remove the operator (and the Kiali CR that may have also been created), run `make operator-delete`.
+
+### Installing the Operator in a Cluster Using OLM
+
+If you have a cluster with OLM installed (e.g. OpenShift), you can test the Kiali OLM metadata by installing the Kiali operator using OLM via make.
+
+If you do not have OLM installed, you can easily install it. First determine what link:https://github.com/operator-framework/operator-lifecycle-manager/releases[OLM release] you want to install. Then simply run the command `curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/${OLM_VERSION}/install.sh | bash -s ${OLM_VERSION}`
+
+Once OLM is installed, you can install the Kiali Operator (and all the required resources such as the OLM catalog source and subscription) via `make olm-operator-create`.
+
+Once the operator is running, you can install a Kiali CR normally. One way to do this is to first create a kiali-operator namespace and run the `kiali-create` make target: `kubectl create ns kiali-operator && make kiali-create`.
+
+To remove the Kiali operator and all the other OLM resources that came with it (including the Kiali CR if you created one via the `kiali-create` target), run `make olm-operator-delete`.
 
 ### Running the Operator Playbook Without Installing in a Cluster
 
@@ -65,6 +79,10 @@ You also must get the required Ansible collections installed. To find out the di
 * for m in $(podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest find .ansible/collections/ansible_collections -name MANIFEST.json); do manifest=$(echo -n ${m} | tr --delete '\r'); echo -n "${manifest}-->"; podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest cat "${manifest}" | jq .collection_info.version; done
 
 To install these, run `ansible-galaxy collection install -r operator/requirements.yml --force-with-deps`
+
+### Running the Operator Without Installing in a Cluster
+
+The previous section tells you how to run the Ansible playbook directly on your local machine. If you want to run the actual operator on your local machine in the same manner in which it runs inside the cluster (that is, within the `ansible-operator` shell process) then use the `make run-operator` make target. This will run the ansible-operator executable and point it to the operator's Ansible playbooks and roles. This operator will watch for Kiali CRs in the cluster - when it sees one, it will process it just as if it was running in the cluster. This will allow you to test the Ansible operator infrastructure as well as the operator's Ansible playbooks themselves.
 
 ### Running the Operator With the Ansible Profiler
 

--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -76,7 +76,7 @@ To get started, try to run `python -m pip install --user --upgrade -r operator/m
 
 You also must get the required Ansible collections installed. To find out the different versions of Ansible collections within the Kiali operator image, run the following:
 
-* for m in $(podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest find .ansible/collections/ansible_collections -name MANIFEST.json); do manifest=$(echo -n ${m} | tr --delete '\r'); echo -n "${manifest}-->"; podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest cat "${manifest}" | jq .collection_info.version; done
+`for m in $(podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest find .ansible/collections/ansible_collections -name MANIFEST.json); do manifest=$(echo -n ${m} | tr --delete '\r'); echo -n "${manifest}-->"; podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest cat "${manifest}" | jq .collection_info.version; done`
 
 To install these, run `ansible-galaxy collection install -r operator/requirements.yml --force-with-deps`
 

--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -60,6 +60,8 @@ Once the operator is running, you can install a Kiali CR normally. One way to do
 
 To remove the Kiali operator and all the other OLM resources that came with it (including the Kiali CR if you created one via the `kiali-create` target), run `make olm-operator-delete`.
 
+NOTE: By default, you will test with the latest version of the metadata. You can specify a different version by setting the `BUNDLE_VERSION` env var on the make command line. If the OC env var points to an `oc` binary, the metadata from the kiali-community will be used; otherwise, the metadata from the kiali-upstream will be used. If you instead want to test with the OSSM metadata, set the env var `OLM_BUNDLE_PACKAGE` to `kiali-ossm` on the make command line.
+
 ### Running the Operator Playbook Without Installing in a Cluster
 
 Sometimes you made simple changes to the operator playbook and roles that can be quickly tested by running the Ansible playbook on your local machine. This saves time because it doesn't require you to install the operator directly in your cluster. To do this, you must have Ansible installed (e.g. `ansible-playbook` must be in your $PATH). You can run the operator playbook via `make run-operator-playbook`. This will run both the kiali-deploy and kiali-remove playbooks so the operator will install and then immediately uninstall a Kiali Server. The operator playbook is configured via the files found in the link:dev-playbook-config[dev-playbook-config directory].

--- a/manifests/kiali-ossm/bundle.Dockerfile
+++ b/manifests/kiali-ossm/bundle.Dockerfile
@@ -1,0 +1,11 @@
+FROM scratch
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=kiali-ossm
+LABEL operators.operatorframework.io.bundle.channels.v1=stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
+
+COPY manifests /manifests/
+COPY metadata /metadata/

--- a/watches.yaml
+++ b/watches.yaml
@@ -2,10 +2,10 @@
 - version: v1alpha1
   group: kiali.io
   kind: Kiali
-  playbook: /opt/ansible/playbooks/kiali-deploy.yml
+  playbook: playbooks/kiali-deploy.yml
   reconcilePeriod: "0s"
   watchDependentResources: False
   watchClusterScopedResources: False
   finalizer:
     name: kiali.io/finalizer
-    playbook: /opt/ansible/playbooks/kiali-remove.yml
+    playbook: playbooks/kiali-remove.yml


### PR DESCRIPTION
The playbook paths can be relative because the operator starts in the correct cwd.

This change is needed by the run-operator target.
required by: https://github.com/kiali/kiali/pull/5366
part of: https://github.com/kiali/kiali/issues/5364

Testing this PR is done while testing its main PR https://github.com/kiali/kiali/pull/5366 - if you test that main PR you will have tested this PR.