### PR TITLE
ARM identifier is arm64

### DIFF
--- a/manifests/kiali-community/1.74.0/manifests/kiali.v1.74.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.74.0/manifests/kiali.v1.74.0.clusterserviceversion.yaml
@@ -3,6 +3,11 @@ kind: ClusterServiceVersion
 metadata:
   name: kiali-operator.v1.74.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
   annotations:
     olm.skipRange: '>=1.0.0 <1.74.0'
     categories: Monitoring,Logging & Tracing

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
-    operatorframework.io/arch.aarch64: supported
+    operatorframework.io/arch.arm64: supported
   annotations:
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     olm.skipRange: '>=1.0.0 <${KIALI_OPERATOR_VERSION}'

--- a/manifests/kiali-upstream/1.74.0/manifests/kiali.v1.74.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.74.0/manifests/kiali.v1.74.0.clusterserviceversion.yaml
@@ -3,6 +3,11 @@ kind: ClusterServiceVersion
 metadata:
   name: kiali-operator.v1.74.0
   namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
   annotations:
     olm.skipRange: '>=1.0.0 <1.74.0'
     categories: Monitoring,Logging & Tracing


### PR DESCRIPTION
The arch name is based on GOARCH, so it has to be `arm64`:

https://olm.operatorframework.io/docs/advanced-tasks/ship-operator-supporting-multiarch/