### PR TITLE
Disable tracing by default

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -349,7 +349,7 @@ spec:
       # default: custom_headers is empty
       custom_headers:
         customHeader1: "customHeader1Value"
-      enabled: true
+      enabled: false
       grpc_port: 9095
       health_check_url: ""
       in_cluster_url: ""

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -19,5 +19,5 @@ spec:
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   external_services:
-   tracing:
-    enabled: true
+    tracing:
+      enabled: true

--- a/molecule/jaeger-test/kiali-cr.yaml
+++ b/molecule/jaeger-test/kiali-cr.yaml
@@ -18,3 +18,6 @@ spec:
     image_version: "{{ kiali.image_version }}"
     accessible_namespaces: {{ kiali.accessible_namespaces }}
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
+  external_services:
+   tracing:
+    enabled: true

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -222,7 +222,7 @@ kiali_defaults:
         use_kiali_token: false
         username: ""
       custom_headers: {}
-      enabled: true
+      enabled: false
       grpc_port: 9095
       health_check_url: ""
       in_cluster_url: ""


### PR DESCRIPTION
Set default for `external_services.tracing.enabled: false`

Ref. [#7332](https://github.com/kiali/kiali/issues/7332) 