### PR TITLE
Upgrade github actions to Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,17 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Validate OLM metadata
-        run: make validate
-      - name: Validate CR
-        run: |
-          kind create cluster
-          CLIENT_EXE=kubectl make validate-cr
-          kind delete cluster
-      - name: Build operator
-        run: make build
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Validate OLM metadata
+      run: make validate
+
+    - name: Validate CR
+      run: |
+        kind create cluster
+        CLIENT_EXE=kubectl make validate-cr
+        kind delete cluster
+
+    - name: Build operator
+      run: make build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       quay_tag: ${{ steps.quay_tag.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -60,7 +60,7 @@ jobs:
       OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch }}  
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       quay_tag: ${{ steps.quay_tag.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -187,7 +187,7 @@ jobs:
       OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
     


### PR DESCRIPTION
Currently, github actions use v3 of actions/checkout, which internally runs on Node 16 (https://github.com/actions/checkout/blob/v3/action.yml#L90). 

This PR upgrades github actions to v4, which internally runs Node on 20 (https://github.com/actions/checkout/blob/v4/action.yml#L102)