### PR TITLE
Update to base image 4.15 / 1.31.0

### DIFF
--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -71,14 +71,16 @@ In order to use these "run-operator-playbook" targets, you must have Python3 in 
 You also must make sure your local Python and Ansible environment matches as closely as possible to the environment of the Kiali operator. To find out the different versions of software within the Kiali operator image, run the following:
 
 * To get the Python version: `podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest python3 --version`
-* To get the Python libraries (`openshift` and `kubernetes` are important ones to look at): `podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest pip3 list`
+* To get the Python libraries (`kubernetes` is an important one to look at): `podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest pip3 list`
 * To get the Ansible version: `podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest ansible --version`
 
-To get started, try to run `python -m pip install --user --upgrade -r operator/molecule/requirements.txt` to get Python3 libraries installed. If you need to, you can install specific versions of the libraries like this: `python -m pip install --user openshift==0.12.1 kubernetes==12.0.1`.
+To get started, try to run `python -m pip install --user --upgrade -r operator/molecule/requirements.txt` to get Python3 libraries installed. If you need to, you can install specific versions of the libraries like this: `python -m pip install --user kubernetes==12.0.1`.
 
 You also must get the required Ansible collections installed. To find out the different versions of Ansible collections within the Kiali operator image, run the following:
 
-`for m in $(podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest find .ansible/collections/ansible_collections -name MANIFEST.json); do manifest=$(echo -n ${m} | tr --delete '\r'); echo -n "${manifest}-->"; podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest cat "${manifest}" | jq .collection_info.version; done`
+`podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest ansible-galaxy collection list`
+
+NOTE: Older versions of the operator base image did not support the `collection list` option to `ansible-galaxy`. For those older images, you can run this script to determine the versions of the collections installed in the image: `for m in $(podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest find .ansible/collections/ansible_collections -name MANIFEST.json); do manifest=$(echo -n ${m} | tr --delete '\r'); echo -n "${manifest}-->"; podman run --rm -i -t --entrypoint "" quay.io/kiali/kiali-operator:latest cat "${manifest}" | jq .collection_info.version; done`
 
 To install these, run `ansible-galaxy collection install -r operator/requirements.yml --force-with-deps`
 

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,13 @@ OPERATOR_QUAY_TAG ?= ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
 DORP ?= docker
 
 # The version of the SDK this Makefile will download if needed, and the corresponding base image
-OPERATOR_SDK_VERSION ?= 1.28.0
+OPERATOR_SDK_VERSION ?= 1.31.0
 OPERATOR_BASE_IMAGE_VERSION ?= v${OPERATOR_SDK_VERSION}
 OPERATOR_BASE_IMAGE_REPO ?= quay.io/operator-framework/ansible-operator
 # These are what we really want - but origin-ansible-operator does not support multiarch today.
 # When that is fixed, we want to use this image instead of the image above.
 # See: https://issues.redhat.com/browse/DPTP-2946
-#OPERATOR_BASE_IMAGE_VERSION ?= 4.13
+#OPERATOR_BASE_IMAGE_VERSION ?= 4.15
 #OPERATOR_BASE_IMAGE_REPO ?= quay.io/openshift/origin-ansible-operator
 
 .PHONY: help

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,6 +15,9 @@ COPY watches-os.yaml ${HOME}/watches-os.yaml
 COPY watches-k8s-ns.yaml ${HOME}/watches-k8s-ns.yaml
 COPY watches-os-ns.yaml ${HOME}/watches-os-ns.yaml
 
+# pull in jmespath py library for json processing
+RUN python3 -m pip install jmespath
+
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
  && chmod -R ug+rwx ${HOME}/.ansible

--- a/molecule/requirements.txt
+++ b/molecule/requirements.txt
@@ -2,7 +2,6 @@
 # 'pip install -r requirements.txt'
 # In addition to these, you must also exec "ansible-galaxy collection install community.general kubernetes.core"
 molecule
-openshift
 jmespath
 junit-xml
 kubernetes

--- a/requirements.yml
+++ b/requirements.yml
@@ -9,14 +9,20 @@
 #
 # podman run \
 #   -it --rm --entrypoint '' \
-#   quay.io/openshift/origin-ansible-operator:4.13 \
+#   quay.io/openshift/origin-ansible-operator:4.15 \
+#   ansible-galaxy collection list
+#
+# NOTE: for older base images, there is no "collection list" command; instead, run the command:
 #   ls /opt/ansible/.ansible/collections/ansible_collections
 #
-# To determine the version of a specific collection, look at the MANIFEST.json:
+# To determine the version of a specific collection
 #
 # podman run \
 #   -it --rm --entrypoint '' \
-#   quay.io/openshift/origin-ansible-operator:4.13 \
+#   quay.io/openshift/origin-ansible-operator:4.15 \
+#   ansible-galaxy collection list kubernetes.core
+#
+# NOTE: for older base images, there is no "collection list" command; instead, look at the MANIFEST.json:
 #   cat /opt/ansible/.ansible/collections/ansible_collections/kubernetes/core/MANIFEST.json | grep version
 #
 # It is best if you have the same version of Ansible installed locally as found in the base image. You can determine
@@ -24,7 +30,7 @@
 #
 # podman run \
 #   -it --rm --entrypoint '' \
-#   quay.io/openshift/origin-ansible-operator:4.13 \
+#   quay.io/openshift/origin-ansible-operator:4.15 \
 #   ansible --version
 #
 # To install that version locally, you can git clone the source via:
@@ -34,8 +40,10 @@
 
 
 collections:
+- name: community.general
+  version: 7.5.0
 - name: kubernetes.core
   version: 4.0.0
 - name: operator_sdk.util
-  version: 0.4.0
+  version: 0.5.0
 


### PR DESCRIPTION
* upgrade ansible collection openshift_sdk.util to 0.5.0 and remove the "openshift" py lib since the operator_sdk.util collection doesn't need it anymore
* newer ansible versions have an option to get the collections versions easily

fixes: https://github.com/kiali/kiali/issues/7385