### PR TITLE
mount with the subdirectory as the name of the secret, not the cluster

### DIFF
--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -246,8 +246,8 @@ kiali_defaults:
       - istio-ca-secret
     clustering:
       autodetect_secrets:
-        enabled: false
-        label: "istio/multiCluster=true"
+        enabled: true
+        label: "kiali.io/multiCluster=true"
       clusters: []
     disabled_features: []
     istio_injection_action: true

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -246,7 +246,7 @@ kiali_defaults:
       - istio-ca-secret
     clustering:
       autodetect_secrets:
-        enabled: true
+        enabled: false
         label: "istio/multiCluster=true"
       clusters: []
     disabled_features: []

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -727,7 +727,7 @@
     all_remote_cluster_secrets: "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='Secret', label_selector=kiali_vars.kiali_feature_flags.clustering.autodetect_secrets.label) }}"
   loop: "{{ all_remote_cluster_secrets }}"
   set_fact:
-    kiali_deployment_remote_cluster_secret_volumes: "{{ kiali_deployment_remote_cluster_secret_volumes | combine({ item.metadata.annotations['networking.istio.io/cluster']|default(item.metadata.name): {'secret_name': item.metadata.name }}) }}"
+    kiali_deployment_remote_cluster_secret_volumes: "{{ kiali_deployment_remote_cluster_secret_volumes | combine({ item.metadata.annotations['kiali.io/cluster']|default(item.metadata.name): {'secret_name': item.metadata.name }}) }}"
   when:
   - kiali_vars.kiali_feature_flags.clustering.autodetect_secrets.enabled
 

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -120,7 +120,7 @@ spec:
 {% endfor %}
 {% for sec in kiali_deployment_remote_cluster_secret_volumes %}
         - name: {{ sec }}
-          mountPath: "/kiali-remote-cluster-secrets/{{ sec }}"
+          mountPath: "/kiali-remote-cluster-secrets/{{ kiali_deployment_remote_cluster_secret_volumes[sec].secret_name }}"
           readOnly: true
 {% endfor %}
 {% if kiali_vars.deployment.resources|length > 0 %}

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -124,7 +124,7 @@ spec:
 {% endfor %}
 {% for sec in kiali_deployment_remote_cluster_secret_volumes %}
         - name: {{ sec }}
-          mountPath: "/kiali-remote-cluster-secrets/{{ sec }}"
+          mountPath: "/kiali-remote-cluster-secrets/{{ kiali_deployment_remote_cluster_secret_volumes[sec].secret_name }}"
           readOnly: true
 {% endfor %}
 {% if kiali_vars.deployment.resources|length > 0 %}


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/5767