### PR TITLE
[v1.65] ARM identifier is arm64

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
-    operatorframework.io/arch.aarch64: supported
+    operatorframework.io/arch.arm64: supported
   annotations:
     operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
     olm.skipRange: '>=1.0.0 <${KIALI_OPERATOR_VERSION}'


### PR DESCRIPTION
The arch name is based on GOARCH, so it has to be `arm64`:

https://olm.operatorframework.io/docs/advanced-tasks/ship-operator-supporting-multiarch/