### PR TITLE
fix the CRD schema and have validation tool print out errors

### DIFF
--- a/crd-docs/bin/validate-kiali-cr.sh
+++ b/crd-docs/bin/validate-kiali-cr.sh
@@ -140,6 +140,8 @@ fi
 # install the test CRD with the schema
 if ! echo "$(crd)" | ${CLIENT_EXE} apply --validate=true --wait=true -f - &> /dev/null ; then
   echo "ERROR! Failed to install the test CRD"
+  # run it again to show the errors
+  echo "$(crd)" | ${CLIENT_EXE} apply --validate=true --wait=true -f -
   exit 1
 fi
 

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -412,7 +412,7 @@ spec:
           label: "istio_io_rev"
       # default: namespaces is an empty list
       namespaces: ["istio-system"]
-      refresh_interval: "60s"
+      refresh_interval: "1m"
     validations:
       ignore: ["KIA1201"]
       skip_wildcard_gateway_hosts: false

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -779,9 +779,6 @@ spec:
                       root_namespace:
                         description: "The namespace to treat as the administrative root namespace for Istio configuration."
                         type: string
-                      skip_wildcard_gateway_hosts:
-                        description: "The KIA0301 validation checks duplicity of host and port combinations across all Istio Gateways. This includes also Gateways with '*' in hosts. But Istio considers such a Gateway with a wildcard in hosts as the last in order, after the Gateways with FQDN in hosts. This option is to skip Gateways with wildcards in hosts from the KIA0301 validations but still keep Gateways with FQDN hosts."
-                        type: boolean
                       url_service_version:
                         description: "The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint."
                         type: string
@@ -1156,6 +1153,9 @@ spec:
                         items:
                           description: "A validation code (e.g. `KIA0101`) for a specific validation error that is to be ignored."
                           type: string
+                      skip_wildcard_gateway_hosts:
+                        description: "The KIA0301 validation checks duplicity of host and port combinations across all Istio Gateways. This includes also Gateways with '*' in hosts. But Istio considers such a Gateway with a wildcard in hosts as the last in order, after the Gateways with FQDN in hosts. This option is to skip Gateways with wildcards in hosts from the KIA0301 validations but still keep Gateways with FQDN hosts."
+                        type: boolean
 
               kubernetes_config:
                 description: "Configuration of Kiali's access of the Kubernetes API."


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/6015

To test this, start a cluster and in the operator repo, run this make target: `make validate-cr` -- it should now pass