### PR TITLE
Add config to support ui list page options

### DIFF
--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1087,6 +1087,8 @@ spec:
                                 enum: ["none","sent","received","total"]
                       list:
                         description: "Default settings for the List views (Apps, Workloads, etc)."
+                        type: object
+                        properties:
                           include_health:
                             description: "Include Health column (by default) for applicable list views. Setting to false can improve performance."
                             type: boolean

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1096,6 +1096,8 @@ spec:
                           include_validations:
                             description: "Include Configuration validation column (by default) for applicable list views. Setting to false can improve performance."
                             type: boolean
+                          show_include_toggles:
+                            description: "If true list pages display checkbox toggles for the include options, Otherwise the configured settings are applied but can not be changed by the user. Default is false."
                       metrics_per_refresh:
                         description: "Duration of metrics to fetch on each refresh. Value must be one of: `1m`, `2m`, `5m`, `10m`, `30m`, `1h`, `3h`, `6h`, `12h`, `1d`, `7d`, or `30d`"
                         type: string

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1085,6 +1085,14 @@ spec:
                                 description: "TCP traffic is measured in sent/received/total bytes. Only request traffic supplies response codes. Value must be one of: `none`, `sent`, `received`, or `total`."
                                 type: string
                                 enum: ["none","sent","received","total"]
+                      list:
+                        description: "Default settings for the List views (Apps, Workloads, etc)."
+                          include_health:
+                            description: "Include Health column (by default) for applicable list views. Setting false can improve performance."
+                            type: boolean
+                          include_istio_resources:
+                            description: "Include Istio resources (by default) in Details column for applicable list views. Setting false can improve performance."
+                            type: boolean
                       metrics_per_refresh:
                         description: "Duration of metrics to fetch on each refresh. Value must be one of: `1m`, `2m`, `5m`, `10m`, `30m`, `1h`, `3h`, `6h`, `12h`, `1d`, `7d`, or `30d`"
                         type: string

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1100,6 +1100,7 @@ spec:
                             type: boolean
                           show_include_toggles:
                             description: "If true list pages display checkbox toggles for the include options, Otherwise the configured settings are applied but can not be changed by the user. Default is false."
+                            type: boolean
                       metrics_per_refresh:
                         description: "Duration of metrics to fetch on each refresh. Value must be one of: `1m`, `2m`, `5m`, `10m`, `30m`, `1h`, `3h`, `6h`, `12h`, `1d`, `7d`, or `30d`"
                         type: string

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1088,10 +1088,13 @@ spec:
                       list:
                         description: "Default settings for the List views (Apps, Workloads, etc)."
                           include_health:
-                            description: "Include Health column (by default) for applicable list views. Setting false can improve performance."
+                            description: "Include Health column (by default) for applicable list views. Setting to false can improve performance."
                             type: boolean
                           include_istio_resources:
-                            description: "Include Istio resources (by default) in Details column for applicable list views. Setting false can improve performance."
+                            description: "Include Istio resources (by default) in Details column for applicable list views. Setting to false can improve performance."
+                            type: boolean
+                          include_validations:
+                            description: "Include Configuration validation column (by default) for applicable list views. Setting to false can improve performance."
                             type: boolean
                       metrics_per_refresh:
                         description: "Duration of metrics to fetch on each refresh. Value must be one of: `1m`, `2m`, `5m`, `10m`, `30m`, `1h`, `3h`, `6h`, `12h`, `1d`, `7d`, or `30d`"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -283,6 +283,7 @@ kiali_defaults:
         include_health: true
         include_istio_resources: true
         include_validations: true
+        show_include_toggles: false
       metrics_inbound:
         aggregations: []
       metrics_outbound:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -279,6 +279,9 @@ kiali_defaults:
           grpc: "requests"
           http: "requests"
           tcp: "sent"
+      list:
+        include_health: true
+        include_istio_resources: true
       metrics_inbound:
         aggregations: []
       metrics_outbound:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -282,6 +282,7 @@ kiali_defaults:
       list:
         include_health: true
         include_istio_resources: true
+        include_validations: true
       metrics_inbound:
         aggregations: []
       metrics_outbound:


### PR DESCRIPTION
Part-of https://github.com/kiali/kiali/issues/5867

Adds UI List page configurability for fatching some data optionally.