### PR TITLE
revert createdAt to avoid publishing problems

### DIFF
--- a/manifests/kiali-community/1.78.0/manifests/kiali.v1.78.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.78.0/manifests/kiali.v1.78.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     support: Kiali
     description: "This community operator provides Kiali and OSSMC. Kiali is the Istio observability and management Console. OSSMC is the OpenShift Service Mesh Console plugin, powered by Kiali."
     repository: https://github.com/kiali/kiali
-    createdAt: 2023-12-11T07:13:40Z
+    createdAt: 2023-11-20T07:13:42Z
     alm-examples: |-
       [
         {


### PR DESCRIPTION
the upstream prod system doesn't like previous bundles changing and somehow this changed (I don't know why). Just put this back so we don't keep hitting this issue with this bundle.

See the problem manifest itself here: https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/3918