### PR TITLE
Remove the kubernetes_config.cache_enabled configuration

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -417,7 +417,6 @@ spec:
   kubernetes_config:
     burst: 200
     cache_duration: 300
-    cache_enabled: true
     cache_istio_types:
     - "AuthorizationPolicy"
     - "DestinationRule"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1157,9 +1157,6 @@ spec:
                   cache_duration:
                     description: "The ratio interval (expressed in seconds) used for the cache to perform a full refresh. Only used when `cache_enabled` is true."
                     type: integer
-                  cache_enabled:
-                    description: "Flag to use a Kubernetes cache for watching changes and updating pods and controllers data asynchronously."
-                    type: boolean
                   cache_istio_types:
                     description: "Kiali can cache VirtualService, DestinationRule, Gateway and ServiceEntry Istio resources if they are present on this list of Istio types. Other Istio types are not yet supported."
                     type: array

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -121,7 +121,6 @@ spec:
   kubernetes_config:
     burst: null
     cache_duration: null
-    cache_enabled: null
     cache_istio_types: null
     cache_namespaces: null
     cache_token_namespace_duration: null

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -290,7 +290,6 @@ kiali_defaults:
   kubernetes_config:
     burst: 200
     cache_duration: 300
-    cache_enabled: true
     cache_istio_types:
     - "AuthorizationPolicy"
     - "DestinationRule"


### PR DESCRIPTION
The kiali back-end will no longer honor the kubernetes_config.cache_enabled configuration (kube cache is going to be mandatory). Thus, this is removing all references in the operator to such configuration, as it will no longer be valid.

Related issue kiali/kiali#5599
Related server PR: kiali/kiali#5779