### PR TITLE
Add url format in tempo config

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -376,6 +376,7 @@ spec:
       tempo_config:
         datasource_uid: ""
         org_id: ""
+        url_format: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
 

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1053,6 +1053,9 @@ spec:
                           org_id:
                             description: "The Id of the organization that the dashboard is in. Default to 1 (the first and default organization)."
                             type: string
+                          url_format:
+                            description: "The URL format for the external url. Can be 'jaeger' or 'grafana'. Default to 'grafana'. Grafana will need a Grafana url in the Grafana settings."
+                            type: string
                       use_grpc:
                         description: "Set to true in order to enable GRPC connections between Kiali and Jaeger which will speed up the queries. In some setups you might not be able to use GRPC (e.g. if Jaeger is behind some reverse proxy that doesn't support it). If not specified, this will defalt to 'true'."
                         type: boolean

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -214,6 +214,7 @@ kiali_defaults:
       tempo_config:
         datasource_uid: ""
         org_id: ""
+        url_format: ""
       use_grpc: true
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
 


### PR DESCRIPTION
Adds a new tempo config option to specify the tracing url format. So it is possible to link to the Jaeger UI or to a Grafana datasource.

Ref. https://github.com/kiali/kiali/issues/7822 