### PR TITLE
[v1.89] support namespaces with just numerals in their names

### DIFF
--- a/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
 {% if kiali_vars.deployment.hpa.spec | length == 0 %}

--- a/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', ap
 kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
 {% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}

--- a/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/cabundle.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-cabundle
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/default/kiali-deploy/templates/openshift/clusterrolebinding-oauth.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/clusterrolebinding-oauth.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/default/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
 {% if kiali_vars.deployment.hpa.spec | length == 0 %}

--- a/roles/default/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/route.yaml
@@ -2,7 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/default/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.instance_name }}-cert-secret

--- a/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/default/kiali-remove/tasks/os-resources-to-remove.yml
+++ b/roles/default/kiali-remove/tasks/os-resources-to-remove.yml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-cabundle

--- a/roles/default/kiali-remove/tasks/resources-to-remove.yml
+++ b/roles/default/kiali-remove/tasks/resources-to-remove.yml
@@ -2,77 +2,77 @@
 apiVersion: {{ kiali_vars_remove.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}
 kind: Ingress
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ReplicaSet
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-service-account
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-viewer
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ kiali_vars_remove.istio_namespace }}
+  namespace: "{{ kiali_vars_remove.istio_namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-controlplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.istio_namespace }}
+  namespace: "{{ kiali_vars_remove.istio_namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-controlplane

--- a/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-conf
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 data:
   nginx.conf: |

--- a/roles/default/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: plugin-conf
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 data:
   plugin-config.json: |

--- a/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -8,7 +8,7 @@ spec:
   backend:
     service:
       name: ossmconsole
-      namespace: {{ ossmconsole_vars.deployment.namespace }}
+      namespace: "{{ ossmconsole_vars.deployment.namespace }}"
       port: 9443
       basePath: "/"
     type: Service
@@ -18,6 +18,6 @@ spec:
     endpoint:
       service:
         name: {{ ossmconsole_vars.kiali.serviceName }}
-        namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
+        namespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         port: {{ ossmconsole_vars.kiali.servicePort }}
       type: Service

--- a/roles/default/ossmconsole-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ossmconsole
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 spec:
   replicas: 1

--- a/roles/default/ossmconsole-deploy/templates/openshift/service.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ossmconsole
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: ossmconsole-cert-secret

--- a/roles/default/ossmconsole-remove/tasks/resources-to-remove.yml
+++ b/roles/default/ossmconsole-remove/tasks/resources-to-remove.yml
@@ -2,25 +2,25 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: nginx-config
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: plugin-config
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: ossmconsole
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: ossmconsole
 ---
 apiVersion: console.openshift.io/v1alpha1

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', ap
 kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.clustering.enabled|bool == True %}

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
 {% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}

--- a/roles/v1.57/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/v1.57/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.57/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/cabundle.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-cabundle
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v1.57/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.57/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}

--- a/roles/v1.57/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.57/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.clustering.enabled|bool == True %}

--- a/roles/v1.57/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.57/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.57/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.57/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.57/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/route.yaml
@@ -2,7 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.57/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.instance_name }}-cert-secret

--- a/roles/v1.57/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', ap
 kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
 {% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}

--- a/roles/v1.65/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/v1.65/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.65/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/cabundle.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-cabundle
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v1.65/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.65/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}

--- a/roles/v1.65/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.65/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/v1.65/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.65/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.65/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.65/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.65/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/route.yaml
@@ -2,7 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.65/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.instance_name }}-cert-secret

--- a/roles/v1.65/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', ap
 kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
 {% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}

--- a/roles/v1.73/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/v1.73/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.73/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/cabundle.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-cabundle
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v1.73/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.73/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   replicas: {{ kiali_vars.deployment.replicas }}

--- a/roles/v1.73/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.73/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/v1.73/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.73/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.73/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.73/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.73/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/route.yaml
@@ -2,7 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.73/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.instance_name }}-cert-secret

--- a/roles/v1.73/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.73/kiali-remove/tasks/os-resources-to-remove.yml
+++ b/roles/v1.73/kiali-remove/tasks/os-resources-to-remove.yml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-cabundle

--- a/roles/v1.73/kiali-remove/tasks/resources-to-remove.yml
+++ b/roles/v1.73/kiali-remove/tasks/resources-to-remove.yml
@@ -2,77 +2,77 @@
 apiVersion: {{ kiali_vars_remove.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}
 kind: Ingress
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ReplicaSet
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-service-account
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-viewer
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ kiali_vars_remove.istio_namespace }}
+  namespace: "{{ kiali_vars_remove.istio_namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-controlplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.istio_namespace }}
+  namespace: "{{ kiali_vars_remove.istio_namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-controlplane

--- a/roles/v1.73/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/v1.73/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-conf
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 data:
   nginx.conf: |

--- a/roles/v1.73/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
+++ b/roles/v1.73/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: plugin-conf
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 data:
   plugin-config.json: |

--- a/roles/v1.73/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/v1.73/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -8,7 +8,7 @@ spec:
   backend:
     service:
       name: ossmconsole
-      namespace: {{ ossmconsole_vars.deployment.namespace }}
+      namespace: "{{ ossmconsole_vars.deployment.namespace }}"
       port: 9443
       basePath: "/"
     type: Service
@@ -18,6 +18,6 @@ spec:
     endpoint:
       service:
         name: {{ ossmconsole_vars.kiali.serviceName }}
-        namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
+        namespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         port: {{ ossmconsole_vars.kiali.servicePort }}
       type: Service

--- a/roles/v1.73/ossmconsole-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.73/ossmconsole-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ossmconsole
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 spec:
   replicas: 1

--- a/roles/v1.73/ossmconsole-deploy/templates/openshift/service.yaml
+++ b/roles/v1.73/ossmconsole-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ossmconsole
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: ossmconsole-cert-secret

--- a/roles/v1.73/ossmconsole-remove/tasks/resources-to-remove.yml
+++ b/roles/v1.73/ossmconsole-remove/tasks/resources-to-remove.yml
@@ -2,25 +2,25 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: nginx-config
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: plugin-config
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: ossmconsole
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: ossmconsole
 ---
 apiVersion: console.openshift.io/v1alpha1

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
 {% if kiali_vars.deployment.hpa.spec | length == 0 %}

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', ap
 kind: Ingress
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/role-controlplane.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
 {% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}

--- a/roles/v1.89/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/v1.89/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.89/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/cabundle.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-cabundle
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v1.89/kiali-deploy/templates/openshift/clusterrolebinding-oauth.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/clusterrolebinding-oauth.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.89/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
   annotations:

--- a/roles/v1.89/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
 {% if kiali_vars.deployment.hpa.spec | length == 0 %}

--- a/roles/v1.89/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 spec:
   scaleTargetRef:

--- a/roles/v1.89/kiali-deploy/templates/openshift/role-controlplane.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/role-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 {% if kiali_vars.kiali_feature_flags.certificates_information_indicators.enabled|bool == True %}

--- a/roles/v1.89/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-viewer
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.89/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 rules:
 - apiGroups: [""]

--- a/roles/v1.89/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/rolebinding-controlplane.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-controlplane
-  namespace: {{ kiali_vars.istio_namespace }}
+  namespace: "{{ kiali_vars.istio_namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v1.89/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ role_binding_kind }}
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ namespace }}
+  namespace: "{{ namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -13,5 +13,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
 {% endfor %}

--- a/roles/v1.89/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/route.yaml
@@ -2,7 +2,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
 {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
   {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}

--- a/roles/v1.89/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.instance_name }}-cert-secret

--- a/roles/v1.89/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ kiali_vars.deployment.instance_name }}-service-account
-  namespace: {{ kiali_vars.deployment.namespace }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
   labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v1.89/kiali-remove/tasks/os-resources-to-remove.yml
+++ b/roles/v1.89/kiali-remove/tasks/os-resources-to-remove.yml
@@ -7,11 +7,11 @@ metadata:
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-cabundle

--- a/roles/v1.89/kiali-remove/tasks/resources-to-remove.yml
+++ b/roles/v1.89/kiali-remove/tasks/resources-to-remove.yml
@@ -2,77 +2,77 @@
 apiVersion: {{ kiali_vars_remove.deployment.hpa.api_version }}
 kind: HorizontalPodAutoscaler
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}
 kind: Ingress
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ReplicaSet
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-service-account
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-viewer
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ kiali_vars_remove.deployment.namespace }}
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: {{ kiali_vars_remove.istio_namespace }}
+  namespace: "{{ kiali_vars_remove.istio_namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-controlplane
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ kiali_vars_remove.istio_namespace }}
+  namespace: "{{ kiali_vars_remove.istio_namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}-controlplane

--- a/roles/v1.89/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/v1.89/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: nginx-conf
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 data:
   nginx.conf: |

--- a/roles/v1.89/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
+++ b/roles/v1.89/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: plugin-conf
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 data:
   plugin-config.json: |

--- a/roles/v1.89/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/v1.89/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -8,7 +8,7 @@ spec:
   backend:
     service:
       name: ossmconsole
-      namespace: {{ ossmconsole_vars.deployment.namespace }}
+      namespace: "{{ ossmconsole_vars.deployment.namespace }}"
       port: 9443
       basePath: "/"
     type: Service
@@ -18,6 +18,6 @@ spec:
     endpoint:
       service:
         name: {{ ossmconsole_vars.kiali.serviceName }}
-        namespace: {{ ossmconsole_vars.kiali.serviceNamespace }}
+        namespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         port: {{ ossmconsole_vars.kiali.servicePort }}
       type: Service

--- a/roles/v1.89/ossmconsole-deploy/templates/openshift/deployment.yaml
+++ b/roles/v1.89/ossmconsole-deploy/templates/openshift/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ossmconsole
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
 spec:
   replicas: 1

--- a/roles/v1.89/ossmconsole-deploy/templates/openshift/service.yaml
+++ b/roles/v1.89/ossmconsole-deploy/templates/openshift/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ossmconsole
-  namespace: {{ ossmconsole_vars.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
   labels: {{ ossmconsole_resource_metadata_labels }}
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: ossmconsole-cert-secret

--- a/roles/v1.89/ossmconsole-remove/tasks/resources-to-remove.yml
+++ b/roles/v1.89/ossmconsole-remove/tasks/resources-to-remove.yml
@@ -2,25 +2,25 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: nginx-config
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: plugin-config
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: ossmconsole
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: {{ ossmconsole_vars_remove.deployment.namespace }}
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
   name: ossmconsole
 ---
 apiVersion: console.openshift.io/v1alpha1


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/7773

cherry pick of https://github.com/kiali/kiali-operator/pull/822

test procedures are the same for https://github.com/kiali/kiali-operator/pull/822 except you just want to try setting `spec.version` to other supported versions (I tried all of them and all worked: `v1.89`, `v1.73`, `v1.65`, `v1.57`) and set `accessible_namespaces` to include `12345` rather than set discovery selectors:
```yaml
spec:
  deployment:
    accessible_namespaces: ["12345"]
```