### PR TITLE
support numeral namespace names (part 2)

### DIFF
--- a/roles/default/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/console-links.yaml
@@ -12,5 +12,5 @@ spec:
   text: {{ ('Kiali [' + kiali_vars.deployment.instance_name + ']') if kiali_vars.deployment.instance_name != 'kiali' else 'Kiali' }}
   namespaceDashboard:
     namespaces:
-    - {{ namespace }}
+    - "{{ namespace }}"
 {% endfor %}

--- a/roles/v1.57/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/v1.57/kiali-deploy/templates/openshift/console-links.yaml
@@ -12,5 +12,5 @@ spec:
   text: {{ ('Kiali [' + kiali_vars.deployment.instance_name + ']') if kiali_vars.deployment.instance_name != 'kiali' else 'Kiali' }}
   namespaceDashboard:
     namespaces:
-    - {{ namespace }}
+    - "{{ namespace }}"
 {% endfor %}

--- a/roles/v1.65/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/v1.65/kiali-deploy/templates/openshift/console-links.yaml
@@ -12,5 +12,5 @@ spec:
   text: {{ ('Kiali [' + kiali_vars.deployment.instance_name + ']') if kiali_vars.deployment.instance_name != 'kiali' else 'Kiali' }}
   namespaceDashboard:
     namespaces:
-    - {{ namespace }}
+    - "{{ namespace }}"
 {% endfor %}

--- a/roles/v1.73/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/v1.73/kiali-deploy/templates/openshift/console-links.yaml
@@ -12,5 +12,5 @@ spec:
   text: {{ ('Kiali [' + kiali_vars.deployment.instance_name + ']') if kiali_vars.deployment.instance_name != 'kiali' else 'Kiali' }}
   namespaceDashboard:
     namespaces:
-    - {{ namespace }}
+    - "{{ namespace }}"
 {% endfor %}

--- a/roles/v1.89/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/v1.89/kiali-deploy/templates/openshift/console-links.yaml
@@ -12,5 +12,5 @@ spec:
   text: {{ ('Kiali [' + kiali_vars.deployment.instance_name + ']') if kiali_vars.deployment.instance_name != 'kiali' else 'Kiali' }}
   namespaceDashboard:
     namespaces:
-    - {{ namespace }}
+    - "{{ namespace }}"
 {% endfor %}


### PR DESCRIPTION
I missed the openshift console link template in the original PR.