### PR TITLE
Divided gateway_namespace into ingress and egress.

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -282,9 +282,10 @@ spec:
       component_status:
         enabled: true
       config_map_name: "istio"
+      egress_gateway_namespace: ""
       envoy_admin_local_port: 15000
       gateway_api_classes: []
-      gateway_namespace: ""
+      ingress_gateway_namespace: ""
       istio_api_enabled: true
       # default: istio_canary_revision is undefined
       istio_canary_revision:

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -795,6 +795,9 @@ spec:
                       config_map_name:
                         description: "The name of the istio control plane config map."
                         type: string
+                      egress_gateway_namespace:
+                        description: "The namespace where Istio EgressGateway component is read for a status check. When left empty, then `istio_namespace` value is used."
+                        type: string
                       envoy_admin_local_port:
                         description: "The port which kiali will open to fetch envoy config data information."
                         type: integer
@@ -810,8 +813,8 @@ spec:
                             class_name:
                               description: "The name of the GatewayClass."
                               type: string
-                      gateway_namespace:
-                        description: "The namespace where Istio gateway components are read for a status check. When left empty, then `istio_namespace` value is used."
+                      ingress_gateway_namespace:
+                        description: "The namespace where Istio IngressGateway component is read for a status check. When left empty, then `istio_namespace` value is used."
                         type: string
                       istio_api_enabled:
                         description: "Indicates if Kiali has access to istiod. true by default."

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -166,9 +166,10 @@ kiali_defaults:
     istio:
       component_status:
         enabled: true
+      egress_gateway_namespace: ""
       envoy_admin_local_port: 15000
       gateway_api_classes: []
-      gateway_namespace: ""
+      ingress_gateway_namespace: ""
       istio_api_enabled: true
       #istio_canary_revision:
         #current: prod


### PR DESCRIPTION
Core PR https://github.com/kiali/kiali/pull/7548

Divided 'gateway_namespace' into 'ingress_gateway_namespace' and 'egress_gateway_namespace'.