### PR TITLE
fix the typo in the new ansible setting name

### DIFF
--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -88,7 +88,7 @@ The previous section tells you how to run the Ansible playbook directly on your 
 
 ### Running the Operator With the Ansible Profiler
 
-If the ansible.cfg has `callback_enabled = profile_tasks` specified, a link:https://docs.ansible.com/ansible/2.9/plugins/callback/profile_tasks.html[profiler] is run and its report is dumped at the end of each reconciliation run. You can tell the operator to use such a configuration by setting the `ANSIBLE_CONFIG` environment variable to `/opt/ansible/ansible-profiler.cfg`.
+If the ansible.cfg has `callbacks_enabled = profile_tasks` specified (or the deprecated `callback_whitelist` for older Ansible installations), a link:https://docs.ansible.com/ansible/2.9/plugins/callback/profile_tasks.html[profiler] is run and its report is dumped at the end of each reconciliation run. You can tell the operator to use such a configuration by setting the `ANSIBLE_CONFIG` environment variable to `/opt/ansible/ansible-profiler.cfg`.
 
 The profiler report is usually good enough to start tracking down performance issues. But it may be difficult to see performance issues over tasks that loop because the profiler report will show duplicate entries for each loop invocation. In that case, copy the profiler report to a file and pipe it to a script with the following content to provide a more cumulative report:
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,4 +16,4 @@ COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible
 
-RUN cp /etc/ansible/ansible.cfg ${HOME}/ansible-profiler.cfg && echo "callback_enabled = profile_tasks" >> ${HOME}/ansible-profiler.cfg && echo "callback_whitelist = profile_tasks" >> ${HOME}/ansible-profiler.cfg
+RUN cp /etc/ansible/ansible.cfg ${HOME}/ansible-profiler.cfg && echo "callbacks_enabled = profile_tasks" >> ${HOME}/ansible-profiler.cfg && echo "callback_whitelist = profile_tasks" >> ${HOME}/ansible-profiler.cfg

--- a/molecule/accessible-namespaces-test/molecule.yml
+++ b/molecule/accessible-namespaces-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ./destroy-accessible-namespaces-test.yml
     prepare: ./prepare-accessible-namespaces-test.yml

--- a/molecule/affinity-tolerations-resources-test/molecule.yml
+++ b/molecule/affinity-tolerations-resources-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/config-values-test/molecule.yml
+++ b/molecule/config-values-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/default-namespace-test/molecule.yml
+++ b/molecule/default-namespace-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/grafana-test/molecule.yml
+++ b/molecule/grafana-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/header-auth-test/molecule.yml
+++ b/molecule/header-auth-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/instance-name-test/molecule.yml
+++ b/molecule/instance-name-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ./destroy-instance-name-test.yml
     prepare: ./prepare-instance-name-test.yml

--- a/molecule/jaeger-test/molecule.yml
+++ b/molecule/jaeger-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/metrics-test/molecule.yml
+++ b/molecule/metrics-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/null-cr-values-test/molecule.yml
+++ b/molecule/null-cr-values-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/only-view-only-mode-test/molecule.yml
+++ b/molecule/only-view-only-mode-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/openid-test/molecule.yml
+++ b/molecule/openid-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/openshift-auth-test/molecule.yml
+++ b/molecule/openshift-auth-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/os-console-links-test/molecule.yml
+++ b/molecule/os-console-links-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/read-certs-secrets-test/molecule.yml
+++ b/molecule/read-certs-secrets-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/roles-test/molecule.yml
+++ b/molecule/roles-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/rolling-restart-test/molecule.yml
+++ b/molecule/rolling-restart-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/molecule/token-test/molecule.yml
+++ b/molecule/token-test/molecule.yml
@@ -11,7 +11,7 @@ provisioner:
   name: ansible
   config_options:
     defaults:
-      callback_enabled: junit
+      callbacks_enabled: junit
   playbooks:
     destroy: ../default/destroy.yml
     prepare: ../default/prepare.yml

--- a/requirements.yml
+++ b/requirements.yml
@@ -29,6 +29,9 @@
 #
 # To install that version locally, you can git clone the source via:
 #   git clone -b v<ansible version> --depth 1 https://github.com/ansible/ansible.git
+# and then set up your environment via:
+#   source ./ansible/hacking/env-setup -q
+
 
 collections:
 - name: kubernetes.core


### PR DESCRIPTION
The new setting name is `callbacks_enabled` (in the plural).

Also keep the deprecated name around since currently we are using an ansible version that doesn't know about the new one.

fixes https://github.com/kiali/kiali/issues/4338