### PR TITLE
[molecule] fix molecule test now that default values have changed

### DIFF
--- a/molecule/asserts/configmap_asserts.yml
+++ b/molecule/asserts/configmap_asserts.yml
@@ -35,11 +35,6 @@
     that:
     - kiali_configmap.external_services.grafana.in_cluster_url == "http://grafana.{{ istio.control_plane_namespace }}:3000"
 
-- name: Assert Kiali Configmap has correct Version Url for Upstream Istio installs
-  assert:
-    that:
-    - kiali_configmap.external_services.istio.url_service_version == "http://istiod.{{ istio.control_plane_namespace }}:15014/version"
-
 - name: Actual Kiali Accessible namespace list should be the same as the CR
   assert:
     that: " kiali_configmap.deployment.accessible_namespaces | symmetric_difference(kiali.accessible_namespaces) | length == 0 "


### PR DESCRIPTION
The url_service_version is no longer auto-discovered by the operator. Need to change the test code to account for this.

To see the tests now work:

1. `hack/k8s-minikube.sh start && hack/k8s-minikube.sh istio`
2. `make -e CLUSTER_TYPE=minikube build build-ui cluster-push`
3. `./hack/run-molecule-tests.sh --client-exe "$(which kubectl)"  --minikube-exe $(which minikube) --minikube-profile ci --cluster-type minikube -udi true -at "only-view-only-mode-test roles-test default"`

You should see the three tests all be successful now (these three failed without this PR):

```
=====================
=== TEST RESULTS: ===
=====================

                only-view-only-mode-test... success [2m 10s]
                              roles-test... success [4m 46s]
                                 default... success [1m 32s]
```