### PR TITLE
Removed 'external_services.istio.component_status.components' duplicate labels.

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -280,24 +280,11 @@ spec:
       url: ""
     istio:
       component_status:
-        components:
-        - app_label: "istiod"
-          is_core: true
-          is_proxy: false
-        - app_label: "istio-ingressgateway"
-          is_core: true
-          is_proxy: true
-          # default: namespace is undefined
-          namespace: istio-system
-        - app_label: "istio-egressgateway"
-          is_core: false
-          is_proxy: true
-          # default: namespace is undefined
-          namespace: istio-system
         enabled: true
       config_map_name: "istio"
       envoy_admin_local_port: 15000
       gateway_api_classes: []
+      gateway_namespace: ""
       istio_api_enabled: true
       # default: istio_canary_revision is undefined
       istio_canary_revision:

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -810,6 +810,9 @@ spec:
                             class_name:
                               description: "The name of the GatewayClass."
                               type: string
+                      gateway_namespace:
+                        description: "The namespace where Istio gateway components are read for a status check. When left empty, then `istio_namespace` value is used."
+                        type: string
                       istio_api_enabled:
                         description: "Indicates if Kiali has access to istiod. true by default."
                         type: boolean

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -165,22 +165,10 @@ kiali_defaults:
       url: ""
     istio:
       component_status:
-        components:
-        - app_label: "istiod"
-          is_core: true
-          is_proxy: false
-          namespace: ""
-        - app_label: "istio-ingressgateway"
-          is_core: true
-          is_proxy: true
-          namespace: ""
-        - app_label: "istio-egressgateway"
-          is_core: false
-          is_proxy: true
-          namespace: ""
         enabled: true
       envoy_admin_local_port: 15000
       gateway_api_classes: []
+      gateway_namespace: ""
       istio_api_enabled: true
       #istio_canary_revision:
         #current: prod


### PR DESCRIPTION
Core PR https://github.com/kiali/kiali/pull/7538

Removed default 'external_services.istio.component_status.components' values.
Added new param `gateway_namespace`.


Issues
https://github.com/kiali/kiali/issues/7501
https://github.com/kiali/kiali/issues/7524