### PR TITLE
remove verbose_mode that has been deprecated

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -208,7 +208,6 @@ spec:
     - key: "example-key"
       operator: "Exists"
       effect: "NoSchedule"
-    verbose_mode: "3"
     version_label: ""
     view_only_mode: false
 

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -567,9 +567,6 @@ spec:
                     items:
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                  verbose_mode:
-                    description: "DEPRECATED! Determines which priority levels of log messages Kiali will output. Use `deployment.logger` settings instead."
-                    type: string
                   version_label:
                     description: |
                       Kiali resources will be assigned a 'version' label when they are deployed.

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         - name: LOG_FORMAT
           value: "{{ kiali_vars.deployment.logger.log_format }}"
         - name: LOG_LEVEL
-          value: "{{ kiali_vars.deployment.verbose_mode if kiali_vars.deployment.verbose_mode is defined else kiali_vars.deployment.logger.log_level }}"
+          value: "{{ kiali_vars.deployment.logger.log_level }}"
         - name: LOG_SAMPLER_RATE
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -97,7 +97,7 @@ spec:
         - name: LOG_FORMAT
           value: "{{ kiali_vars.deployment.logger.log_format }}"
         - name: LOG_LEVEL
-          value: "{{ kiali_vars.deployment.verbose_mode if kiali_vars.deployment.verbose_mode is defined else kiali_vars.deployment.logger.log_level }}"
+          value: "{{ kiali_vars.deployment.logger.log_level }}"
         - name: LOG_SAMPLER_RATE
           value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
         - name: LOG_TIME_FIELD_FORMAT


### PR DESCRIPTION
It has been deprecated/superceded since v1.26 (4 years ago)

part of: https://github.com/kiali/kiali/issues/7208