### PR TITLE
[v1.57] secrets now injected into pod file system, not as env vars

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -629,54 +629,55 @@
   when:
   - kiali_vars.login_token.signing_key == ""
 
-# Prepare any additional environment variables that need to be defined in the deployment
+# Some credentials in the config can be overridden by secrets that are to be mounted on the file system.
+# Prepare these overrides that need to be defined as volumes in the deployment.
 
 - set_fact:
-    kiali_deployment_environment_variables: {}
+    kiali_deployment_secret_volumes: {}
 
-- name: Prepare environment variable for prometheus password
+- name: Prepare the secret volume for prometheus password
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'PROMETHEUS_PASSWORD': {'secret_name': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'prometheus-password': {'secret_name': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.prometheus.auth.password | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for prometheus token
+- name: Prepare the secret volume for prometheus token
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'PROMETHEUS_TOKEN': {'secret_name': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'prometheus-token': {'secret_name': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.prometheus.auth.token | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for tracing password
+- name: Prepare the secret volume for tracing password
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_PASSWORD': {'secret_name': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'tracing-password': {'secret_name': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.tracing.enabled|bool == True
   - kiali_vars.external_services.tracing.auth.password | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for tracing token
+- name: Prepare the secret volume for tracing token
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_TOKEN': {'secret_name': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'tracing-token': {'secret_name': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.tracing.enabled|bool == True
   - kiali_vars.external_services.tracing.auth.token | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for grafana password
+- name: Prepare the secret volume for grafana password
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_PASSWORD': {'secret_name': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'grafana-password': {'secret_name': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.grafana.enabled|bool == True
   - kiali_vars.external_services.grafana.auth.password | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for grafana token
+- name: Prepare the secret volume for grafana token
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_TOKEN': {'secret_name': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'grafana-token': {'secret_name': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.grafana.enabled|bool == True
   - kiali_vars.external_services.grafana.auth.token | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for login token signing key
+- name: Prepare the secret volume for login token signing key
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'LOGIN_TOKEN_SIGNING_KEY': {'secret_name': kiali_vars.login_token.signing_key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.login_token.signing_key | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'login-token-signing-key': {'secret_name': kiali_vars.login_token.signing_key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.login_token.signing_key | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.login_token.signing_key | regex_search('secret:.+:.+')
 

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -102,13 +102,6 @@ spec:
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT
           value: "{{ kiali_vars.deployment.logger.time_field_format }}"
-{% for env in kiali_deployment_environment_variables %}
-        - name: {{ env }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ kiali_deployment_environment_variables[env].secret_name }}
-              key: {{ kiali_deployment_environment_variables[env].secret_key }}
-{% endfor %}
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
@@ -116,6 +109,11 @@ spec:
           mountPath: "/kiali-secret"
         - name: kiali-cabundle
           mountPath: "/kiali-cabundle"
+{% for sec in kiali_deployment_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-override-secrets/{{ sec }}"
+          readOnly: true
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
         - name: {{ secret.name }}
           mountPath: "{{ secret.mount }}"
@@ -138,6 +136,15 @@ spec:
         configMap:
           name: {{ kiali_vars.deployment.instance_name }}-cabundle
           optional: true
+{% for sec in kiali_deployment_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_secret_volumes[sec].secret_name }}
+          items:
+          - key: {{ kiali_deployment_secret_volumes[sec].secret_key }}
+            path: value.txt
+          optional: false
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
       - name: {{ secret.name }}
         secret:

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -102,13 +102,6 @@ spec:
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT
           value: "{{ kiali_vars.deployment.logger.time_field_format }}"
-{% for env in kiali_deployment_environment_variables %}
-        - name: {{ env }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ kiali_deployment_environment_variables[env].secret_name }}
-              key: {{ kiali_deployment_environment_variables[env].secret_key }}
-{% endfor %}
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
@@ -120,6 +113,11 @@ spec:
           mountPath: "/kiali-secret"
         - name: kiali-cabundle
           mountPath: "/kiali-cabundle"
+{% for sec in kiali_deployment_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-override-secrets/{{ sec }}"
+          readOnly: true
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
         - name: {{ secret.name }}
           mountPath: "{{ secret.mount }}"
@@ -146,6 +144,15 @@ spec:
       - name: kiali-cabundle
         configMap:
           name: {{ kiali_vars.deployment.instance_name }}-cabundle
+{% for sec in kiali_deployment_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_secret_volumes[sec].secret_name }}
+          items:
+          - key: {{ kiali_deployment_secret_volumes[sec].secret_key }}
+            path: value.txt
+          optional: false
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
       - name: {{ secret.name }}
         secret:

--- a/roles/v1.57/kiali-deploy/tasks/main.yml
+++ b/roles/v1.57/kiali-deploy/tasks/main.yml
@@ -629,54 +629,55 @@
   when:
   - kiali_vars.login_token.signing_key == ""
 
-# Prepare any additional environment variables that need to be defined in the deployment
+# Some credentials in the config can be overridden by secrets that are to be mounted on the file system.
+# Prepare these overrides that need to be defined as volumes in the deployment.
 
 - set_fact:
-    kiali_deployment_environment_variables: {}
+    kiali_deployment_secret_volumes: {}
 
-- name: Prepare environment variable for prometheus password
+- name: Prepare the secret volume for prometheus password
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'PROMETHEUS_PASSWORD': {'secret_name': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'prometheus-password': {'secret_name': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.prometheus.auth.password | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for prometheus token
+- name: Prepare the secret volume for prometheus token
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'PROMETHEUS_TOKEN': {'secret_name': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'prometheus-token': {'secret_name': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.prometheus.auth.token | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for tracing password
+- name: Prepare the secret volume for tracing password
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_PASSWORD': {'secret_name': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'tracing-password': {'secret_name': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.tracing.enabled|bool == True
   - kiali_vars.external_services.tracing.auth.password | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for tracing token
+- name: Prepare the secret volume for tracing token
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'TRACING_TOKEN': {'secret_name': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'tracing-token': {'secret_name': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.tracing.enabled|bool == True
   - kiali_vars.external_services.tracing.auth.token | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for grafana password
+- name: Prepare the secret volume for grafana password
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_PASSWORD': {'secret_name': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'grafana-password': {'secret_name': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.grafana.enabled|bool == True
   - kiali_vars.external_services.grafana.auth.password | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for grafana token
+- name: Prepare the secret volume for grafana token
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'GRAFANA_TOKEN': {'secret_name': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'grafana-token': {'secret_name': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.external_services.grafana.enabled|bool == True
   - kiali_vars.external_services.grafana.auth.token | regex_search('secret:.+:.+')
 
-- name: Prepare environment variable for login token signing key
+- name: Prepare the secret volume for login token signing key
   set_fact:
-    kiali_deployment_environment_variables: "{{ kiali_deployment_environment_variables | combine({'LOGIN_TOKEN_SIGNING_KEY': {'secret_name': kiali_vars.login_token.signing_key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.login_token.signing_key | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes | combine({'login-token-signing-key': {'secret_name': kiali_vars.login_token.signing_key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.login_token.signing_key | regex_replace('secret:.+:(.+)', '\\1') }}) }}"
   when:
   - kiali_vars.login_token.signing_key | regex_search('secret:.+:.+')
 

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -102,13 +102,6 @@ spec:
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT
           value: "{{ kiali_vars.deployment.logger.time_field_format }}"
-{% for env in kiali_deployment_environment_variables %}
-        - name: {{ env }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ kiali_deployment_environment_variables[env].secret_name }}
-              key: {{ kiali_deployment_environment_variables[env].secret_key }}
-{% endfor %}
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
@@ -116,6 +109,11 @@ spec:
           mountPath: "/kiali-secret"
         - name: kiali-cabundle
           mountPath: "/kiali-cabundle"
+{% for sec in kiali_deployment_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-override-secrets/{{ sec }}"
+          readOnly: true
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
         - name: {{ secret.name }}
           mountPath: "{{ secret.mount }}"
@@ -138,6 +136,15 @@ spec:
         configMap:
           name: {{ kiali_vars.deployment.instance_name }}-cabundle
           optional: true
+{% for sec in kiali_deployment_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_secret_volumes[sec].secret_name }}
+          items:
+          - key: {{ kiali_deployment_secret_volumes[sec].secret_key }}
+            path: value.txt
+          optional: false
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
       - name: {{ secret.name }}
         secret:

--- a/roles/v1.57/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/deployment.yaml
@@ -102,13 +102,6 @@ spec:
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT
           value: "{{ kiali_vars.deployment.logger.time_field_format }}"
-{% for env in kiali_deployment_environment_variables %}
-        - name: {{ env }}
-          valueFrom:
-            secretKeyRef:
-              name: {{ kiali_deployment_environment_variables[env].secret_name }}
-              key: {{ kiali_deployment_environment_variables[env].secret_key }}
-{% endfor %}
         volumeMounts:
         - name: kiali-configuration
           mountPath: "/kiali-configuration"
@@ -120,6 +113,11 @@ spec:
           mountPath: "/kiali-secret"
         - name: kiali-cabundle
           mountPath: "/kiali-cabundle"
+{% for sec in kiali_deployment_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-override-secrets/{{ sec }}"
+          readOnly: true
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
         - name: {{ secret.name }}
           mountPath: "{{ secret.mount }}"
@@ -146,6 +144,15 @@ spec:
       - name: kiali-cabundle
         configMap:
           name: {{ kiali_vars.deployment.instance_name }}-cabundle
+{% for sec in kiali_deployment_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_secret_volumes[sec].secret_name }}
+          items:
+          - key: {{ kiali_deployment_secret_volumes[sec].secret_key }}
+            path: value.txt
+          optional: false
+{% endfor %}
 {% for secret in kiali_vars.deployment.custom_secrets %}
       - name: {{ secret.name }}
         secret:


### PR DESCRIPTION
* secrets now injected into pod file system, not as env vars
* put the change in the 1.57 role since we want this in 1.57 also

cherry pick of https://github.com/kiali/kiali-operator/pull/585

test procedures from the original PR can be used for the two backport PRs also: https://github.com/kiali/kiali/pull/5592#issuecomment-1298855778