### PR TITLE
fix remote cluster secret label default

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -374,7 +374,7 @@ spec:
     clustering:
       autodetect_secrets:
         enabled: true
-        label: "istio/multiCluster=true"
+        label: "kiali.io/multiCluster=true"
       clusters: []
     disabled_features: []
     istio_annotation_action: true

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1008,7 +1008,7 @@ spec:
                             description: "If true then remote cluster secrets will be autodetected during the installation of the Kiali Server Deployment. Any remote cluster secrets found in the Kiali deployment namespace will be mounted to the Kiali Server's file system. If false, you can still manually specify the remote cluster secret information in the 'clusters' setting if you wish to utilize multicluster features."
                             type: boolean
                           label:
-                            description: "The name and value of a label that exists on all remote cluster secrets. Default is 'istio/multiCluster=true'."
+                            description: "The name and value of a label that exists on all remote cluster secrets. Default is 'kiali.io/multiCluster=true'."
                             type: string
                       clusters:
                         description: "A list of clusters that the Kiali Server can access. You need to specify the remote clusters here if 'autodetect_secrets.enabled' is false."


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/6344

The default is defined here - you can see it is "kiali.io" not "istio" prefix: https://github.com/kiali/kiali-operator/blob/master/roles/default/kiali-deploy/defaults/main.yml#L251
