### PR TITLE
[molecule] fix token-test - create SA secret

### DIFF
--- a/molecule/token-test/prepare-token.yml
+++ b/molecule/token-test/prepare-token.yml
@@ -8,9 +8,22 @@
     namespace: "{{ sa_namespace }}"
   register: sa_default
 
-- name: Determine the name of the secret that contains the token
-  set_fact:
-    test_token_secret_name: "{{ sa_default.resources[0].secrets | selectattr('name', 'match', 'default-token-.*') | map(attribute='name') | list | first }}"
+- name: Create a secret that will contain the token
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: default-secret
+        namespace: "{{ sa_namespace }}"
+        annotations:
+          kubernetes.io/service-account.name: default
+      type: kubernetes.io/service-account-token
+  register: sa_secret
+
+- set_fact:
+    test_token_secret_name: "default-secret"
 
 - name: Get secret [{{ test_token_secret_name }}] containing the service account token
   k8s_info:


### PR DESCRIPTION
This is to support k8s versions that do not by default provide SA secrets.
fixes: https://github.com/kiali/kiali/issues/5258

How to test:

1. Log into an OpenShift 4.11 cluster
2. Run this command: `make -e MOLECULE_SCENARIO="token-test" molecule-test`

Test should pass