### PR TITLE
[v1.86] check Kiali version when installing OSSMC

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -296,6 +296,8 @@ spec:
                   value: "true"
                 - name: ACCESSIBLE_NAMESPACES_LABEL
                   value: "maistra.io/member-of"
+                - name: OSSMC_SKIP_VERSION_CHECK
+                  value: "false"
                 - name: PROFILE_TASKS_TASK_OUTPUT_LIMIT
                   value: "100"
                 - name: ANSIBLE_DEBUG_LOGS

--- a/roles/default/ossmconsole-deploy/tasks/main.yml
+++ b/roles/default/ossmconsole-deploy/tasks/main.yml
@@ -240,6 +240,27 @@
         serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         servicePort: "{{ ossmconsole_vars.kiali.servicePort }}"
 
+# The OSSMC plugin must talk to a Kiali of the same version.
+# We asked the Kiali Server what version it is, so we already have that.
+# To know the OSSMC version, we assume even if the user overrides the imageName/imageVersion, that that image must
+# support the same major.minor version of the playbook (i.e. spec.version). We look up the version of the playbook
+# in supported_ossmconsole_images and obtain the imageVersion that that playbook supports and assume that is the version
+# of OSSMC that is being installed - so that is the version we compare with the Kiali version. Note that if imageVersion
+# is the string "operator_version", the supported OSSMC version is the same version as the operator itself.
+# Note that we ignore any "v" prefix that may be in front of the version numbers; always just compare major.minor (v or no-v).
+# If, for some reason, the user runs into an edge case where OSSMC needs to be installed even if the versions don't match,
+# set the env var OSSMC_SKIP_VERSION_CHECK=true in the operator.
+- name: Ensure Kiali major.minor version is supported by the version of OSSMC being installed
+  vars:
+    kiali_version_to_match: "{{ kiali_version | default('') | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+    ossmc_version_expected: "{{ supported_ossmconsole_images[ossmconsole_vars.version].imageVersion | default ('') }}"
+    ossmc_version_to_match: "{{ ((operator_version | default('')) if ossmc_version_expected == 'operator_version' else ossmc_version_expected) | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+  fail:
+    msg: "The version of the Kiali Server [{{ kiali_version_to_match }}] does not match the OSSMC version [{{ ossmc_version_to_match }}]. OSSMC will not be installed. To skip this check and allow for the install to continue, set the operator environment variable OSSMC_SKIP_VERSION_CHECK to 'true'."
+  when:
+  - kiali_version_to_match != ossmc_version_to_match
+  - lookup('env', 'OSSMC_SKIP_VERSION_CHECK') | default('false', True) != "true"
+
 - name: Only allow ad-hoc OSSM Console image when appropriate
   fail:
     msg: "The operator is forbidden from accepting an OSSMConsole CR that defines an ad hoc OSSM Console image [{{ ossmconsole_vars.deployment.imageName }}{{ '@' + ossmconsole_vars.deployment.imageDigest if ossmconsole_vars.deployment.imageDigest != '' else '' }}:{{ ossmconsole_vars.deployment.imageVersion }}]. Remove spec.deployment.imageName, spec.deployment.imageVersion, and spec.deployment.imageDigest from the OSSMConsole CR."

--- a/roles/v1.73/ossmconsole-deploy/tasks/main.yml
+++ b/roles/v1.73/ossmconsole-deploy/tasks/main.yml
@@ -244,6 +244,27 @@
         serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         servicePort: "{{ ossmconsole_vars.kiali.servicePort }}"
 
+# The OSSMC plugin must talk to a Kiali of the same version.
+# We asked the Kiali Server what version it is, so we already have that.
+# To know the OSSMC version, we assume even if the user overrides the imageName/imageVersion, that that image must
+# support the same major.minor version of the playbook (i.e. spec.version). We look up the version of the playbook
+# in supported_ossmconsole_images and obtain the imageVersion that that playbook supports and assume that is the version
+# of OSSMC that is being installed - so that is the version we compare with the Kiali version. Note that if imageVersion
+# is the string "operator_version", the supported OSSMC version is the same version as the operator itself.
+# Note that we ignore any "v" prefix that may be in front of the version numbers; always just compare major.minor (v or no-v).
+# If, for some reason, the user runs into an edge case where OSSMC needs to be installed even if the versions don't match,
+# set the env var OSSMC_SKIP_VERSION_CHECK=true in the operator.
+- name: Ensure Kiali major.minor version is supported by the version of OSSMC being installed
+  vars:
+    kiali_version_to_match: "{{ kiali_version | default('') | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+    ossmc_version_expected: "{{ supported_ossmconsole_images[ossmconsole_vars.version].imageVersion | default ('') }}"
+    ossmc_version_to_match: "{{ ((operator_version | default('')) if ossmc_version_expected == 'operator_version' else ossmc_version_expected) | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+  fail:
+    msg: "The version of the Kiali Server [{{ kiali_version_to_match }}] does not match the OSSMC version [{{ ossmc_version_to_match }}]. OSSMC will not be installed. To skip this check and allow for the install to continue, set the operator environment variable OSSMC_SKIP_VERSION_CHECK to 'true'."
+  when:
+  - kiali_version_to_match != ossmc_version_to_match
+  - lookup('env', 'OSSMC_SKIP_VERSION_CHECK') | default('false', True) != "true"
+
 - name: Only allow ad-hoc OSSM Console image when appropriate
   fail:
     msg: "The operator is forbidden from accepting an OSSMConsole CR that defines an ad hoc OSSM Console image [{{ ossmconsole_vars.deployment.imageName }}{{ '@' + ossmconsole_vars.deployment.imageDigest if ossmconsole_vars.deployment.imageDigest != '' else '' }}:{{ ossmconsole_vars.deployment.imageVersion }}]. Remove spec.deployment.imageName, spec.deployment.imageVersion, and spec.deployment.imageDigest from the OSSMConsole CR."

--- a/roles/v1.86/ossmconsole-deploy/tasks/main.yml
+++ b/roles/v1.86/ossmconsole-deploy/tasks/main.yml
@@ -240,6 +240,27 @@
         serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         servicePort: "{{ ossmconsole_vars.kiali.servicePort }}"
 
+# The OSSMC plugin must talk to a Kiali of the same version.
+# We asked the Kiali Server what version it is, so we already have that.
+# To know the OSSMC version, we assume even if the user overrides the imageName/imageVersion, that that image must
+# support the same major.minor version of the playbook (i.e. spec.version). We look up the version of the playbook
+# in supported_ossmconsole_images and obtain the imageVersion that that playbook supports and assume that is the version
+# of OSSMC that is being installed - so that is the version we compare with the Kiali version. Note that if imageVersion
+# is the string "operator_version", the supported OSSMC version is the same version as the operator itself.
+# Note that we ignore any "v" prefix that may be in front of the version numbers; always just compare major.minor (v or no-v).
+# If, for some reason, the user runs into an edge case where OSSMC needs to be installed even if the versions don't match,
+# set the env var OSSMC_SKIP_VERSION_CHECK=true in the operator.
+- name: Ensure Kiali major.minor version is supported by the version of OSSMC being installed
+  vars:
+    kiali_version_to_match: "{{ kiali_version | default('') | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+    ossmc_version_expected: "{{ supported_ossmconsole_images[ossmconsole_vars.version].imageVersion | default ('') }}"
+    ossmc_version_to_match: "{{ ((operator_version | default('')) if ossmc_version_expected == 'operator_version' else ossmc_version_expected) | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+  fail:
+    msg: "The version of the Kiali Server [{{ kiali_version_to_match }}] does not match the OSSMC version [{{ ossmc_version_to_match }}]. OSSMC will not be installed. To skip this check and allow for the install to continue, set the operator environment variable OSSMC_SKIP_VERSION_CHECK to 'true'."
+  when:
+  - kiali_version_to_match != ossmc_version_to_match
+  - lookup('env', 'OSSMC_SKIP_VERSION_CHECK') | default('false', True) != "true"
+
 - name: Only allow ad-hoc OSSM Console image when appropriate
   fail:
     msg: "The operator is forbidden from accepting an OSSMConsole CR that defines an ad hoc OSSM Console image [{{ ossmconsole_vars.deployment.imageName }}{{ '@' + ossmconsole_vars.deployment.imageDigest if ossmconsole_vars.deployment.imageDigest != '' else '' }}:{{ ossmconsole_vars.deployment.imageVersion }}]. Remove spec.deployment.imageName, spec.deployment.imageVersion, and spec.deployment.imageDigest from the OSSMConsole CR."


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/7619

backport of https://github.com/kiali/kiali-operator/pull/801