### PR TITLE
Increase pause in cluster wide access test

### DIFF
--- a/molecule/cluster-wide-access-test/converge.yml
+++ b/molecule/cluster-wide-access-test/converge.yml
@@ -169,7 +169,7 @@
 
   - name: Pause for a few seconds to ensure the server gets notified of the change to the Istio ConfigMap
     pause:
-      seconds: 15
+      seconds: 25
 
   - debug: msg="Now that we do not have discoverySelectors, we should see all AN namespaces (istio-system, cluster-wide-access-test-1, cluster-wide-access-test-2, cluster-wide-access-test-x)"
   - include_tasks: ../asserts/assert-api-namespaces-result.yml


### PR DESCRIPTION
This gives the namespace cache enough time to clear so that the kiali server will return fresh results rather than returning what was previously saved in cache.