### PR TITLE
New Tempo grafana datasource settings

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -354,8 +354,8 @@ spec:
         cluster: "cluster-east"
       query_timeout: 5
       tempo_config:
-        org_id: ""
         datasource_uid: ""
+        org_id: ""
       url: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -353,6 +353,9 @@ spec:
         mesh_id: "mesh-1"
         cluster: "cluster-east"
       query_timeout: 5
+      tempo_config:
+        org_id: ""
+        datasource_uid: ""
       url: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -972,11 +972,11 @@ spec:
                         description: "Settings used to configure the access url to the Tempo Datasource in Grafana."
                         type: object
                         properties:
-                          org_id:
-                            description: "The Id of the organization that the dashboard is in. Default to 1 (the first and default organization)."
-                            type: string
                           datasource_uid:
                             description: "The unique identifier (uid) of the Tempo datasource in Grafana."
+                            type: string
+                          org_id:
+                            description: "The Id of the organization that the dashboard is in. Default to 1 (the first and default organization)."
                             type: string
                       url:
                         description: "The external URL that will be used to generate links to Jaeger. It must be accessible to clients external to the cluster (e.g: a browser) in order to generate valid links. If the tracing service is deployed with a QUERY_BASE_PATH set, set this URL like https://<hostname>/<QUERY_BASE_PATH>. For example, https://tracing-service:8080/jaeger"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -968,6 +968,16 @@ spec:
                       query_timeout:
                         description: "The amount of time in seconds Kiali will wait for a response from 'jaeger-query' service when fetching traces."
                         type: integer
+                      tempo_config:
+                        description: "Settings used to configure the access url to the Tempo Datasource in Grafana."
+                        type: object
+                        properties:
+                          org_id:
+                            description: "The Id of the organization that the dashboard is in. Default to 1 (the first and default organization)."
+                            type: string
+                          datasource_uid:
+                            description: "The unique identifier (uid) of the Tempo datasource in Grafana."
+                            type: string
                       url:
                         description: "The external URL that will be used to generate links to Jaeger. It must be accessible to clients external to the cluster (e.g: a browser) in order to generate valid links. If the tracing service is deployed with a QUERY_BASE_PATH set, set this URL like https://<hostname>/<QUERY_BASE_PATH>. For example, https://tracing-service:8080/jaeger"
                         type: string

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -232,6 +232,9 @@ kiali_defaults:
       provider: "jaeger"
       query_scope: {}
       query_timeout: 5
+      tempo_config:
+        org_id: ""
+        datasource_uid: ""
       url: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -233,8 +233,8 @@ kiali_defaults:
       query_scope: {}
       query_timeout: 5
       tempo_config:
-        org_id: ""
         datasource_uid: ""
+        org_id: ""
       url: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]


### PR DESCRIPTION
For the new Grafana URL format, Kiali will need to know the Grafana Tempo Datasource UID and the org Id in order to generate the trace/span links.

Ref. https://github.com/kiali/kiali/pull/7085