### PR TITLE
remove ansible loops from deploy - should make it faster

### DIFF
--- a/roles/default/kiali-deploy/tasks/clusterroles-to-remove.yml
+++ b/roles/default/kiali-deploy/tasks/clusterroles-to-remove.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-viewer

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -7,23 +7,20 @@
 - name: Create Kiali objects on Kubernetes
   include_tasks: process-resource.yml
   vars:
-    process_resource_cluster: "kubernetes"
     role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
-  loop:
-  - serviceaccount
-  - configmap
-  - "{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}"
-  - role-controlplane
-  - rolebinding
-  - rolebinding-controlplane
-  - deployment
-  - service
-  - "{{ 'hpa' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"
-  loop_control:
-    loop_var: process_resource_item
+    process_resource_templates:
+    - "templates/kubernetes/serviceaccount.yaml"
+    - "templates/kubernetes/configmap.yaml"
+    - "templates/kubernetes/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/kubernetes/role-controlplane.yaml"
+    - "templates/kubernetes/rolebinding.yaml"
+    - "templates/kubernetes/rolebinding-controlplane.yaml"
+    - "templates/kubernetes/deployment.yaml"
+    - "templates/kubernetes/service.yaml"
+    - "{{ 'templates/kubernetes/hpa.yaml' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"
+    - "{{ 'templates/kubernetes/ingress.yaml' if kiali_vars.deployment.ingress.enabled|bool == True else '' }}"
   when:
   - is_k8s == True
-  - process_resource_item != ''
 
 - name: Remove HPA if disabled on Kubernetes
   k8s:
@@ -35,19 +32,6 @@
   when:
   - is_k8s == True
   - kiali_vars.deployment.hpa.spec | length == 0
-
-- name: Create Ingress on Kubernetes if enabled
-  include_tasks: process-resource.yml
-  vars:
-    process_resource_cluster: "kubernetes"
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
-  loop:
-  - ingress
-  loop_control:
-    loop_var: process_resource_item
-  when:
-  - is_k8s == True
-  - kiali_vars.deployment.ingress.enabled|bool == True
 
 - name: Delete Ingress on Kubernetes if disabled
   k8s:
@@ -67,20 +51,13 @@
   - is_k8s == True
   - '"**" not in kiali_vars.deployment.accessible_namespaces'
 
-- name: Create additional Kiali roles on all accessible namespaces on Kubernetes
+- name: Create additional Kiali roles/bindings on all accessible namespaces on Kubernetes
   vars:
     role_namespaces: "{{ kiali_vars.deployment.accessible_namespaces }}"
   k8s:
-    definition: "{{ lookup('template', 'templates/kubernetes/' + ('role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role') + '.yaml') }}"
-  when:
-  - is_k8s == True
-  - '"**" not in kiali_vars.deployment.accessible_namespaces'
-
-- name: Create additional Kiali role bindings on all accessible namespaces on Kubernetes
-  vars:
-    role_namespaces: "{{ kiali_vars.deployment.accessible_namespaces }}"
-  k8s:
-    definition: "{{ lookup('template', 'templates/kubernetes/rolebinding.yaml') }}"
+    template:
+    - "templates/kubernetes/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/kubernetes/rolebinding.yaml"
   when:
   - is_k8s == True
   - '"**" not in kiali_vars.deployment.accessible_namespaces'

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -156,7 +156,8 @@
   # restrict to 40 chars, not 63, because instance_name is a prefix and we need to prepend additional chars for some resource names (like "-service-account")
   - kiali_vars.deployment.instance_name is not regex('^(?![0-9]+$)(?!-)[a-z0-9-]{,40}(?<!-)$')
 
-- set_fact:
+- name: "Determine environment to store in status"
+  set_fact:
     status_environment: "{{ status_environment | default({}) | combine({item.0: item.1}) }}"
   loop: "{{ data[0] | zip(data[1]) | list }}"
   vars:
@@ -941,9 +942,10 @@
     definition: "{{ updated_deployment }}"
   when:
   - deployment_is_new == False
-  - processed_resources.configmap is defined
-  - processed_resources.configmap.changed == True
-  - processed_resources.configmap.method == "patch"
+  - processed_resources_dict is defined
+  - processed_resources_dict['ConfigMap'] is defined
+  - processed_resources_dict['ConfigMap'].changed == True
+  - processed_resources_dict['ConfigMap'].method == "patch"
 
 # Can't just populate with the list of namespaces - see https://github.com/operator-framework/operator-sdk-ansible-util/issues/12
 # So instead - if the list of namespaces is manageable, store them in a comma-separate list.

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -934,8 +934,12 @@
   - is_k8s == True
 
 # If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
+# We do this by checking the processed_resources_dict created by process-resources.yml task. If there is a map key
+# with the kind (ConfigMap) with the name of our config map appended to it ("-" + the kiali instanance name) see if that config map changed.
+# If it did, we need to restart the kiali pod so it can re-read the new config.
 - name: Force the Kiali pod to restart if necessary
   vars:
+    keyname: "{{ 'ConfigMap-' + kiali_vars.deployment.instance_name }}"
     updated_deployment: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
   k8s:
     state: "present"
@@ -943,9 +947,9 @@
   when:
   - deployment_is_new == False
   - processed_resources_dict is defined
-  - processed_resources_dict['ConfigMap'] is defined
-  - processed_resources_dict['ConfigMap'].changed == True
-  - processed_resources_dict['ConfigMap'].method == "patch"
+  - processed_resources_dict[keyname] is defined
+  - processed_resources_dict[keyname].changed == True
+  - processed_resources_dict[keyname].method == "patch"
 
 # Can't just populate with the list of namespaces - see https://github.com/operator-framework/operator-sdk-ansible-util/issues/12
 # So instead - if the list of namespaces is manageable, store them in a comma-separate list.

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -7,24 +7,21 @@
 - name: Create Kiali objects on OpenShift
   include_tasks: process-resource.yml
   vars:
-    process_resource_cluster: "openshift"
     role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
-  loop:
-  - serviceaccount
-  - configmap
-  - cabundle
-  - "{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}"
-  - role-controlplane
-  - rolebinding
-  - rolebinding-controlplane
-  - deployment
-  - service
-  - "{{ 'hpa' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"
-  loop_control:
-    loop_var: process_resource_item
+    process_resource_templates:
+    - "templates/openshift/serviceaccount.yaml"
+    - "templates/openshift/configmap.yaml"
+    - "templates/openshift/cabundle.yaml"
+    - "templates/openshift/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/openshift/role-controlplane.yaml"
+    - "templates/openshift/rolebinding.yaml"
+    - "templates/openshift/rolebinding-controlplane.yaml"
+    - "templates/openshift/deployment.yaml"
+    - "templates/openshift/service.yaml"
+    - "{{ 'templates/openshift/hpa.yaml' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"
+    - "{{ 'templates/openshift/route.yaml' if kiali_vars.deployment.ingress.enabled|bool == True else '' }}"
   when:
   - is_openshift == True
-  - process_resource_item != ''
 
 - name: Remove HPA if disabled on OpenShift
   k8s:
@@ -36,19 +33,6 @@
   when:
   - is_openshift == True
   - kiali_vars.deployment.hpa.spec | length == 0
-
-- name: Create Route on OpenShift if enabled
-  include_tasks: process-resource.yml
-  vars:
-    process_resource_cluster: "openshift"
-    role_namespace: "{{ kiali_vars.deployment.namespace }}"
-  loop:
-  - route
-  loop_control:
-    loop_var: process_resource_item
-  when:
-  - is_openshift == True
-  - kiali_vars.deployment.ingress.enabled|bool == True
 
 - name: Delete Route on OpenShift if disabled
   k8s:
@@ -68,20 +52,13 @@
   - is_openshift == True
   - '"**" not in kiali_vars.deployment.accessible_namespaces'
 
-- name: Create additional Kiali roles on all accessible namespaces on OpenShift
+- name: Create additional Kiali roles/bindings on all accessible namespaces on OpenShift
   vars:
     role_namespaces: "{{ kiali_vars.deployment.accessible_namespaces }}"
   k8s:
-    definition: "{{ lookup('template', 'templates/openshift/' + ('role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role') + '.yaml') }}"
-  when:
-  - is_openshift == True
-  - '"**" not in kiali_vars.deployment.accessible_namespaces'
-
-- name: Create additional Kiali role bindings on all accessible namespaces on OpenShift
-  vars:
-    role_namespaces: "{{ kiali_vars.deployment.accessible_namespaces }}"
-  k8s:
-    definition: "{{ lookup('template', 'templates/openshift/rolebinding.yaml') }}"
+    template:
+    - "templates/openshift/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/openshift/rolebinding.yaml"
   when:
   - is_openshift == True
   - '"**" not in kiali_vars.deployment.accessible_namespaces'

--- a/roles/default/kiali-deploy/tasks/process-resource.yml
+++ b/roles/default/kiali-deploy/tasks/process-resource.yml
@@ -1,15 +1,31 @@
-- name: "Create resource [{{ process_resource_item }}] on [{{ process_resource_cluster }}]"
+# process all template names found in process_resource_templates - any empty strings in the list are ignored.
+# This will keep a running tally of all processed resources in "processed_resources_dict".
+- name: "Create Kiali resources from templates"
   k8s:
     state: "present"
-    definition: "{{ lookup('template', 'templates/' + process_resource_cluster + '/' + process_resource_item + '.yaml') }}"
-  register: process_resource_result
-  until:
-  - process_resource_result.error is not defined
-  - process_resource_result.result is defined
-  - process_resource_result.result.metadata is defined
+    continue_on_error: false
+    template: "{{ process_resource_templates | select() | list }}"
+  register: process_resource_templates_result
   retries: 6
   delay: 10
 
-# Store the results of the processed resource so they can be examined later (e.g. to know if something changed or stayed the same)
-- set_fact:
-    processed_resources: "{{ processed_resources | default({}) | combine( { process_resource_item: { 'changed': process_resource_result.changed, 'method': process_resource_result.method } } ) }}"
+# Store the results of the processed resources so they can be examined later (e.g. to know if something changed or stayed the same)
+- vars:
+    kinds: "{{ process_resource_templates_result.result.results | map(attribute='result.kind') | list }}"
+    names: "{{ process_resource_templates_result.result.results | map(attribute='result.metadata.name') | list }}"
+    changed: "{{ process_resource_templates_result.result.results | map(attribute='changed') | list }}"
+    method: "{{ process_resource_templates_result.result.results | map(attribute='method') | list }}"
+    thedict: "{{ processed_resources_dict | default({}) }}"
+  set_fact:
+    processed_resources_dict: |
+      {% for kind in kinds %}
+      {%   set _ = thedict.update({ kind: {'name': names[loop.index0], 'changed': changed[loop.index0], 'method': method[loop.index0]}}) %}
+      {% endfor %}
+      {{ thedict }}
+  when:
+  - process_resource_templates_result is defined
+  - process_resource_templates_result | length > 0
+
+- name: "Kiali resource creation results"
+  debug:
+    msg: "{{ processed_resources_dict }}"

--- a/roles/default/kiali-deploy/tasks/process-resource.yml
+++ b/roles/default/kiali-deploy/tasks/process-resource.yml
@@ -19,7 +19,7 @@
   set_fact:
     processed_resources_dict: |
       {% for kind in kinds %}
-      {%   set _ = thedict.update({ kind: {'name': names[loop.index0], 'changed': changed[loop.index0], 'method': method[loop.index0]}}) %}
+      {%   set _ = thedict.update({ (kind + '-' + names[loop.index0]): {'name': names[loop.index0], 'changed': changed[loop.index0], 'method': method[loop.index0]}}) %}
       {% endfor %}
       {{ thedict }}
   when:

--- a/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/default/kiali-deploy/tasks/remove-clusterroles.yml
@@ -2,23 +2,8 @@
   ignore_errors: yes
   k8s:
     state: absent
-    api_version: "{{ k8s_item.apiVersion }}"
-    kind: "{{ k8s_item.kind }}"
-    name: "{{ k8s_item.metadata.name }}"
-  register: delete_result
-  until: delete_result.result == {} or (delete_result.result.status is defined and delete_result.result.status == "Success")
+    continue_on_error: false
+    template:
+    - clusterroles-to-remove.yml
   retries: 6
   delay: 10
-  when:
-  - is_openshift == True or is_k8s == True
-  - k8s_item is defined
-  - k8s_item.apiVersion is defined
-  - k8s_item.kind is defined
-  - k8s_item.metadata is defined
-  - k8s_item.metadata.name is defined
-  with_items:
-  - "{{ query(k8s_plugin, kind='ClusterRoleBinding', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1') }}"
-  - "{{ query(k8s_plugin, kind='ClusterRole', resource_name=kiali_vars.deployment.instance_name + '-viewer', api_version='rbac.authorization.k8s.io/v1') }}"
-  loop_control:
-    loop_var: k8s_item


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/6032

analogous to https://github.com/kiali/kiali-operator/pull/636 which sped up the remove playbook by removing ansible loops. This PR does the same only in the deploy playbook.