### PR TITLE
[molecule] fix flake in "os-console-links-test"

### DIFF
--- a/molecule/os-console-links-test/converge.yml
+++ b/molecule/os-console-links-test/converge.yml
@@ -10,7 +10,7 @@
   - import_tasks: ../asserts/pod_asserts.yml
   - import_tasks: ../asserts/accessible_namespaces_contains.yml
     vars:
-      namespace_list: [ '**' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}" ]
 
   # Test that there are no main masthead console links (we used to create these, but no longer)
   - name: Get app links if exist
@@ -25,34 +25,17 @@
       that:
       - "{{ applink.resources | length == 0 }}"
 
-  # Create some test namespaces
-  - k8s:
-      state: present
-      api_version: v1
-      kind: Namespace
-      name: consolelinks1
-  - k8s:
-      state: present
-      api_version: v1
-      kind: Namespace
-      name: consolelinks2
-  - k8s:
-      state: present
-      api_version: v1
-      kind: Namespace
-      name: noconsolelinks
-
   # change to accessible_namespaces to a fixed list of namespaces
   - import_tasks: ../common/set_accessible_namespaces_to_list.yml
     vars:
-      namespace_list: [ 'istio-system', 'consolelinks1', 'consolelinks2' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'consolelinks1', 'consolelinks2' ]
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
   - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
   - import_tasks: ../asserts/accessible_namespaces_equals.yml
     vars:
-      namespace_list: [ 'istio-system', 'consolelinks1', 'consolelinks2' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'consolelinks1', 'consolelinks2' ]
 
   # Test that console links are correct across namespaces
   - name: Get links from consolelinks1
@@ -90,14 +73,14 @@
   # change to accessible_namespaces by removing consolelinks2 from the list
   - import_tasks: ../common/set_accessible_namespaces_to_list.yml
     vars:
-      namespace_list: [ 'istio-system', 'consolelinks1' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'consolelinks1' ]
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
   - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
   - import_tasks: ../asserts/accessible_namespaces_equals.yml
     vars:
-      namespace_list: [ 'istio-system', 'consolelinks1' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'consolelinks1' ]
 
   # Test that console links are correct - note we removed a namespace from accessible_namespaces so the link should be gone
   - name: Get links from consolelinks1
@@ -130,14 +113,14 @@
   # change to accessible_namespaces by adding a namespace to the existing fixed list of accessible namespaces
   - import_tasks: ../common/set_accessible_namespaces_to_list.yml
     vars:
-      namespace_list: [ 'istio-system', 'consolelinks1', 'consolelinks2' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'consolelinks1', 'consolelinks2' ]
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
   - import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
   - import_tasks: ../asserts/accessible_namespaces_equals.yml
     vars:
-      namespace_list: [ 'istio-system', 'consolelinks1', 'consolelinks2' ]
+      namespace_list: [ "{{ istio.control_plane_namespace }}", 'consolelinks1', 'consolelinks2' ]
 
   # Test that console links are correct across namespaces
   - name: Get links from consolelinks1
@@ -191,20 +174,3 @@
     - all_console_links.resources | length == 0
     retries: "{{ wait_retries }}"
     delay: 5
-
-  # Remove the test namespaces we created earlier
-  - k8s:
-      state: absent
-      api_version: v1
-      kind: Namespace
-      name: consolelinks1
-  - k8s:
-      state: absent
-      api_version: v1
-      kind: Namespace
-      name: consolelinks2
-  - k8s:
-      state: absent
-      api_version: v1
-      kind: Namespace
-      name: noconsolelinks

--- a/molecule/os-console-links-test/destroy-os-console-links-test.yml
+++ b/molecule/os-console-links-test/destroy-os-console-links-test.yml
@@ -1,0 +1,13 @@
+- name: Destroy
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+- name: Include the base destroy play to destroy the first kiali install
+  import_playbook: ../default/destroy.yml
+
+- name: Delete the test namespaces
+  import_playbook: ./process-namespaces.yml
+  vars:
+    state: absent

--- a/molecule/os-console-links-test/molecule.yml
+++ b/molecule/os-console-links-test/molecule.yml
@@ -13,8 +13,8 @@ provisioner:
     defaults:
       callbacks_enabled: junit
   playbooks:
-    destroy: ../default/destroy.yml
-    prepare: ../default/prepare.yml
+    destroy: ./destroy-os-console-links-test.yml
+    prepare: ./prepare-os-console-links-test.yml
     cleanup: ../default/cleanup.yml
   inventory:
     group_vars:
@@ -27,7 +27,7 @@ provisioner:
         kiali:
           spec_version: "{{ lookup('env', 'MOLECULE_KIALI_CR_SPEC_VERSION') | default('default', True) }}"
           install_namespace: istio-system
-          accessible_namespaces: ["**"]
+          accessible_namespaces: ["istio-system"]
           auth_strategy: openshift
           operator_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}" # if external operator, assume operator is in OLM location
           operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"

--- a/molecule/os-console-links-test/prepare-os-console-links-test.yml
+++ b/molecule/os-console-links-test/prepare-os-console-links-test.yml
@@ -1,0 +1,13 @@
+- name: Prepare
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+- name: Create the test namespaces
+  import_playbook: ./process-namespaces.yml
+  vars:
+    state: present
+
+- name: Include the base prepare play to create the first kiali install
+  import_playbook: ../default/prepare.yml

--- a/molecule/os-console-links-test/process-namespaces.yml
+++ b/molecule/os-console-links-test/process-namespaces.yml
@@ -1,0 +1,22 @@
+- name: "Process Test Namespaces [state={{ state }}]"
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+  tasks:
+  - k8s:
+      state: "{{ state }}"
+      api_version: v1
+      kind: Namespace
+      name: consolelinks1
+  - k8s:
+      state: "{{ state }}"
+      api_version: v1
+      kind: Namespace
+      name: consolelinks2
+  - k8s:
+      state: "{{ state }}"
+      api_version: v1
+      kind: Namespace
+      name: noconsolelinks


### PR DESCRIPTION
I think this should fix it. I do not see this happening on my local machine. This PR also has the positive side effect of cleaning up the test even on failure (before it was leaving test namespaces in the cluster on failure).

fixes: https://github.com/kiali/kiali/issues/7243