### PR TITLE
[v1.65] provide permission to support override_yaml.spec.host on openshift

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -395,6 +395,7 @@ spec:
         - apiGroups: ["route.openshift.io"]
           resources:
           - routes
+          - routes/custom-host
           verbs:
           - create
           - delete


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/6083

This is a cherry pick that ignores the following files from the commit:

manifests/kiali-community/1.68.0/manifests/kiali.v1.68.0.clusterserviceversion.yaml manifests/kiali-upstream/1.68.0/manifests/kiali.v1.68.0.clusterserviceversion.yaml

We don't need those in the v1.65 branch so no need worrying about the conflicts. Just ignore those.