### PR TITLE
fix grafana and jaeger molecule tests

### DIFF
--- a/molecule/grafana-test/converge.yml
+++ b/molecule/grafana-test/converge.yml
@@ -26,17 +26,18 @@
       msg: "{{ status_response.json }}"  
 
   # IstioStatus API returns a statuses list of external components (Grafana is one of them)
-  # If Grafana is in the list, it means that there is an error (Unreacheable)
+  # If Grafana is in the list get the status (it should be Healthy)
   - name: Check if Grafana status is present
     set_fact:
-      grafana_error: "{{ item.status }}"     
+      grafana_healthy: "{{ item.status }}"
     loop: "{{ status_response.json }}"
-    when: "item.name == 'grafana'"
+    when:
+    - item.name == 'grafana'
   
   - name: Assert that there is no error related to Grafana
     assert:
       that:
-      - grafana_error is not defined
+      - grafana_healthy == 'Healthy'
   
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
 
@@ -71,9 +72,9 @@
 
   - name: Check if Grafana status is present
     set_fact:
-      grafana_bad_url_error: "{{ item.status }}"     
+      grafana_bad_url_error: "{{ item.status }}"
     loop: "{{ status_response.json }}"
-    when: "item.name == 'grafana'"
+    when: "item.name == 'grafana' and item.status != 'Healthy'"
   
   - name: Assert that there is an error related to Grafana
     assert:
@@ -108,12 +109,12 @@
       msg: "{{ status_response.json }}"  
 
   # IstioStatus API returns a statuses list of external components (Grafana is one of them)
-  # If Grafana is in the list, it means that there is an error (Unreacheable)
+  # If Grafana is in the list and not "Healthy", it means that there is an error (Unreacheable)
   - name: Check if Grafana status is present
     set_fact:
       grafana_health_url_error: "{{ item.status }}"     
     loop: "{{ status_response.json }}"
-    when: "item.name == 'grafana'"
+    when: "item.name == 'grafana' and item.status != 'Healthy'"
   
   - name: Assert that there is no error related to Grafana
     assert:

--- a/molecule/jaeger-test/converge.yml
+++ b/molecule/jaeger-test/converge.yml
@@ -22,17 +22,18 @@
       msg: "{{ status_response.json }}"  
 
   # IstioStatus API returns a statuses list of external components (Jaeger is one of them)
-  # If Jaeger is in the list, it means that there is an error (Unreacheable)
+  # If Jaeger is in the list, get the status (it should be Healthy)
   - name: Check if Jaeger status is present
     set_fact:
-      tracing_error: "{{ item.status }}"
+      tracing_healthy: "{{ item.status }}"
     loop: "{{ status_response.json }}"
-    when: "item.name == 'tracing'"
+    when:
+    - item.name == 'tracing'
   
   - name: Assert that there is no error related to Jaeger
     assert:
       that:
-      - tracing_error is not defined
+      - tracing_healthy == 'Healthy'
 
   # Update Jaeger URL to a bad URL just to test a bad integration
   - import_tasks: update-jaeger-url.yml
@@ -59,7 +60,7 @@
     set_fact:
       tracing_error: "{{ item.status }}"
     loop: "{{ status_response.json }}"
-    when: "item.name == 'tracing'"
+    when: "item.name == 'tracing' and item.status != 'Healthy'"
   
   - name: Assert that there is an error related to Jaeger
     assert:


### PR DESCRIPTION
The component status now indicate healthy as well as unhealthy, we have to check more than just existence in the list now. See https://github.com/kiali/kiali/pull/7308

part of https://github.com/kiali/kiali/issues/7326