### PR TITLE
[v1.65] set oauth redirect to route with non-standard port

### DIFF
--- a/roles/default/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/oauth.yaml
@@ -5,6 +5,9 @@ metadata:
   labels: {{ kiali_resource_metadata_labels }}
 redirectURIs:
   - {{ kiali_route_url }}
+{% if kiali_vars.server.web_port | length > 0 %}
+  - {{ kiali_route_url }}:{{ kiali_vars.server.web_port }}
+{% endif %}
 grantMethod: auto
 {% if kiali_vars.auth.openshift.token_inactivity_timeout is defined %}
 accessTokenInactivityTimeoutSeconds: {{ kiali_vars.auth.openshift.token_inactivity_timeout }}

--- a/roles/v1.57/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/oauth.yaml
@@ -5,6 +5,9 @@ metadata:
   labels: {{ kiali_resource_metadata_labels }}
 redirectURIs:
   - {{ kiali_route_url }}
+{% if kiali_vars.server.web_port | length > 0 %}
+  - {{ kiali_route_url }}:{{ kiali_vars.server.web_port }}
+{% endif %}
 grantMethod: auto
 {% if kiali_vars.auth.openshift.token_inactivity_timeout is defined %}
 accessTokenInactivityTimeoutSeconds: {{ kiali_vars.auth.openshift.token_inactivity_timeout }}

--- a/roles/v1.65/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/oauth.yaml
@@ -5,6 +5,9 @@ metadata:
   labels: {{ kiali_resource_metadata_labels }}
 redirectURIs:
   - {{ kiali_route_url }}
+{% if kiali_vars.server.web_port | length > 0 %}
+  - {{ kiali_route_url }}:{{ kiali_vars.server.web_port }}
+{% endif %}
 grantMethod: auto
 {% if kiali_vars.auth.openshift.token_inactivity_timeout is defined %}
 accessTokenInactivityTimeoutSeconds: {{ kiali_vars.auth.openshift.token_inactivity_timeout }}


### PR DESCRIPTION
backport to versions 1.57 and 1.65 of the ansible roles

part of https://github.com/kiali/kiali/issues/6180

cherry-pick of https://github.com/kiali/kiali-operator/pull/649