### PR TITLE
clean up some stuff now that istio secrets are no longer accessed

### DIFF
--- a/manifests/kiali-community/2.1.0/manifests/kiali.v2.1.0.clusterserviceversion.yaml
+++ b/manifests/kiali-community/2.1.0/manifests/kiali.v2.1.0.clusterserviceversion.yaml
@@ -348,14 +348,6 @@ spec:
           - watch
         - apiGroups: [""]
           resourceNames:
-          - cacerts
-          - istio-ca-secret
-          resources:
-          - secrets
-          verbs:
-          - get
-        - apiGroups: [""]
-          resourceNames:
           - kiali-signing-key
           resources:
           - secrets

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -374,14 +374,6 @@ spec:
           - watch
         - apiGroups: [""]
           resourceNames:
-          - cacerts
-          - istio-ca-secret
-          resources:
-          - secrets
-          verbs:
-          - get
-        - apiGroups: [""]
-          resourceNames:
           - kiali-signing-key
           resources:
           - secrets

--- a/manifests/kiali-upstream/2.1.0/manifests/kiali.v2.1.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.1.0/manifests/kiali.v2.1.0.clusterserviceversion.yaml
@@ -295,14 +295,6 @@ spec:
           - watch
         - apiGroups: [""]
           resourceNames:
-          - cacerts
-          - istio-ca-secret
-          resources:
-          - secrets
-          verbs:
-          - get
-        - apiGroups: [""]
-          resourceNames:
           - kiali-signing-key
           resources:
           - secrets

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -235,11 +235,6 @@ kiali_defaults:
     version_label_name: "version"
 
   kiali_feature_flags:
-    certificates_information_indicators:
-      enabled: true
-      secrets:
-      - cacerts
-      - istio-ca-secret
     disabled_features: []
     istio_annotation_action: true
     istio_injection_action: true


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/7855

I checked the helm charts, everything is purged from over there. Looks like we just missed OLM metadata and the operator defaults.