### PR TITLE
Add IPv6 support to ossmconsole nginx configuration

### DIFF
--- a/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -15,6 +15,7 @@ data:
       keepalive_timeout  65;
       server {
         listen              9443 ssl;
+        listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
 

--- a/roles/v1.73/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/v1.73/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -15,6 +15,7 @@ data:
       keepalive_timeout  65;
       server {
         listen              9443 ssl;
+        listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
 


### PR DESCRIPTION
This PR allows OSSM console plugin to be deployed in OpenShift IPv6 clusters.

Closes https://github.com/kiali/openshift-servicemesh-plugin/issues/281