### PR TITLE
be able to enable/disable namespace watching

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,6 +12,8 @@ COPY roles/ ${HOME}/roles/
 COPY playbooks/ ${HOME}/playbooks/
 COPY watches-k8s.yaml ${HOME}/watches-k8s.yaml
 COPY watches-os.yaml ${HOME}/watches-os.yaml
+COPY watches-k8s-ns.yaml ${HOME}/watches-k8s-ns.yaml
+COPY watches-os-ns.yaml ${HOME}/watches-os-ns.yaml
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/manifests/kiali-community/1.84.0/manifests/kiali.v1.84.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/1.84.0/manifests/kiali.v1.84.0.clusterserviceversion.yaml
@@ -249,7 +249,7 @@ spec:
                 args:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
-                - "--watches-file=./watches-os.yaml"
+                - "--watches-file=./$(WATCHES_FILE)"
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false
@@ -300,6 +300,8 @@ spec:
                   value: "/tmp/ansible/tmp"
                 - name: ANSIBLE_REMOTE_TEMP
                   value: "/tmp/ansible/tmp"
+                - name: WATCHES_FILE
+                  value: "watches-os.yaml"
                 ports:
                 - name: http-metrics
                   containerPort: 8080

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -259,7 +259,7 @@ spec:
                 args:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
-                - "--watches-file=./watches-os.yaml"
+                - "--watches-file=./$(WATCHES_FILE)"
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false
@@ -310,6 +310,8 @@ spec:
                   value: "/tmp/ansible/tmp"
                 - name: ANSIBLE_REMOTE_TEMP
                   value: "/tmp/ansible/tmp"
+                - name: WATCHES_FILE
+                  value: "watches-os.yaml"
                 - name: RELATED_IMAGE_kiali_default
                   value: "${KIALI_1_73}"
                 - name: RELATED_IMAGE_kiali_v1_73

--- a/manifests/kiali-upstream/1.84.0/manifests/kiali.v1.84.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/1.84.0/manifests/kiali.v1.84.0.clusterserviceversion.yaml
@@ -200,7 +200,7 @@ spec:
                 args:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
-                - "--watches-file=./watches-k8s.yaml"
+                - "--watches-file=./$(WATCHES_FILE)"
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false
@@ -247,6 +247,8 @@ spec:
                   value: "/tmp/ansible/tmp"
                 - name: ANSIBLE_REMOTE_TEMP
                   value: "/tmp/ansible/tmp"
+                - name: WATCHES_FILE
+                  value: "watches-k8s.yaml"
                 ports:
                 - name: http-metrics
                   containerPort: 8080

--- a/watches-k8s-ns.yaml
+++ b/watches-k8s-ns.yaml
@@ -1,4 +1,4 @@
-# OPENSHIFT WATCHES YAML
+# KUBERNETES/NON-OPENSHIFT WATCHES YAML WITH NAMESPACE WATCHING
 ---
 # The normal Kiali CR processing playbook
 - version: v1alpha1
@@ -12,15 +12,13 @@
   finalizer:
     name: kiali.io/finalizer
     playbook: playbooks/kiali-remove.yml
-# The normal processing for the OpenShift ServiceMesh Console plugin playbook
-- version: v1alpha1
-  group: kiali.io
-  kind: OSSMConsole
-  playbook: playbooks/ossmconsole-deploy.yml
+# Watching new namespaces so the operator can determine if they should be accessible to Kiali
+- version: v1
+  group: ""
+  kind: Namespace
+  playbook: playbooks/kiali-new-namespace-detected.yml
   reconcilePeriod: "0s"
+  manageStatus: False
   watchDependentResources: False
   watchClusterScopedResources: False
-  snakeCaseParameters: False
-  finalizer:
-    name: kiali.io/finalizer
-    playbook: playbooks/ossmconsole-remove.yml
+  watchAnnotationsChanges: False

--- a/watches-k8s.yaml
+++ b/watches-k8s.yaml
@@ -12,13 +12,3 @@
   finalizer:
     name: kiali.io/finalizer
     playbook: playbooks/kiali-remove.yml
-# Watching new namespaces so the operator can determine if they should be accessible to Kiali
-- version: v1
-  group: ""
-  kind: Namespace
-  playbook: playbooks/kiali-new-namespace-detected.yml
-  reconcilePeriod: "0s"
-  manageStatus: False
-  watchDependentResources: False
-  watchClusterScopedResources: False
-  watchAnnotationsChanges: False

--- a/watches-os-ns.yaml
+++ b/watches-os-ns.yaml
@@ -1,4 +1,4 @@
-# OPENSHIFT WATCHES YAML
+# OPENSHIFT WATCHES YAML WITH NAMESPACE WATCHING
 ---
 # The normal Kiali CR processing playbook
 - version: v1alpha1
@@ -12,6 +12,16 @@
   finalizer:
     name: kiali.io/finalizer
     playbook: playbooks/kiali-remove.yml
+# Watching new namespaces so the operator can determine if they should be accessible to Kiali
+- version: v1
+  group: ""
+  kind: Namespace
+  playbook: playbooks/kiali-new-namespace-detected.yml
+  reconcilePeriod: "0s"
+  manageStatus: False
+  watchDependentResources: False
+  watchClusterScopedResources: False
+  watchAnnotationsChanges: False
 # The normal processing for the OpenShift ServiceMesh Console plugin playbook
 - version: v1alpha1
   group: kiali.io


### PR DESCRIPTION
This disables namespace watching by default. But it provides a way for the user to enable it if that feature is desired.

fixes: https://github.com/kiali/kiali/issues/7322

To test (you could test on an non-OpenShift cluster but the steps below are for OpenShift - I used CRC):

1. Be logged into an OpenShift cluster and make sure Istio is installed
2. Log into the image registry of the cluster (see the `make cluster-status` output for the command to use to login)
3. Push the dev images to the cluster via `make cluster-push`
4. Install the operator via OLM using `make olm-operator-create`
5. At this point, the default behavior should NOT watch namespaces. Look at the operator logs and you should not see the namespace processing playbook being run for every namespace in the cluster. The operator logs should be relatively quiet. The operator is located in the `openshift-operators` namespace (so you do something like `oc logs -n openshift-operators <operator pod name>`).
6. Now turn on the namespace watching. The FAQ explains the details here: https://kiali.io/docs/faq/installation/#operator-configuration but below is what you want to do. You basically want to set the operator Deployment's env var `WATCHES_FILE` to `watches-os-ns.yaml` (or `watches-k8s-ns.yaml` if testing on non-k8s but for this test we are using OpenShift). You can do this via this set of commands:
```bash
ENV_NAME="WATCHES_FILE"

ENV_VALUE="watches-os-ns.yaml"

OPERATOR_NAMESPACE="openshift-operators"
oc -n ${OPERATOR_NAMESPACE} patch $(oc -n ${OPERATOR_NAMESPACE} get csv -o name | grep kiali) --type=json -p "[{'op':'replace','path':"/spec/install/spec/deployments/0/spec/template/spec/containers/0/env/$(oc -n ${OPERATOR_NAMESPACE} get $(oc -n ${OPERATOR_NAMESPACE} get csv -o name | grep kiali) -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].env[*].name}' | tr ' ' '\n' | cat --number | grep ${ENV_NAME} | cut -f 1 | xargs echo -n | cat - <(echo "-1") | bc)/value",'value':"\"${ENV_VALUE}\""}]"
```
7. Do the same as step 5 - look at the operator logs - but this time you should see namespace processing happening, once for each namespace in the cluster.