### PR TITLE
Add a new configuration for jaeger query timeout

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -332,6 +332,7 @@ spec:
       query_scope:
         mesh_id: "mesh-1"
         cluster: "cluster-east"
+      query_timeout: 5
       url: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -895,6 +895,9 @@ spec:
                         description: "A set of tagKey/tagValue settings applied to every Jaeger query. Used to narrow unified traces to only those scoped to the Kiali instance."
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      query_timeout:
+                        description: "The amount of time in seconds Kiali will wait for a response from 'jaeger-query' service when fetching traces."
+                        type: integer
                       url:
                         description: "The external URL that will be used to generate links to Jaeger. It must be accessible to clients external to the cluster (e.g: a browser) in order to generate valid links. If the tracing service is deployed with a QUERY_BASE_PATH set, set this URL like https://<hostname>/<QUERY_BASE_PATH>. For example, https://tracing-service:8080/jaeger"
                         type: string

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -220,6 +220,7 @@ kiali_defaults:
       is_core: false
       namespace_selector: true
       query_scope: {}
+      query_timeout: 5
       url: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]


### PR DESCRIPTION
Kiali's query to 'jaeger-query' service for fetching traces times out occasionally and the timeout value is hardcoded.
Add a new configuration: 'query_timeout' to enable users to configure that timeout.

Closes https://github.com/kiali/kiali/issues/5751