### PR TITLE
Add hidden feature flag for choosing which graph impls to display

### DIFF
--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -256,6 +256,8 @@ kiali_defaults:
     istio_upgrade_action: false
     ui_defaults:
       graph:
+        enable_cytoscape: true
+        enable_patternfly: false
         find_options:
         - description: "Find: slow edges (> 1s)"
           expression: "rt > 1000"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -256,8 +256,6 @@ kiali_defaults:
     istio_upgrade_action: false
     ui_defaults:
       graph:
-        enable_cytoscape: true
-        enable_patternfly: false
         find_options:
         - description: "Find: slow edges (> 1s)"
           expression: "rt > 1000"
@@ -274,6 +272,7 @@ kiali_defaults:
           expression:  "name = unknown"
         - description: "Hide: nodes ranked lower than the 2 top rankings"
           expression:  "rank > 2"
+        impl: "cy"
         settings:
           font_label: 13
           min_font_badge: 7


### PR DESCRIPTION
This is supposed to be a "hidden" feature flag that can allow us to choose just cytoscape graph, just patternfly graph, or both, which is useful for comparing/debugging.