### PR TITLE
install jmespath py library as root

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,6 +6,9 @@ USER root
 # see https://github.com/operator-framework/operator-sdk/issues/5745
 RUN yum remove -y subscription-manager python3-subscription-manager-rhsm
 RUN yum update -y && yum clean all
+# pull in jmespath py library for json processing
+RUN python3 -m pip install jmespath
+
 USER ${USER_UID}
 
 COPY roles/ ${HOME}/roles/
@@ -14,9 +17,6 @@ COPY watches-k8s.yaml ${HOME}/watches-k8s.yaml
 COPY watches-os.yaml ${HOME}/watches-os.yaml
 COPY watches-k8s-ns.yaml ${HOME}/watches-k8s-ns.yaml
 COPY watches-os-ns.yaml ${HOME}/watches-os-ns.yaml
-
-# pull in jmespath py library for json processing
-RUN python3 -m pip install jmespath
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \


### PR DESCRIPTION
We are seeing issues on OpenShift not finding this jmespath library. I don't know if this fixes the problem, but installing that py library as root might be a solution. Need to test this.