### PR TITLE
fix processing around replicas when HPA is involved

### DIFF
--- a/molecule/affinity-tolerations-resources-test/converge.yml
+++ b/molecule/affinity-tolerations-resources-test/converge.yml
@@ -159,6 +159,21 @@
       - hpa_resource_raw.resources | length == 1
       fail_msg: "HPA was not created successfully: {{ hpa_resource_raw }}"
 
+  - name: Wait until the Kiali deployment is up to date with the HPA replicas
+    k8s_info:
+      api_version: apps/v1
+      kind: Deployment
+      namespace: "{{ kiali.install_namespace }}"
+      label_selectors:
+      - "app.kubernetes.io/instance={{ kiali.instance_name | default('kiali') }}"
+    register: kiali_deployment
+    until:
+    - kiali_deployment.resources | length > 0
+    - kiali_deployment.resources[0].status.replicas == 2
+    - kiali_deployment.resources[0].status.readyReplicas == 2
+    retries: 30
+    delay: 10
+
   - name: Assert that deployment.replicas does not take effect (HPA is now defining replicas as 2)
     assert:
       that:

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -4,6 +4,17 @@
   when:
   - is_k8s == True
 
+- name: Remove HPA if disabled on Kubernetes
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
+    kind: "HorizontalPodAutoscaler"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.hpa.spec | length == 0
+
 - name: Create Kiali objects on Kubernetes
   include_tasks: process-resource.yml
   vars:
@@ -21,17 +32,6 @@
     - "{{ 'templates/kubernetes/ingress.yaml' if kiali_vars.deployment.ingress.enabled|bool == True else '' }}"
   when:
   - is_k8s == True
-
-- name: Remove HPA if disabled on Kubernetes
-  k8s:
-    state: absent
-    api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
-    kind: "HorizontalPodAutoscaler"
-    namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "{{ kiali_vars.deployment.instance_name }}"
-  when:
-  - is_k8s == True
-  - kiali_vars.deployment.hpa.spec | length == 0
 
 - name: Delete Ingress on Kubernetes if disabled
   k8s:

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -14,6 +14,17 @@
   when:
   - is_openshift == True
 
+- name: Remove HPA if disabled on OpenShift
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
+    kind: "HorizontalPodAutoscaler"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.hpa.spec | length == 0
+
 - name: Create Kiali objects on OpenShift
   include_tasks: process-resource.yml
   vars:
@@ -34,17 +45,6 @@
     - "{{ 'templates/openshift/route.yaml' if kiali_vars.deployment.ingress.enabled|bool == True else '' }}"
   when:
   - is_openshift == True
-
-- name: Remove HPA if disabled on OpenShift
-  k8s:
-    state: absent
-    api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
-    kind: "HorizontalPodAutoscaler"
-    namespace: "{{ kiali_vars.deployment.namespace }}"
-    name: "{{ kiali_vars.deployment.instance_name }}"
-  when:
-  - is_openshift == True
-  - kiali_vars.deployment.hpa.spec | length == 0
 
 - name: Delete Route on OpenShift if disabled
   k8s:


### PR DESCRIPTION
Testing on CRC/openshift, there was a lag when HPA adjusts replicas on the Deployment. Add a check in the molecule test so it waits for the replicas to reach steady state before continuing.

After I fixed that, I noticed another race condition in the code related to HPA that I fixed here.