### PR TITLE
Provide different OpenShift and non-OpenShift watches yaml files

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,8 @@ USER ${USER_UID}
 
 COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
-COPY watches.yaml ${HOME}/watches.yaml
+COPY watches-k8s.yaml ${HOME}/watches-k8s.yaml
+COPY watches-os.yaml ${HOME}/watches-os.yaml
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -257,6 +257,7 @@ spec:
                 args:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
+                - "--watches-file=./watches-os.yaml"
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false

--- a/watches-k8s.yaml
+++ b/watches-k8s.yaml
@@ -1,0 +1,24 @@
+# KUBERNETES/NON-OPENSHIFT WATCHES YAML
+---
+# The normal Kiali CR processing playbook
+- version: v1alpha1
+  group: kiali.io
+  kind: Kiali
+  playbook: playbooks/kiali-deploy.yml
+  reconcilePeriod: "0s"
+  watchDependentResources: False
+  watchClusterScopedResources: False
+  watchAnnotationsChanges: True
+  finalizer:
+    name: kiali.io/finalizer
+    playbook: playbooks/kiali-remove.yml
+# Watching new namespaces so the operator can determine if they should be accessible to Kiali
+- version: v1
+  group: ""
+  kind: Namespace
+  playbook: playbooks/kiali-new-namespace-detected.yml
+  reconcilePeriod: "0s"
+  manageStatus: False
+  watchDependentResources: False
+  watchClusterScopedResources: False
+  watchAnnotationsChanges: False

--- a/watches-os.yaml
+++ b/watches-os.yaml
@@ -1,3 +1,4 @@
+# OPENSHIFT WATCHES YAML
 ---
 # The normal Kiali CR processing playbook
 - version: v1alpha1


### PR DESCRIPTION
partial cherry pick of https://github.com/kiali/kiali-operator/pull/710

need to pick up the changes for the new watches files and changes to the kiali-ossm OLM metadata

part of : https://github.com/kiali/kiali/issues/6790