### PR TITLE
Add i18n settings to kiali operator

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -68,7 +68,7 @@ spec:
 
   deployment:
     # default: accessible_namespaces is undefined
-    accessible_namespaces: [ "my-mesh.*" ]
+    accessible_namespaces: ["my-mesh.*"]
     # default: additional_service_yaml is empty
     additional_service_yaml:
       externalName: "kiali.example.com"
@@ -371,7 +371,7 @@ spec:
   istio_labels:
     app_label_name: "app"
     injection_label_name: "istio-injection"
-    injection_label_rev:  "istio.io/rev"
+    injection_label_rev: "istio.io/rev"
     version_label_name: "version"
 
   kiali_feature_flags:
@@ -396,18 +396,21 @@ spec:
         - description: "Find: slow edges (> 1s)"
           expression: "rt > 1000"
         - description: "Find: unhealthy nodes"
-          expression:  "! healthy"
+          expression: "! healthy"
         - description: "Find: unknown nodes"
-          expression:  "name = unknown"
+          expression: "name = unknown"
         hide_options:
         - description: "Hide: healthy nodes"
           expression: "healthy"
         - description: "Hide: unknown nodes"
-          expression:  "name = unknown"
+          expression: "name = unknown"
         traffic:
           grpc: "requests"
           http: "requests"
-          tcp:  "sent"
+          tcp: "sent"
+      i18n:
+        default: "en"
+        languages: ["en"]
       metrics_per_refresh: "1m"
       # default: metrics_inbound is undefined
       metrics_inbound:

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -410,7 +410,7 @@ spec:
           tcp: "sent"
       i18n:
         language: "en"
-        show_selector: true
+        show_selector: false
       list:
         include_health: true
         include_istio_resources: true

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -409,8 +409,13 @@ spec:
           http: "requests"
           tcp: "sent"
       i18n:
-        default: "en"
-        languages: ["en"]
+        language: "en"
+        show_selector: true
+      list:
+        include_health: true
+        include_istio_resources: true
+        include_validations: true
+        show_include_toggles: false
       metrics_per_refresh: "1m"
       # default: metrics_inbound is undefined
       metrics_inbound:

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -140,7 +140,7 @@ spec:
 
                       When empty, this value will default to `openshift` on OpenShift and `token` on other Kubernetes environments.
                     type: string
-                    enum: ["","anonymous","token","openshift","openid","header"]
+                    enum: ["", "anonymous", "token", "openshift", "openid", "header"]
                   openid:
                     description: "To learn more about these settings and how to configure the OpenId authentication strategy, read the documentation at https://kiali.io/docs/configuration/authentication/openid/"
                     type: object
@@ -491,11 +491,11 @@ spec:
                       log_level:
                         description: "The lowest priority of messages to log. Must be one of: `trace`, `debug`, `info`, `warn`, `error`, or `fatal`."
                         type: string
-                        enum: ["trace","debug","info","warn","error","fatal"]
+                        enum: ["trace", "debug", "info", "warn", "error", "fatal"]
                       log_format:
                         description: "Indicates if the logs should be written with one log message per line or using a JSON format. Must be one of: `text` or `json`."
                         type: string
-                        enum: ["text","json"]
+                        enum: ["text", "json"]
                       sampler_rate:
                         description: "With this setting every sampler_rate-th message will be logged. By default, every message is logged. As an example, setting this to `'2'` means every other message will be logged. The value of this setting is a string but must be parsable as an integer."
                         type: string
@@ -531,16 +531,16 @@ spec:
                     type: integer
                   resources:
                     description: |
-                       Defines compute resources that are to be given to the Kiali pod's container. The value is a dict as defined by Kubernetes. See the Kubernetes documentation (https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container).
-                       If you set this to an empty dict (`{}`) then no resources will be defined in the Deployment.
-                       If you do not set this at all, the default is,
-                       ```
-                       requests:
-                         cpu: "10m"
-                         memory: "64Mi"
-                       limits:
-                         memory: "1Gi"
-                       ```
+                      Defines compute resources that are to be given to the Kiali pod's container. The value is a dict as defined by Kubernetes. See the Kubernetes documentation (https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container).
+                      If you set this to an empty dict (`{}`) then no resources will be defined in the Deployment.
+                      If you do not set this at all, the default is,
+                      ```
+                      requests:
+                        cpu: "10m"
+                        memory: "64Mi"
+                      limits:
+                        memory: "1Gi"
+                      ```
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   secret_name:
@@ -1160,15 +1160,27 @@ spec:
                               grpc:
                                 description: "gRPC traffic is measured in requests or sent/received/total messages. Value must be one of: `none`, `requests`, `sent`, `received`, or `total`."
                                 type: string
-                                enum: ["none","requests","sent","received","total"]
+                                enum: ["none", "requests", "sent", "received", "total"]
                               http:
                                 description: "HTTP traffic is measured in requests. Value must be one of: `none` or `requests`."
                                 type: string
-                                enum: ["none","requests"]
+                                enum: ["none", "requests"]
                               tcp:
                                 description: "TCP traffic is measured in sent/received/total bytes. Only request traffic supplies response codes. Value must be one of: `none`, `sent`, `received`, or `total`."
                                 type: string
-                                enum: ["none","sent","received","total"]
+                                enum: ["none", "sent", "received", "total"]
+                      i18n:
+                        description: "Default settings for the i18n values (default and available languages)."
+                        type: object
+                        properties:
+                          default:
+                            description: "Default language value used in Kiali application"
+                            type: string
+                          languages:
+                            description: "Available languages in Kiali application. For the moment possible values are English ('en') and/or Chinese ('zh')"
+                            type: array
+                            items:
+                              type: string
                       list:
                         description: "Default settings for the List views (Apps, Workloads, etc)."
                         type: object
@@ -1188,7 +1200,7 @@ spec:
                       metrics_per_refresh:
                         description: "Duration of metrics to fetch on each refresh. Value must be one of: `1m`, `2m`, `5m`, `10m`, `30m`, `1h`, `3h`, `6h`, `12h`, `1d`, `7d`, or `30d`"
                         type: string
-                        enum: ["1m","2m","5m","10m","30m","1h","3h","6h","12h","1d","7d","30d"]
+                        enum: ["1m", "2m", "5m", "10m", "30m", "1h", "3h", "6h", "12h", "1d", "7d", "30d"]
                       metrics_inbound:
                         description: |
                           Additional label aggregation for inbound metric pages in detail pages.
@@ -1245,7 +1257,7 @@ spec:
                       refresh_interval:
                         description: "The automatic refresh interval for pages offering automatic refresh. Value must be one of: `pause`, `10s`, `15s`, `30s`, `1m`, `5m` or `15m`"
                         type: string
-                        enum: ["pause","10s","15s","30s","1m","5m","15m"]
+                        enum: ["pause", "10s", "15s", "30s", "1m", "5m", "15m"]
                   validations:
                     description: "Features specific to the validations subsystem."
                     type: object
@@ -1382,4 +1394,4 @@ spec:
                   web_schema:
                     description: "Defines the public HTTP schema used to serve Kiali. Value must be one of: `http` or `https`. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup."
                     type: string
-                    enum: ["","http","https"]
+                    enum: ["", "http", "https"]

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1170,17 +1170,15 @@ spec:
                                 type: string
                                 enum: ["none", "sent", "received", "total"]
                       i18n:
-                        description: "Default settings for the i18n values (default and available languages)."
+                        description: "Default settings for the i18n values."
                         type: object
                         properties:
-                          default:
-                            description: "Default language value used in Kiali application"
+                          language:
+                            description: "Default language used in Kiali application."
                             type: string
-                          languages:
-                            description: "Available languages in Kiali application. For the moment possible values are English ('en') and/or Chinese ('zh')"
-                            type: array
-                            items:
-                              type: string
+                          show_selector:
+                            description: "If true Kiali masthead displays language selector icon. Default is true."
+                            type: boolean
                       list:
                         description: "Default settings for the List views (Apps, Workloads, etc)."
                         type: object

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1177,7 +1177,7 @@ spec:
                             description: "Default language used in Kiali application."
                             type: string
                           show_selector:
-                            description: "If true Kiali masthead displays language selector icon. Default is true."
+                            description: "If true Kiali masthead displays language selector icon. Default is false."
                             type: boolean
                       list:
                         description: "Default settings for the List views (Apps, Workloads, etc)."


### PR DESCRIPTION
Add i18n settings to kiali operator.

```
kiali_feature_flags:
  ui_defaults:
    i18n:
      default: string
      languages: array
```

By default only supported language is English.

To test the PR, build and deploy the kiali-operator in your cluster and modify Kiali CR to add "Chinese" to available languages:
```
  i18n:
    default: zh
    languages: 
    - en
    - zh 
```

After operator reconcile process, Kiali application should show chinese language as default and show language switch component:

![image](https://github.com/kiali/kiali-operator/assets/122779323/d0bb44c5-36b7-48cf-88f0-ba408035a0e7)

