### PR TITLE
[v1.73] Ignore CRs that are not in control of the OSSMC installation.

### DIFF
--- a/roles/default/ossmconsole-deploy/tasks/main.yml
+++ b/roles/default/ossmconsole-deploy/tasks/main.yml
@@ -5,6 +5,25 @@
   set_fact:
     current_cr: "{{ _kiali_io_ossmconsole }}"
 
+- name: Find oldest CR
+  vars:
+    crs: "{{ query(k8s_plugin, kind=current_cr.kind, api_version=current_cr.apiVersion) | sort(attribute='metadata.creationTimestamp') }}"
+  set_fact:
+    oldest_ossmconsole_cr: "{{ crs[0] }}"
+  when:
+  - crs | length > 0
+
+- block:
+  - debug:
+      msg: "Ignoring this CR [{{ current_cr.metadata.namespace }}/{{ current_cr.metadata.name }}]. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - include_tasks: update-status-progress.yml
+    vars:
+      status_progress_message: "Ignoring this CR. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - meta: end_play
+  when:
+  - oldest_ossmconsole_cr is defined
+  - oldest_ossmconsole_cr.metadata.name != current_cr.metadata.name or oldest_ossmconsole_cr.metadata.namespace != current_cr.metadata.namespace
+
 - include_tasks: update-status-progress.yml
   vars:
     status_progress_message: "Initializing"

--- a/roles/default/ossmconsole-remove/tasks/main.yml
+++ b/roles/default/ossmconsole-remove/tasks/main.yml
@@ -14,6 +14,22 @@
   set_fact:
     current_cr: "{{ _kiali_io_ossmconsole }}"
 
+- name: Find oldest CR
+  vars:
+    crs: "{{ query(k8s_plugin, kind=current_cr.kind, api_version=current_cr.apiVersion) | sort(attribute='metadata.creationTimestamp') }}"
+  set_fact:
+    oldest_ossmconsole_cr: "{{ crs[0] }}"
+  when:
+  - crs | length > 0
+
+- block:
+  - debug:
+      msg: "Ignoring this CR [{{ current_cr.metadata.namespace }}/{{ current_cr.metadata.name }}]. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - meta: end_play
+  when:
+  - oldest_ossmconsole_cr is defined
+  - oldest_ossmconsole_cr.metadata.name != current_cr.metadata.name or oldest_ossmconsole_cr.metadata.namespace != current_cr.metadata.namespace
+
 - name: Print some debug information
   ignore_errors: yes
   vars:

--- a/roles/v1.73/ossmconsole-deploy/tasks/main.yml
+++ b/roles/v1.73/ossmconsole-deploy/tasks/main.yml
@@ -5,6 +5,25 @@
   set_fact:
     current_cr: "{{ _kiali_io_ossmconsole }}"
 
+- name: Find oldest CR
+  vars:
+    crs: "{{ query(k8s_plugin, kind=current_cr.kind, api_version=current_cr.apiVersion) | sort(attribute='metadata.creationTimestamp') }}"
+  set_fact:
+    oldest_ossmconsole_cr: "{{ crs[0] }}"
+  when:
+  - crs | length > 0
+
+- block:
+  - debug:
+      msg: "Ignoring this CR [{{ current_cr.metadata.namespace }}/{{ current_cr.metadata.name }}]. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - include_tasks: update-status-progress.yml
+    vars:
+      status_progress_message: "Ignoring this CR. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - meta: end_play
+  when:
+  - oldest_ossmconsole_cr is defined
+  - oldest_ossmconsole_cr.metadata.name != current_cr.metadata.name or oldest_ossmconsole_cr.metadata.namespace != current_cr.metadata.namespace
+
 - include_tasks: update-status-progress.yml
   vars:
     status_progress_message: "Initializing"

--- a/roles/v1.73/ossmconsole-remove/tasks/main.yml
+++ b/roles/v1.73/ossmconsole-remove/tasks/main.yml
@@ -14,6 +14,22 @@
   set_fact:
     current_cr: "{{ _kiali_io_ossmconsole }}"
 
+- name: Find oldest CR
+  vars:
+    crs: "{{ query(k8s_plugin, kind=current_cr.kind, api_version=current_cr.apiVersion) | sort(attribute='metadata.creationTimestamp') }}"
+  set_fact:
+    oldest_ossmconsole_cr: "{{ crs[0] }}"
+  when:
+  - crs | length > 0
+
+- block:
+  - debug:
+      msg: "Ignoring this CR [{{ current_cr.metadata.namespace }}/{{ current_cr.metadata.name }}]. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - meta: end_play
+  when:
+  - oldest_ossmconsole_cr is defined
+  - oldest_ossmconsole_cr.metadata.name != current_cr.metadata.name or oldest_ossmconsole_cr.metadata.namespace != current_cr.metadata.namespace
+
 - name: Print some debug information
   ignore_errors: yes
   vars:


### PR DESCRIPTION
The first CR created (i.e. the oldest one) is the one that controls OSSMC.

fixes: https://github.com/kiali/kiali/issues/6792

backport of: https://github.com/kiali/kiali-operator/pull/712