### PR TITLE
ignore replicas if HPA is set

### DIFF
--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -538,7 +538,7 @@ spec:
                     description: "The priorityClassName used to assign the priority of the Kiali pod."
                     type: string
                   replicas:
-                    description: "The replica count for the Kiail deployment."
+                    description: "The replica count for the Kiail deployment. If `deployment.hpa` is specified, this setting is ignored."
                     type: integer
                   resources:
                     description: |

--- a/molecule/affinity-tolerations-resources-test/converge.yml
+++ b/molecule/affinity-tolerations-resources-test/converge.yml
@@ -8,6 +8,12 @@
   tasks:
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
+
+  - name: Assert that replicas takes effect (there is no HPA defined yet)
+    assert:
+      that:
+      - kiali_deployment.resources[0].spec.replicas == 1
+
   # set affinity and tolerations and resources and pod_annotations and service_annotations and pod_labels
   - import_tasks: set-affinity-tolerations-resources.yml
     vars:
@@ -65,15 +71,20 @@
         some.test.label/labelKeepCamelCaseFOO: labelCamelCaseValueFOO
       new_hpa:
         spec:
-          minReplicas: 1
-          maxReplicas: 1
+          minReplicas: 2
+          maxReplicas: 2
       new_ingress_labels:
         aaa: bbb
         camelCaseName: camelCaseValue
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
-  - import_tasks: ../common/wait_for_kiali_running.yml
+  - name: Now expect that HPA will set replicas to 2
+    import_tasks: ../common/wait_for_kiali_running.yml
+    vars:
+      kiali_expected_replicas: 2
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
+    vars:
+      kiali_expected_replicas: 2
 
   - name: Assert that tolerations were applied to the deployment
     assert:
@@ -148,6 +159,11 @@
       - hpa_resource_raw.resources | length == 1
       fail_msg: "HPA was not created successfully: {{ hpa_resource_raw }}"
 
+  - name: Assert that deployment.replicas does not take effect (HPA is now defining replicas as 2)
+    assert:
+      that:
+      - kiali_deployment.resources[0].spec.replicas == 2
+
   # Reset them all to empty dicts
   - import_tasks: set-affinity-tolerations-resources.yml
     vars:
@@ -163,7 +179,8 @@
       new_hpa: null
       new_ingress_labels: null
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
-  - import_tasks: ../common/wait_for_kiali_running.yml
+  - name: Replicas should be back to 1 now that HPA is no longer defined
+    import_tasks: ../common/wait_for_kiali_running.yml
   - import_tasks: ../common/tasks.yml
   - import_tasks: ../asserts/pod_asserts.yml
 
@@ -199,6 +216,11 @@
       - hpa_resource_raw.resources is defined
       - hpa_resource_raw.resources | length == 0
       fail_msg: "HPA was not deleted successfully: {{ hpa_resource_raw }} [kiali CR={{ kiali_cr }}]"
+
+  - name: Assert that replicas takes effect (there is no HPA defined anymore)
+    assert:
+      that:
+      - kiali_deployment.resources[0].spec.replicas == 1
 
 # There is no mechanism in the operator right now that let's you remove an already existing annotation.
 # See: https://github.com/kiali/kiali/issues/2247

--- a/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
+++ b/molecule/affinity-tolerations-resources-test/kiali-cr.yaml
@@ -8,6 +8,7 @@ spec:
   auth:
     strategy: {{ kiali.auth_strategy }}
   deployment:
+    replicas: 1
     ingress:
       enabled: true
     logger:

--- a/molecule/asserts/pod_asserts.yml
+++ b/molecule/asserts/pod_asserts.yml
@@ -1,9 +1,10 @@
 # This will assume the pod is already running and there is only one.
+# If you expect more than one pod, set "kiali_expected_replicas"
 # Use common/wait_for_kiali_running.yml if you want to wait for this condition to occur.
-- name: Assert Kiali Pod is Running and there is only one
+- name: Assert Kiali Pod(s) are Running
   assert:
     that:
-    - kiali_pod.resources | length == 1 and kiali_pod.resources[0].status.phase is defined and kiali_pod.resources[0].status.phase == "Running"
+    - kiali_pod.resources | length == (kiali_expected_replicas|default(1)) and kiali_pod.resources[0].status.phase is defined and kiali_pod.resources[0].status.phase == "Running"
 
 - name: Assert Kiali Pod is Running on the correct Namespace
   assert:

--- a/molecule/common/wait_for_kiali_running.yml
+++ b/molecule/common/wait_for_kiali_running.yml
@@ -1,4 +1,5 @@
-- name: Asserting that Kiali Pod exists and there is only one
+# By default, expect just one pod, but if you expect more set "kiali_expected_replicas"
+- name: Asserting that Kiali Pod(s) exists
   vars:
     instance_name: "{{ kiali.instance_name | default('kiali') }}"
   k8s_info:
@@ -10,7 +11,7 @@
   register: kiali_pod
   until:
   - kiali_pod is success
-  - kiali_pod.resources | length == 1
+  - kiali_pod.resources | length == (kiali_expected_replicas|default(1))
   - kiali_pod.resources[0].status is defined
   - kiali_pod.resources[0].status.phase is defined
   - kiali_pod.resources[0].status.phase == "Running"

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 spec:
+{% if kiali_vars.deployment.hpa.spec | length == 0 %}
   replicas: {{ kiali_vars.deployment.replicas }}
+{% endif %}
   selector:
     matchLabels:
       app.kubernetes.io/name: kiali

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: {{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 spec:
+{% if kiali_vars.deployment.hpa.spec | length == 0 %}
   replicas: {{ kiali_vars.deployment.replicas }}
+{% endif %}
   selector:
     matchLabels:
       app.kubernetes.io/name: kiali


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/7559

helm chart PR: https://github.com/kiali/helm-charts/pull/275

To test:
1. Check out this PR branch
2. Create minikube cluster and install Istio: `hack/k8s-minikube.sh start && hack/k8s-minikube.sh istio`
3. Build and push the images to the cluster: `make -e CLUSTER_TYPE=minikube build build-ui cluster-push`
4. Run the molecule test that tests this new functionality (if this passes, this PR is good):
```
make -e CLUSTER_TYPE=minikube MOLECULE_USE_DEV_IMAGES=true MOLECULE_SCENARIO="affinity-tolerations-resources-test" molecule-test
```
