### PR TITLE
Added Istio Ingress and Egress Gateway workload label selectors into configs.

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -389,6 +389,8 @@ spec:
 
   istio_labels:
     app_label_name: "app"
+    egress_gateway_label: "istio=egressgateway"
+    ingress_gateway_label: "istio=ingressgateway"
     injection_label_name: "istio-injection"
     injection_label_rev: "istio.io/rev"
     version_label_name: "version"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1057,6 +1057,12 @@ spec:
                   app_label_name:
                     description: "The name of the label used to define what application a workload belongs to. This is typically something like `app` or `app.kubernetes.io/name`."
                     type: string
+                  egress_gateway_label:
+                    description: "The selector label for Egress Gateway workload. This is typically `istio=egressgateway`."
+                    type: string
+                  ingress_gateway_label:
+                    description: "The selector label for Ingress Gateway workload. This is typically `istio=ingressgateway`."
+                    type: string
                   injection_label_name:
                     description: "The name of the label used to instruct Istio to automatically inject sidecar proxies when applications are deployed."
                     type: string

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -250,6 +250,8 @@ kiali_defaults:
 
   istio_labels:
     app_label_name: "app"
+    egress_gateway_label: "istio=egressgateway"
+    ingress_gateway_label: "istio=ingressgateway"
     injection_label_name: "istio-injection"
     injection_label_rev: "istio.io/rev"
     version_label_name: "version"


### PR DESCRIPTION
Added configurations for `egress_gateway_label` and `ingress_gateway_label`. Before they were hardcoded in the code.

Issue https://github.com/kiali/kiali/issues/7232
Core PR https://github.com/kiali/kiali/pull/7492