### PR TITLE
system namespaces are now filtered out when no discovery selectors are set

### DIFF
--- a/molecule/accessible-namespaces-test/converge.yml
+++ b/molecule/accessible-namespaces-test/converge.yml
@@ -13,17 +13,20 @@
     vars:
       namespace_list: []
 
-  # Cluster Wide Access (CWA) is true by default - with no discovery selectors, all namespaces should be retrieved
+  # Cluster Wide Access (CWA) is true by default - with no discovery selectors, all namespaces should be retrieved, minus system namespaces
   - debug: msg="test to make sure the default (CWA=true) behavior works"
   - include_tasks: ../asserts/assert-api-namespaces-result.yml
     vars:
-      min_namespaces_expected: 5
+      min_namespaces_expected: 4
       namespaces_expected:
       - "{{ istio.control_plane_namespace }}"
-      - kiali-operator
       - kiali-test-other
       - kiali-test-region-east
       - kiali-test-region-west
+      namespaces_not_expected:
+      - kiali-operator
+      - kube-system
+      - openshift-operators
 
   - name: Assert status field does not specify any discovery selector namespaces
     assert:
@@ -297,13 +300,16 @@
 
   - include_tasks: ../asserts/assert-api-namespaces-result.yml
     vars:
-      min_namespaces_expected: 5
+      min_namespaces_expected: 4
       namespaces_expected:
       - "{{ istio.control_plane_namespace }}"
-      - kiali-operator
       - kiali-test-other
       - kiali-test-region-east
       - kiali-test-region-west
+      namespaces_not_expected:
+      - kiali-operator
+      - kube-system
+      - openshift-operators
 
   - name: Assert status field does not specify any discovery selector namespaces
     assert:


### PR DESCRIPTION
part of: https://github.com/kiali/kiali/issues/7687

no changes to the operator need to be made - we only need to change tests now that system namespaces are being filtered out when no discovery selectors are set.