### PR TITLE
add new custom headers setting to tracing config

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -346,6 +346,9 @@ spec:
         type: "none"
         use_kiali_token: false
         username: ""
+      # default: custom_headers is empty
+      custom_headers:
+        customHeader1: "customHeader1Value"
       enabled: true
       grpc_port: 9095
       health_check_url: ""

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -944,6 +944,10 @@ spec:
                           username:
                             description: "Username to be used when making requests to the Tracing server with `basic` authentication."
                             type: string
+                      custom_headers:
+                        description: "A set of name/value settings that will be passed as headers when requests are sent to the Tracing backend."
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       enabled:
                         description: "When true, connections to the Tracing server are enabled. `in_cluster_url` and/or `url` need to be provided."
                         type: boolean

--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -45,6 +45,7 @@
       - kiali_configmap.external_services.prometheus.url != ""
       - kiali_configmap.external_services.prometheus.custom_headers | length == 0
       - kiali_configmap.external_services.prometheus.query_scope | length == 0
+      - kiali_configmap.external_services.tracing.custom_headers | length == 0
       - kiali_configmap.external_services.tracing.query_scope | length == 0
       - kiali_configmap.identity.cert_file is defined
       - kiali_configmap.identity.private_key_file is defined

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -224,6 +224,7 @@ kiali_defaults:
         type: "none"
         use_kiali_token: false
         username: ""
+      custom_headers: {}
       enabled: true
       grpc_port: 9095
       health_check_url: ""

--- a/roles/default/kiali-deploy/tasks/snake_camel_case.yaml
+++ b/roles/default/kiali-deploy/tasks/snake_camel_case.yaml
@@ -137,4 +137,10 @@
       {%   set kiali_vars=kiali_vars | combine({'deployment': {'custom_secrets': current_cr.spec.deployment.custom_secrets}}, recursive=True) %}
       {% endif %}
       {# #}
+      {# external_services.tracing.custom_headers #}
+      {% if kiali_vars.external_services.tracing.custom_headers is defined and kiali_vars.external_services.tracing.custom_headers | length > 0 %}
+      {%   set _=kiali_vars['external_services']['tracing'].pop('custom_headers') %}
+      {%   set kiali_vars=kiali_vars | combine({'external_services': {'tracing': {'custom_headers': current_cr.spec.external_services.tracing.custom_headers }}}, recursive=True) %}
+      {% endif %}
+      {# #}
       {{ kiali_vars }}


### PR DESCRIPTION
Supports custom headers for tracing backend requests

part of: https://github.com/kiali/kiali/issues/7266