### PR TITLE
Fix parameters for metrics scraping by prometheus

### DIFF
--- a/manifests/kiali-community/1.66.0/manifests/kiali.v1.66.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.66.0/manifests/kiali.v1.66.0.clusterserviceversion.yaml
@@ -194,6 +194,8 @@ spec:
                 app.kubernetes.io/part-of: kiali-operator
               annotations:
                 prometheus.io/scrape: "true"
+                prometheus.io/path: /metrics
+                prometheus.io/port: "8080"
             spec:
               serviceAccountName: kiali-operator
               containers:

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -188,6 +188,8 @@ spec:
                 app.kubernetes.io/part-of: kiali-operator
               annotations:
                 prometheus.io/scrape: "true"
+                prometheus.io/path: /metrics
+                prometheus.io/port: "8080"
             spec:
               serviceAccountName: kiali-operator
               containers:
@@ -241,7 +243,7 @@ spec:
                 - name: RELATED_IMAGE_kiali_default
                   value: "${KIALI_1_65}"
                 - name: RELATED_IMAGE_kiali_v1_65
-                  value: "${KIALI_1_65}"  
+                  value: "${KIALI_1_65}"
                 - name: RELATED_IMAGE_kiali_v1_57
                   value: "${KIALI_1_57}"
                 - name: RELATED_IMAGE_kiali_v1_48

--- a/manifests/kiali-upstream/1.66.0/manifests/kiali.v1.66.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.66.0/manifests/kiali.v1.66.0.clusterserviceversion.yaml
@@ -194,6 +194,8 @@ spec:
                 app.kubernetes.io/part-of: kiali-operator
               annotations:
                 prometheus.io/scrape: "true"
+                prometheus.io/path: /metrics
+                prometheus.io/port: "8080"
             spec:
               serviceAccountName: kiali-operator
               containers:


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/5949 [added by @jmazzitelli]

By default `metrics.enabled` set to `true`, this adds annotation `prometheus.io/scrape: true`. However there no annotations that describe what port and endpoint needs to be used:
```
    prometheus.io/path: /metrics
    prometheus.io/port: "8080"
```

If `kiali-operator` deployed with istio sidecar - sidecar trying to scrap applications metrics from default port `80`.

This triggers errors like this:
```
	 2023-03-25T22:34:09.768729Z	error	failed scraping application metrics: error scraping http://localhost:80/metrics: Get "http://localhost:80/metrics": dial tcp [::1]:80: connect: connection refused
```

To fix it - need to add annotations for `Deployment`:
```
    prometheus.io/path: /metrics
    prometheus.io/port: "8080"
```

You can also check thread in `istio.slack.com` here https://istio.slack.com/archives/C37A4KAAD/p1679928230016999