### PR TITLE
Add rhel 8 for old kiali versions

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -270,13 +270,15 @@ spec:
                 - name: ANSIBLE_CONFIG
                   value: "/etc/ansible/ansible.cfg"
                 - name: RELATED_IMAGE_kiali_default
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali${KIALI_1_48_TAG}"
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali${KIALI_1_57_TAG}"
+                - name: RELATED_IMAGE_kiali_v1_57
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali${KIALI_1_57_TAG}"   
                 - name: RELATED_IMAGE_kiali_v1_48
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali${KIALI_1_48_TAG}"  
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_48_TAG}"  
                 - name: RELATED_IMAGE_kiali_v1_36
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali${KIALI_1_36_TAG}"
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_36_TAG}"
                 - name: RELATED_IMAGE_kiali_v1_24
-                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali${KIALI_1_24_TAG}"
+                  value: "registry-proxy.engineering.redhat.com/rh-osbs/openshift-service-mesh-kiali-rhel8${KIALI_1_24_TAG}"
                 ports:
                 - name: http-metrics
                   containerPort: 8080


### PR DESCRIPTION
My head....old kiali supported versions have the rhel8....we need to take care for "next release" to remove rhel-8 for default and newers