### PR TITLE
include task has been deprecated in ansible - use include_tasks instead

### DIFF
--- a/roles/default/ossmconsole-deploy/tasks/main.yml
+++ b/roles/default/ossmconsole-deploy/tasks/main.yml
@@ -368,7 +368,7 @@
 # Now deploy all resources for the specific cluster environment
 
 - name: Execute for OpenShift environment
-  include: openshift/os-main.yml
+  include_tasks: openshift/os-main.yml
   vars:
     deployment_last_updated: "{{ current_deployment_last_updated }}"
 

--- a/roles/v1.73/ossmconsole-deploy/tasks/main.yml
+++ b/roles/v1.73/ossmconsole-deploy/tasks/main.yml
@@ -372,7 +372,7 @@
 # Now deploy all resources for the specific cluster environment
 
 - name: Execute for OpenShift environment
-  include: openshift/os-main.yml
+  include_tasks: openshift/os-main.yml
   vars:
     deployment_last_updated: "{{ current_deployment_last_updated }}"
 

--- a/roles/v1.89/ossmconsole-deploy/tasks/main.yml
+++ b/roles/v1.89/ossmconsole-deploy/tasks/main.yml
@@ -368,7 +368,7 @@
 # Now deploy all resources for the specific cluster environment
 
 - name: Execute for OpenShift environment
-  include: openshift/os-main.yml
+  include_tasks: openshift/os-main.yml
   vars:
     deployment_last_updated: "{{ current_deployment_last_updated }}"
 


### PR DESCRIPTION
I don't know how this one sneaked through, but all others have already been replaced. This needs to be replaced, too.

This isn't necessary right now (so no need to backport) but this will be needed in the future when we get a new ansible operator base image that has Ansible 2.16+ in it. So let's get this in now.