### PR TITLE
Add config for the server timeout

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -495,6 +495,7 @@ spec:
     port: 20001
     profiler:
       enabled: false
+    timeout: 30
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -495,9 +495,9 @@ spec:
     port: 20001
     profiler:
       enabled: false
-    timeout: 30
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""
     web_root: ""
     web_schema: ""
+    write_timeout: 30

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1402,6 +1402,9 @@ spec:
                       enabled:
                         description: "When 'true', the profiler will be enabled and accessible at /debug/pprof/ on the Kiali endpoint."
                         type: boolean
+                  timeout:
+                    description: "The write timeout in seconds for the server. Default is 30."
+                    type: integer
                   web_fqdn:
                     description: "Defines the public domain where Kiali is being served. This is the 'domain' part of the URL (usually it's a fully-qualified domain name). For example, `kiali.example.org`. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup."
                     type: string

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1402,9 +1402,6 @@ spec:
                       enabled:
                         description: "When 'true', the profiler will be enabled and accessible at /debug/pprof/ on the Kiali endpoint."
                         type: boolean
-                  timeout:
-                    description: "The write timeout in seconds for the server. Default is 30."
-                    type: integer
                   web_fqdn:
                     description: "Defines the public domain where Kiali is being served. This is the 'domain' part of the URL (usually it's a fully-qualified domain name). For example, `kiali.example.org`. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup."
                     type: string
@@ -1421,3 +1418,6 @@ spec:
                     description: "Defines the public HTTP schema used to serve Kiali. Value must be one of: `http` or `https`. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup."
                     type: string
                     enum: ["", "http", "https"]
+                  write_timeout:
+                    description: "The maximum duration, in seconds, before timing out writes of the HTTP response back to the client. Default is 30."
+                    type: integer

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -357,12 +357,12 @@ kiali_defaults:
     port: 20001
     profiler:
       enabled: false
-    timeout: 30
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""
     web_root: ""
     web_schema: ""
+    write_timeout: 30
 
 # These variables are outside of the kiali_defaults. Their values will be
 # auto-detected by the role and are not meant to be set by the user.

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -357,6 +357,7 @@ kiali_defaults:
     port: 20001
     profiler:
       enabled: false
+    timeout: 30
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""


### PR DESCRIPTION
Added new option to make the server timeout as a config, in case there is the need to increase it. 
It is called just timeout for simplicity, but it is just affecting the server write time out (Which I think it is usually the problematic). 

Ref PR: https://github.com/kiali/kiali/pull/7389