### PR TITLE
Add new config option skip_wildcard_gateway_hosts

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -415,6 +415,7 @@ spec:
       refresh_interval: "60s"
     validations:
       ignore: ["KIA1201"]
+      skip_wildcard_gateway_hosts: false
 
   kubernetes_config:
     burst: 200

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -779,6 +779,9 @@ spec:
                       root_namespace:
                         description: "The namespace to treat as the administrative root namespace for Istio configuration."
                         type: string
+                      skip_wildcard_gateway_hosts:
+                        description: "To skip KIA0301 validation for Gateways with wildcards in hosts."
+                        type: boolean
                       url_service_version:
                         description: "The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint."
                         type: string

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -780,7 +780,7 @@ spec:
                         description: "The namespace to treat as the administrative root namespace for Istio configuration."
                         type: string
                       skip_wildcard_gateway_hosts:
-                        description: "To skip KIA0301 validation for Gateways with wildcards in hosts."
+                        description: "The KIA0301 validation checks duplicity of host and port combinations across all Istio Gateways. This includes also Gateways with '*' in hosts. But Istio considers such a Gateway with a wildcard in hosts as the last in order, after the Gateways with FQDN in hosts. This option is to skip Gateways with wildcards in hosts from the KIA0301 validations but still keep Gateways with FQDN hosts."
                         type: boolean
                       url_service_version:
                         description: "The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint."

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -288,6 +288,7 @@ kiali_defaults:
       refresh_interval: "60s"
     validations:
       ignore: ["KIA1201"]
+      skip_wildcard_gateway_hosts: false
 
   kubernetes_config:
     burst: 200


### PR DESCRIPTION
RFE https://github.com/kiali/kiali/issues/5711

Added new option "skip_wildcard_gateway_hosts" to skip "KIA0301 More than one Gateway for the same host port combination" validation for Gateways with wildcard in hostname.

Related core PR https://github.com/kiali/kiali/pull/5869