### PR TITLE
use ConsolePlugin v1 now that OCP 4.17 has removed v1alpha1

### DIFF
--- a/molecule/ossmconsole-common/tasks.yml
+++ b/molecule/ossmconsole-common/tasks.yml
@@ -32,7 +32,7 @@
 
 - name: Get OSSMConsole ConsolePlugin
   set_fact:
-    ossmconsole_consoleplugin: "{{ lookup('kubernetes.core.k8s', api_version='console.openshift.io/v1alpha1', kind='ConsolePlugin', namespace=ossmconsole.install_namespace, resource_name='ossmconsole') }}"
+    ossmconsole_consoleplugin: "{{ lookup('kubernetes.core.k8s', api_version='console.openshift.io/v1', kind='ConsolePlugin', namespace=ossmconsole.install_namespace, resource_name='ossmconsole') }}"
 - name: Dump OSSMConsole ConsolePlugin
   debug:
     msg: "{{ ossmconsole_consoleplugin }}"

--- a/molecule/ossmconsole-config-values-test/converge.yml
+++ b/molecule/ossmconsole-config-values-test/converge.yml
@@ -19,15 +19,21 @@
 
   - name: Confirm the Kiali Service Name is as expected
     assert:
-      that: "{{ ossmconsole_consoleplugin.spec.proxy[0].service.name == current_ossmconsole_cr.status.kiali.serviceName }}"
+      that:
+      - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.name == current_ossmconsole_cr.status.kiali.serviceName
+      - ossmconsole_consoleplugin.spec.backend.service.name == 'ossmconsole'
 
   - name: Confirm the Kiali Service Namespace is as expected
     assert:
-      that: "{{ ossmconsole_consoleplugin.spec.proxy[0].service.namespace == current_ossmconsole_cr.status.kiali.serviceNamespace }}"
+      that:
+      - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.namespace == current_ossmconsole_cr.status.kiali.serviceNamespace
+      - ossmconsole_consoleplugin.spec.backend.service.namespace == current_ossmconsole_cr.status.deployment.namespace
 
   - name: Confirm the Kiali Service Port is as expected
     assert:
-      that: "{{ ossmconsole_consoleplugin.spec.proxy[0].service.port == (current_ossmconsole_cr.status.kiali.servicePort | int) }}"
+      that:
+      - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.port == (current_ossmconsole_cr.status.kiali.servicePort | int)
+      - ossmconsole_consoleplugin.spec.backend.service.port == 9443
 
   - name: Confirm the Kiali Graph Impl is the expected default in the ConfigMap
     assert:

--- a/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -1,20 +1,23 @@
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: ossmconsole
   labels: {{ ossmconsole_resource_metadata_labels }}
 spec:
   displayName: "OpenShift Service Mesh Console"
-  service:
-    name: ossmconsole
-    namespace: {{ ossmconsole_vars.deployment.namespace }}
-    port: 9443
-    basePath: "/"
-  proxy:
-  - type: Service
-    alias: kiali
-    authorize: true
+  backend:
     service:
-      name: {{ ossmconsole_vars.kiali.serviceName }}
-      namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
-      port: {{ ossmconsole_vars.kiali.servicePort }}
+      name: ossmconsole
+      namespace: {{ ossmconsole_vars.deployment.namespace }}
+      port: 9443
+      basePath: "/"
+    type: Service
+  proxy:
+  - alias: kiali
+    authorization: UserToken
+    endpoint:
+      service:
+        name: {{ ossmconsole_vars.kiali.serviceName }}
+        namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
+        port: {{ ossmconsole_vars.kiali.servicePort }}
+      type: Service

--- a/roles/v1.73/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/v1.73/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -1,20 +1,23 @@
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: ossmconsole
   labels: {{ ossmconsole_resource_metadata_labels }}
 spec:
   displayName: "OpenShift Service Mesh Console"
-  service:
-    name: ossmconsole
-    namespace: {{ ossmconsole_vars.deployment.namespace }}
-    port: 9443
-    basePath: "/"
-  proxy:
-  - type: Service
-    alias: kiali
-    authorize: true
+  backend:
     service:
-      name: {{ ossmconsole_vars.kiali.serviceName }}
-      namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
-      port: {{ ossmconsole_vars.kiali.servicePort }}
+      name: ossmconsole
+      namespace: {{ ossmconsole_vars.deployment.namespace }}
+      port: 9443
+      basePath: "/"
+    type: Service
+  proxy:
+  - alias: kiali
+    authorization: UserToken
+    endpoint:
+      service:
+        name: {{ ossmconsole_vars.kiali.serviceName }}
+        namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
+        port: {{ ossmconsole_vars.kiali.servicePort }}
+      type: Service

--- a/roles/v1.86/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/v1.86/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -1,20 +1,23 @@
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: ossmconsole
   labels: {{ ossmconsole_resource_metadata_labels }}
 spec:
   displayName: "OpenShift Service Mesh Console"
-  service:
-    name: ossmconsole
-    namespace: {{ ossmconsole_vars.deployment.namespace }}
-    port: 9443
-    basePath: "/"
-  proxy:
-  - type: Service
-    alias: kiali
-    authorize: true
+  backend:
     service:
-      name: {{ ossmconsole_vars.kiali.serviceName }}
-      namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
-      port: {{ ossmconsole_vars.kiali.servicePort }}
+      name: ossmconsole
+      namespace: {{ ossmconsole_vars.deployment.namespace }}
+      port: 9443
+      basePath: "/"
+    type: Service
+  proxy:
+  - alias: kiali
+    authorization: UserToken
+    endpoint:
+      service:
+        name: {{ ossmconsole_vars.kiali.serviceName }}
+        namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
+        port: {{ ossmconsole_vars.kiali.servicePort }}
+      type: Service


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/7622