### PR TITLE
Fix upgrade with no label_selector_include (#6778)

### DIFF
--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -788,6 +788,7 @@
   - current_cluster_wide_access is defined
   - current_cluster_wide_access|bool == False
   - current_label_selector_include is defined
+  - current_label_selector_include != ""
   - kiali_vars.api.namespaces.label_selector_include is defined
   - current_label_selector_include != kiali_vars.api.namespaces.label_selector_include
 
@@ -884,6 +885,7 @@
   when:
   - no_longer_accessible_namespaces is defined
   - current_label_selector_include is defined
+  - current_label_selector_include != ""
 
 - name: Create additional Kiali label on all accessible namespaces
   vars:


### PR DESCRIPTION
fixes: kiali/kiali#6778

When `label_selector_include` is not set in Kiali CR, upgrade still tries to patch some namespaces as variable used to retrieve it has empty string as value.

Make sure it's not the case anymore