### PR TITLE
Added new config gateway_api_class_name

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -272,6 +272,7 @@ spec:
         enabled: true
       config_map_name: "istio"
       envoy_admin_local_port: 15000
+      gateway_api_class_name: ""
       # default: istio_canary_revision is undefined
       istio_canary_revision:
         current: "1-9-9"
@@ -284,7 +285,6 @@ spec:
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
       url_service_version: ""
-      gateway_api_class_name: ""
     prometheus:
       auth:
         ca_file: ""

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -284,6 +284,7 @@ spec:
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
       url_service_version: ""
+      gateway_api_class_name: ""
     prometheus:
       auth:
         ca_file: ""

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -733,6 +733,9 @@ spec:
                       envoy_admin_local_port:
                         description: "The port which kiali will open to fetch envoy config data information."
                         type: integer
+                      gateway_api_class_name:
+                        description: "The K8s Gateway API GatewayClass's Name used in Istio. If empty, the default value 'istio' is used."
+                        type: string
                       istio_canary_revision:
                         description: "These values are used in Canary upgrade/downgrade functionality when `istio_upgrade_action` is true."
                         type: object
@@ -766,9 +769,6 @@ spec:
                         type: string
                       url_service_version:
                         description: "The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint."
-                        type: string
-                      gateway_api_class_name:
-                        description: "The K8s Gateway API GatewayClass's Name used in Istio. If empty, the default value 'istio' is used."
                         type: string
                   prometheus:
                     description: "The Prometheus configuration defined here refers to the Prometheus instance that is used by Istio to store its telemetry."

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -767,6 +767,9 @@ spec:
                       url_service_version:
                         description: "The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint."
                         type: string
+                      gateway_api_class_name:
+                        description: "The K8s Gateway API GatewayClass's Name used in Istio. If empty, the default value 'istio' is used."
+                        type: string
                   prometheus:
                     description: "The Prometheus configuration defined here refers to the Prometheus instance that is used by Istio to store its telemetry."
                     type: object

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -180,6 +180,7 @@ kiali_defaults:
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
       url_service_version: ""
+      gateway_api_class_name: ""
     prometheus:
       auth:
         ca_file: ""

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -169,6 +169,7 @@ kiali_defaults:
         enabled: true
       config_map_name: "istio"
       envoy_admin_local_port: 15000
+      gateway_api_class_name: ""
       #istio_canary_revision:
         #current: prod
         #upgrade: canary
@@ -180,7 +181,6 @@ kiali_defaults:
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
       url_service_version: ""
-      gateway_api_class_name: ""
     prometheus:
       auth:
         ca_file: ""


### PR DESCRIPTION
Issue https://github.com/kiali/kiali/issues/5594

Added new configuration "gateway_api_class_name" in external Istio configs to specify Gateway API GatewayClass Name configuration in Istio.