### PR TITLE
[v1.65] default to HPA v2 which is supported on OpenShift 4.10+

### DIFF
--- a/roles/v1.48/kiali-deploy/defaults/main.yml
+++ b/roles/v1.48/kiali-deploy/defaults/main.yml
@@ -60,7 +60,7 @@ kiali_defaults:
     custom_secrets: []
     host_aliases: []
     hpa:
-      api_version: "autoscaling/v2beta2"
+      api_version: "autoscaling/v2"
       spec: {}
     image_digest: ""
     image_name: ""


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/OSSM-4069