### PR TITLE
Create provider field in the tracing config

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -331,6 +331,7 @@ spec:
       in_cluster_url: ""
       is_core: false
       namespace_selector: true
+      provider: "jaeger"
       # default: query_scope is empty
       query_scope:
         mesh_id: "mesh-1"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -894,7 +894,7 @@ spec:
                       namespace_selector:
                         description: "Kiali use this boolean to find traces with a namespace selector : service.namespace."
                         type: boolean
-                      provide:
+                      provider:
                         description: "The trace provider to get the traces from. Value must be one of: `jaeger` or `tempo`."
                         type: string
                       query_scope:

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -854,7 +854,7 @@ spec:
                         description: "The URL used to query the Prometheus Server. This URL must be accessible from the Kiali pod. If empty, the default will assume Prometheus is in the Istio control plane namespace; e.g. `http://prometheus.<istio_namespace>:9090`."
                         type: string
                   tracing:
-                    description: "Configuration used to access the Tracing (Jaeger) dashboards."
+                    description: "Configuration used to access the Tracing (Jaeger or Tempo) dashboards."
                     type: object
                     properties:
                       auth:
@@ -894,6 +894,9 @@ spec:
                       namespace_selector:
                         description: "Kiali use this boolean to find traces with a namespace selector : service.namespace."
                         type: boolean
+                      provide:
+                        description: "The trace provider to get the traces from. Value must be one of: `jaeger` or `tempo`."
+                        type: string
                       query_scope:
                         description: "A set of tagKey/tagValue settings applied to every Jaeger query. Used to narrow unified traces to only those scoped to the Kiali instance."
                         type: object

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -220,6 +220,7 @@ kiali_defaults:
       in_cluster_url: ""
       is_core: false
       namespace_selector: true
+      provider: "jaeger"
       query_scope: {}
       query_timeout: 5
       url: ""


### PR DESCRIPTION
Ref. https://github.com/kiali/kiali/pull/6518

Example:

```
  tracing:
    enabled: true
    provider: "tempo"
    in_cluster_url: http://localhost:16685
    url: http://localhost:16686
```