### PR TITLE
provide a way to tell the operator to create only the remote cluster resources

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -38,6 +38,7 @@ spec:
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
     openshift:
+      #kiali_route_url:
       #token_inactivity_timeout:
       #token_max_age:
 

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -218,6 +218,7 @@ spec:
     pod_labels:
       sidecar.istio.io/inject: "true"
     priority_class_name: ""
+    remote_cluster_resources_only: false
     replicas: 1
     # default: resources is undefined
     resources:

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -38,7 +38,7 @@ spec:
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
     openshift:
-      #kiali_route_url:
+      #redirect_uris:
       #token_inactivity_timeout:
       #token_max_age:
 

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -594,6 +594,9 @@ spec:
                   priority_class_name:
                     description: "The priorityClassName used to assign the priority of the Kiali pod."
                     type: string
+                  remote_cluster_resources_only:
+                    description: "When `true`, only those resources necessary for a remote Kiali Server to access this cluster are created (such as the service account and roles/bindings). There will be no Kiali Server deployment/pod created when this is `true`."
+                    type: boolean
                   replicas:
                     description: "The replica count for the Kiail deployment. If `deployment.hpa` is specified, this setting is ignored."
                     type: integer

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -148,9 +148,11 @@ spec:
                     description: "To learn more about these settings and how to configure the OpenShift authentication strategy, read the documentation at https://kiali.io/docs/configuration/authentication/openshift/"
                     type: object
                     properties:
-                      kiali_route_url:
-                        description: "The URL for the Kiali Route that will be used for the OAuth redirect URI. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `openshift` auth strategy enabled."
-                        type: string
+                      redirect_uris:
+                        description: "The OAuthClient redirect URIs. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `auth.strategy` set to `openshift`."
+                        type: array
+                        items:
+                          type: string
                       token_inactivity_timeout:
                         description: "Timeout that overrides the default OpenShift token inactivity timeout. This value represents the maximum amount of time in seconds that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. If 0, the Kiali tokens never timeout. OpenShift may have a minimum allowed value - see the OpenShift documentation specific for the version of OpenShift you are using. WARNING: existing tokens will not be affected by changing this setting."
                         type: integer

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -148,6 +148,9 @@ spec:
                     description: "To learn more about these settings and how to configure the OpenShift authentication strategy, read the documentation at https://kiali.io/docs/configuration/authentication/openshift/"
                     type: object
                     properties:
+                      kiali_route_url:
+                        description: "The URL for the Kiali Route that will be used for the OAuth redirect URI. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `openshift` auth strategy enabled."
+                        type: string
                       token_inactivity_timeout:
                         description: "Timeout that overrides the default OpenShift token inactivity timeout. This value represents the maximum amount of time in seconds that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. If 0, the Kiali tokens never timeout. OpenShift may have a minimum allowed value - see the OpenShift documentation specific for the version of OpenShift you are using. WARNING: existing tokens will not be affected by changing this setting."
                         type: integer

--- a/molecule/common/tasks.yml
+++ b/molecule/common/tasks.yml
@@ -14,6 +14,18 @@
 - debug:
     msg: "Present Kiali CR: {{ kiali_cr }}"
 
+- name: Get Kiali Configmap
+  vars:
+    instance_name: "{{ kiali.instance_name | default('kiali') }}"
+  set_fact:
+    kiali_configmap_resource: "{{ lookup('kubernetes.core.k8s', api_version='v1', kind='ConfigMap', namespace=kiali.install_namespace, resource_name=instance_name) }}"
+
+- name: Format Configmap
+  set_fact:
+    kiali_configmap: "{{ kiali_configmap_resource.data['config.yaml'] | from_yaml }}"
+- debug:
+    msg: "Present Kiali ConfigMap: {{ kiali_configmap }}"
+
 - name: Get Kiali Operator Pod
   k8s_info:
     api_version: v1
@@ -33,18 +45,8 @@
     label_selectors:
     - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_pod
-
-- name: Get Kiali Configmap
-  vars:
-    instance_name: "{{ kiali.instance_name | default('kiali') }}"
-  set_fact:
-    kiali_configmap_resource: "{{ lookup('kubernetes.core.k8s', api_version='v1', kind='ConfigMap', namespace=kiali.install_namespace, resource_name=instance_name) }}"
-
-- name: Format Configmap
-  set_fact:
-    kiali_configmap: "{{ kiali_configmap_resource.data['config.yaml'] | from_yaml }}"
-- debug:
-    msg: "Present Kiali ConfigMap: {{ kiali_configmap }}"
+  when:
+  - kiali_configmap.deployment.remote_cluster_resources_only == False
 
 - name: Get Kiali Deployment
   vars:
@@ -56,6 +58,8 @@
     label_selectors:
     - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_deployment
+  when:
+  - kiali_configmap.deployment.remote_cluster_resources_only == False
 
 - name: Get Kiali Service
   vars:
@@ -67,6 +71,8 @@
     label_selectors:
     - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_service
+  when:
+  - kiali_configmap.deployment.remote_cluster_resources_only == False
 
 - name: Get Kiali Route
   vars:
@@ -80,6 +86,7 @@
   register: kiali_route
   when:
   - is_openshift == True
+  - kiali_configmap.deployment.remote_cluster_resources_only == False
 
 - name: Get Kiali Ingress
   ignore_errors: yes
@@ -93,7 +100,8 @@
     - "app.kubernetes.io/instance={{ instance_name }}"
   register: kiali_ingress
   when:
-  - is_openshift != True
+  - is_openshift == False
+  - kiali_configmap.deployment.remote_cluster_resources_only == False
 
 - name: Determine the Kiali Route URL on OpenShift
   vars:
@@ -102,6 +110,7 @@
     kiali_base_url: "https://{{ kiali_route.resources[0].spec.host }}{{ web_root }}"
   when:
   - is_openshift == True
+  - kiali_configmap.deployment.remote_cluster_resources_only == False
 
 # To avoid problems with Ingress/Minikube conflicts, if installing multiple kiali instances set web_root to the instance name
 - name: Determine the Kiali Ingress URL on minikube
@@ -112,9 +121,11 @@
     kiali_base_url: "https://{{ lookup('env', 'MOLECULE_MINIKUBE_IP') }}{{ web_root }}"
   when:
   - is_minikube == True
+  - kiali_configmap.deployment.remote_cluster_resources_only == False
 
 - name: Determine the Kiali Ingress URL on kind
   set_fact:
     kiali_base_url: "http://{{ kiali_service.resources[0].status.loadBalancer.ingress[0].ip }}:20001/kiali"
   when:
   - is_kind == True
+  - kiali_configmap.deployment.remote_cluster_resources_only == False

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -110,6 +110,9 @@
       namespace: "{{ cr_namespace }}"
       definition: "{{ kiali_cr_definition }}"
 
+  # We normally always want to wait for kiali to be deployed, but for those tests
+  # where this is not wanted (e.g. when remote_cluster_resources_only==true), then
+  # import this playbook with the var "wait_for_kiali_pod_after_prepare" set to false.
   - name: Asserting that Kiali is Deployed
     vars:
       instance_name: "{{ kiali.instance_name | default('kiali') }}"
@@ -127,3 +130,5 @@
     - kiali_deployment.resources[0].status.availableReplicas == 1
     retries: "{{ wait_retries }}"
     delay: 5
+    when:
+    - wait_for_kiali_pod_after_prepare | default(true) == True

--- a/molecule/remote-cluster-resources-test/converge.yml
+++ b/molecule/remote-cluster-resources-test/converge.yml
@@ -1,0 +1,251 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+
+  # just set some common constants so our assert code in the below tests is easier to read
+  - set_fact:
+      querySelector: "app.kubernetes.io/instance=kiali"
+      queryNamespace: "{{ kiali.install_namespace }}"
+      apiCMap: "v1"
+      apiCoLn: "console.openshift.io/v1"
+      apiDepl: "apps/v1"
+      apiPod:  "v1"
+      apiSecr: "v1"
+      apiServ: "v1"
+      apiSvcA: "v1"
+      apiIngr: "networking.k8s.io/{{ 'v1' if (lookup('k8s', kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
+      apiRout: "route.openshift.io/v1"
+      apiOAut: "oauth.openshift.io/v1"
+
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  # ASSERT CWA=TRUE
+  - include_tasks: ../asserts/accessible_namespaces_contains.yml
+    vars:
+      namespace_list: []
+
+  - debug: msg="test to make sure cluster-wide-access is True"
+  - assert:
+      that:
+      - kiali_configmap.deployment.cluster_wide_access == True
+
+  - debug: msg="assert that we have clusterroles since we have been given cluster wide access"
+  - include_tasks: ../asserts/roles-test/rw_clusterrole_asserts.yml
+  - include_tasks: ../asserts/roles-test/none_role_asserts.yml
+    vars:
+      role_namespaces_to_test:
+      - "{{ istio.control_plane_namespace }}"
+      - remote-cluster-resources-test-1
+      - remote-cluster-resources-test-2
+      - remote-cluster-resources-test-x
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift-specific resources
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+
+  # SET discovery selectors=[istio-system, remote-cluster-resources-test-1, remote-cluster-resources-test-x]
+  - debug: msg="change accessible namespaces to a fixed list of namespaces but keep cluster-wide-access (set to True)"
+  - include_tasks: ../common/set_discovery_selectors_to_list.yml
+    vars:
+      new_cluster_wide_access: true
+      discovery_selectors:
+      - matchLabels:
+          kubernetes.io/metadata.name: "{{ istio.control_plane_namespace}}"
+      - matchLabels:
+          kubernetes.io/metadata.name: "remote-cluster-resources-test-1"
+      - matchLabels:
+          kubernetes.io/metadata.name: "remote-cluster-resources-test-x"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+  - name: CWA is true so there should be no labels on any namespaces
+    include_tasks: ../asserts/accessible_namespaces_contains.yml
+    vars:
+      namespace_list: []
+
+  - debug: msg="test the normal accessible namespaces"
+  - name: "Even though discovery selectors are set, cluster wide access should still be True because we explicitly asked for it"
+    assert:
+      that:
+      - kiali_configmap.deployment.cluster_wide_access == True
+
+  - debug: msg="assert that we have clusterroles since we have been given cluster wide access"
+  - include_tasks: ../asserts/roles-test/rw_clusterrole_asserts.yml
+  - include_tasks: ../asserts/roles-test/none_role_asserts.yml
+    vars:
+      role_namespaces_to_test:
+      - "{{ istio.control_plane_namespace }}"
+      - remote-cluster-resources-test-1
+      - remote-cluster-resources-test-2
+      - remote-cluster-resources-test-x
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift-specific resources
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+
+  - debug: msg="Turn off cluster wide access and set our discovery selectors to [istio-system, remote-cluster-resources-test-1]"
+  - include_tasks: ../common/set_discovery_selectors_to_list.yml
+    vars:
+      new_cluster_wide_access: false
+      discovery_selectors:
+      - matchLabels:
+          kubernetes.io/metadata.name: "{{ istio.control_plane_namespace}}"
+      - matchLabels:
+          kubernetes.io/metadata.name: "remote-cluster-resources-test-1"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+  - include_tasks: ../asserts/accessible_namespaces_contains.yml
+    vars:
+      namespace_list:
+      - "{{ istio.control_plane_namespace }}"
+      - 'remote-cluster-resources-test-1'
+  - assert:
+      that:
+      - kiali_configmap.deployment.cluster_wide_access == False
+
+  - debug: msg="assert that we have roles since we have NOT been given cluster wide access"
+  - include_tasks: ../asserts/roles-test/rw_role_asserts.yml
+    vars:
+      role_namespaces_to_test:
+      - "{{ istio.control_plane_namespace }}"
+      - remote-cluster-resources-test-1
+  - include_tasks: ../asserts/roles-test/none_clusterrole_asserts.yml
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift-specific resources
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+
+  - debug: msg="We have discovery selectors and CWA=false. Now let's set CWA=true and see the roles get removed and cluster roles added"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'deployment': {'cluster_wide_access': True }}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  - include_tasks: ../asserts/roles-test/rw_clusterrole_asserts.yml
+  - include_tasks: ../asserts/roles-test/none_role_asserts.yml
+    vars:
+      role_namespaces_to_test:
+      - "{{ istio.control_plane_namespace }}"
+      - remote-cluster-resources-test-1
+      - remote-cluster-resources-test-2
+      - remote-cluster-resources-test-x
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift-specific resources
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+
+  - debug: msg="We have discovery selectors and CWA=true. Now let's set CWA back to false and see the roles get added and cluster roles removed"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'deployment': {'cluster_wide_access': False }}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  - include_tasks: ../asserts/roles-test/rw_role_asserts.yml
+    vars:
+      role_namespaces_to_test:
+      - "{{ istio.control_plane_namespace }}"
+      - remote-cluster-resources-test-1
+  - include_tasks: ../asserts/roles-test/none_clusterrole_asserts.yml
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift-specific resources
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+
+  - debug: msg="remove discovery selectors but keep CWA=true and see that the roles have been removed and we are back to using cluster-wide-access and clusterroles"
+  - include_tasks: ../common/set_discovery_selectors_to_all.yml
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+  - include_tasks: ../asserts/accessible_namespaces_contains.yml
+    vars:
+      namespace_list: []
+
+  - debug: msg="test to make sure we are back to cluster-wide-access is True"
+  - assert:
+      that:
+      - kiali_configmap.deployment.cluster_wide_access == True
+
+  - include_tasks: ../asserts/roles-test/rw_clusterrole_asserts.yml
+  - include_tasks: ../asserts/roles-test/none_role_asserts.yml
+    vars:
+      role_namespaces_to_test:
+      - "{{ istio.control_plane_namespace }}"
+      - remote-cluster-resources-test-1
+      - remote-cluster-resources-test-2
+      - remote-cluster-resources-test-x
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift-specific resources
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0

--- a/molecule/remote-cluster-resources-test/converge.yml
+++ b/molecule/remote-cluster-resources-test/converge.yml
@@ -56,9 +56,9 @@
       - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
       - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
       - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
-      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
-      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
-      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
 
   # SET discovery selectors=[istio-system, remote-cluster-resources-test-1, remote-cluster-resources-test-x]
   - debug: msg="change accessible namespaces to a fixed list of namespaces but keep cluster-wide-access (set to True)"
@@ -106,9 +106,9 @@
       - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
       - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
       - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
-      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
-      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
-      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
 
   - debug: msg="Turn off cluster wide access and set our discovery selectors to [istio-system, remote-cluster-resources-test-1]"
   - include_tasks: ../common/set_discovery_selectors_to_list.yml
@@ -149,9 +149,9 @@
       - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
       - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
       - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
-      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
-      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
-      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
 
   - debug: msg="We have discovery selectors and CWA=false. Now let's set CWA=true and see the roles get removed and cluster roles added"
   - include_tasks: ../common/set_kiali_cr.yml
@@ -180,9 +180,9 @@
       - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
       - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
       - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
-      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
-      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
-      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
 
   - debug: msg="We have discovery selectors and CWA=true. Now let's set CWA back to false and see the roles get added and cluster roles removed"
   - include_tasks: ../common/set_kiali_cr.yml
@@ -209,9 +209,9 @@
       - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
       - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
       - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
-      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
-      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
-      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
 
   - debug: msg="remove discovery selectors but keep CWA=true and see that the roles have been removed and we are back to using cluster-wide-access and clusterroles"
   - include_tasks: ../common/set_discovery_selectors_to_all.yml
@@ -246,6 +246,6 @@
       - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
       - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
       - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
-      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector) | length == 0
-      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector) | length == 0
-      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0

--- a/molecule/remote-cluster-resources-test/converge.yml
+++ b/molecule/remote-cluster-resources-test/converge.yml
@@ -249,3 +249,47 @@
       - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
       - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
       - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
+
+  - debug: msg="Change auth strategy to openshift to confirm OAuthClient is created"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'strategy': 'openshift', 'openshift': {'kiali_route_url': 'http://test-kiali-route' }}}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift ConsoleLink, but should have OpenShift OAuthClient resource
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 1
+
+  - debug: msg="Change auth strategy back to anonymous to see OAuthClient resource gets removed"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'strategy': 'anonymous', 'openshift': {'kiali_route_url': '' }}}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  # there should be no deployment, pod, service, ingress/route, or OpenShift-specific resources
+  - name: Make sure we only have the resources that are expected
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0

--- a/molecule/remote-cluster-resources-test/converge.yml
+++ b/molecule/remote-cluster-resources-test/converge.yml
@@ -253,7 +253,7 @@
   - debug: msg="Change auth strategy to openshift to confirm OAuthClient is created"
   - include_tasks: ../common/set_kiali_cr.yml
     vars:
-      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'strategy': 'openshift', 'openshift': {'kiali_route_url': 'http://test-kiali-route' }}}}, recursive=True) }}"
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'strategy': 'openshift', 'openshift': {'redirect_uris': ['http://one-redirect-uri', 'http://two-redirect-uri'] }}}}, recursive=True) }}"
   - include_tasks: ../common/wait_for_kiali_cr_changes.yml
   - include_tasks: ../common/tasks.yml
 
@@ -272,10 +272,19 @@
       - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
       - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 1
 
+  - name: Make sure the OAuthClient has the correct redirectURIs defined
+    vars:
+      oauthclient: "{{ query('k8s', kind='OAuthClient', api_version=apiOAut, label_selector=querySelector)[0] }}"
+    assert:
+      that:
+      - oauthclient.redirectURIs | length == 2
+      - oauthclient.redirectURIs[0] == 'http://one-redirect-uri'
+      - oauthclient.redirectURIs[1] == 'http://two-redirect-uri'
+
   - debug: msg="Change auth strategy back to anonymous to see OAuthClient resource gets removed"
   - include_tasks: ../common/set_kiali_cr.yml
     vars:
-      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'strategy': 'anonymous', 'openshift': {'kiali_route_url': '' }}}}, recursive=True) }}"
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'strategy': 'anonymous', 'openshift': {'redirect_uris': [] }}}}, recursive=True) }}"
   - include_tasks: ../common/wait_for_kiali_cr_changes.yml
   - include_tasks: ../common/tasks.yml
 

--- a/molecule/remote-cluster-resources-test/destroy-remote-cluster-resources-test.yml
+++ b/molecule/remote-cluster-resources-test/destroy-remote-cluster-resources-test.yml
@@ -1,0 +1,13 @@
+- name: Destroy
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+- name: Include the base destroy play to destroy the Kiali CR and operator
+  import_playbook: ../default/destroy.yml
+
+- name: Delete the test namespaces
+  import_playbook: ./process-namespaces.yml
+  vars:
+    state: absent

--- a/molecule/remote-cluster-resources-test/kiali-cr.yaml
+++ b/molecule/remote-cluster-resources-test/kiali-cr.yaml
@@ -1,0 +1,12 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+spec:
+  version: {{ kiali.spec_version }}
+  auth:
+    strategy: {{ kiali.auth_strategy }}
+  deployment:
+    namespace: {{ kiali.install_namespace }}
+    cluster_wide_access: {{ kiali.cluster_wide_access|bool }}
+    remote_cluster_resources_only: true

--- a/molecule/remote-cluster-resources-test/molecule.yml
+++ b/molecule/remote-cluster-resources-test/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callbacks_enabled: junit
+  playbooks:
+    destroy: ./destroy-remote-cluster-resources-test.yml
+    prepare: ./prepare-remote-cluster-resources-test.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/remote-cluster-resources-test/kiali-cr.yaml"
+        cr_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR must go in control plane namespace
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          spec_version: "{{ lookup('env', 'MOLECULE_KIALI_CR_SPEC_VERSION') | default('default', True) }}"
+          install_namespace: istio-system
+          cluster_wide_access: true
+          auth_strategy: anonymous
+          operator_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}" # if external operator, assume operator is in OLM location
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: kiali-operator
+          operator_cluster_role_creator: "true"
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+scenario:
+  name: remote-cluster-resources-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/molecule/remote-cluster-resources-test/prepare-remote-cluster-resources-test.yml
+++ b/molecule/remote-cluster-resources-test/prepare-remote-cluster-resources-test.yml
@@ -1,0 +1,15 @@
+- name: Prepare
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+- name: Create the test namespaces
+  import_playbook: ./process-namespaces.yml
+  vars:
+    state: present
+
+- name: Include the base prepare play to create the first kiali CR
+  import_playbook: ../default/prepare.yml
+  vars:
+    wait_for_kiali_pod_after_prepare: false

--- a/molecule/remote-cluster-resources-test/process-namespaces.yml
+++ b/molecule/remote-cluster-resources-test/process-namespaces.yml
@@ -1,0 +1,36 @@
+- name: "Process Test Namespaces [state={{ state }}]"
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+  tasks:
+  - k8s:
+      state: "{{ state }}"
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: remote-cluster-resources-test-1
+          labels:
+            discoverySelectorLabel1: test
+            test: kiali
+  - k8s:
+      state: "{{ state }}"
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: remote-cluster-resources-test-2
+          labels:
+            discoverySelectorLabel2: matchme
+            test: kiali
+  - k8s:
+      state: "{{ state }}"
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: remote-cluster-resources-test-x
+          labels:
+            test: kiali

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -87,6 +87,7 @@ kiali_defaults:
     pod_annotations: {}
     pod_labels: {}
     priority_class_name: ""
+    remote_cluster_resources_only: false
     replicas: 1
     #resources:
     secret_name: "kiali"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -35,7 +35,7 @@ kiali_defaults:
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
     openshift:
-      #kiali_route_url:
+      #redirect_uris:
       #token_inactivity_timeout:
       #token_max_age:
     strategy: ""

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -35,6 +35,7 @@ kiali_defaults:
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
     openshift:
+      #kiali_route_url:
       #token_inactivity_timeout:
       #token_max_age:
     strategy: ""

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -21,7 +21,7 @@
     role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
     process_resource_templates:
     - "templates/kubernetes/serviceaccount.yaml"
-    - "{{ 'templates/kubernetes/configmap.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "templates/kubernetes/configmap.yaml"
     - "templates/kubernetes/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
     - "templates/kubernetes/rolebinding.yaml"
     - "{{ 'templates/kubernetes/deployment.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -21,13 +21,13 @@
     role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
     process_resource_templates:
     - "templates/kubernetes/serviceaccount.yaml"
-    - "templates/kubernetes/configmap.yaml"
+    - "{{ 'templates/kubernetes/configmap.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
     - "templates/kubernetes/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
     - "templates/kubernetes/rolebinding.yaml"
-    - "templates/kubernetes/deployment.yaml"
-    - "templates/kubernetes/service.yaml"
-    - "{{ 'templates/kubernetes/hpa.yaml' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"
-    - "{{ 'templates/kubernetes/ingress.yaml' if kiali_vars.deployment.ingress.enabled|bool == True else '' }}"
+    - "{{ 'templates/kubernetes/deployment.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/kubernetes/service.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/kubernetes/hpa.yaml' if ((kiali_vars.deployment.hpa.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/kubernetes/ingress.yaml' if ((kiali_vars.deployment.ingress.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
   when:
   - is_k8s == True
 

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -132,6 +132,7 @@
   fail:
     msg: "The operator is forbidden from installing Kiali in a namespace [{{ kiali_vars.deployment.namespace }}] that is different from the namespace where the CR was created [{{ current_cr.metadata.namespace }}]"
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.deployment.namespace != current_cr.metadata.namespace
   - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
 
@@ -185,6 +186,7 @@
   fail:
     msg: "The operator is forbidden from accepting a Kiali CR that defines an ad hoc Kiali image [{{ kiali_vars.deployment.image_name }}{{ '@' + kiali_vars.deployment.image_digest if kiali_vars.deployment.image_digest != '' else '' }}:{{ kiali_vars.deployment.image_version }}]. Remove spec.deployment.image_name, spec.deployment.image_version, and spec.deployment.image_digest from the Kiali CR."
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.deployment.image_name != "" or kiali_vars.deployment.image_version != "" or kiali_vars.deployment.image_digest != ""
   - lookup('env', 'ALLOW_AD_HOC_KIALI_IMAGE') | default('false', True) != "true"
 
@@ -381,6 +383,7 @@
 - fail:
     msg: "Could not determine what the image version should be. Set deployment.image_version to a valid value"
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.deployment.image_version == "" or kiali_vars.deployment.image_version == "unknown"
 
 - name: Determine version_label based on image_version
@@ -516,12 +519,13 @@
   fail:
     msg: "Signing key must be 16, 24 or 32 byte length"
   when:
-    - kiali_vars.auth.strategy != 'anonymous'
-    - kiali_vars.login_token.signing_key != ""
-    - not(kiali_vars.login_token.signing_key | regex_search('secret:.+:.+'))
-    - kiali_vars.login_token.signing_key | length != 16
-    - kiali_vars.login_token.signing_key | length != 24
-    - kiali_vars.login_token.signing_key | length != 32
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.auth.strategy != 'anonymous'
+  - kiali_vars.login_token.signing_key != ""
+  - not(kiali_vars.login_token.signing_key | regex_search('secret:.+:.+'))
+  - kiali_vars.login_token.signing_key | length != 16
+  - kiali_vars.login_token.signing_key | length != 24
+  - kiali_vars.login_token.signing_key | length != 32
 
 # If the signing key is empty string, we need to ensure a signing key secret exists. If one does not exist, we need to generate one.
 # Note that to avoid granting to the operator the very powerful permission to CRUD all secrets in all namespaces, we always generate
@@ -538,6 +542,7 @@
     name: kiali-signing-key
   register: signing_key_secret_raw
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.login_token.signing_key == ""
 
 - name: Create kiali-signing-key secret to store a random signing key if a secret does not already exist and we need one
@@ -554,6 +559,7 @@
       data:
         key: "{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') | b64encode }}"
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.login_token.signing_key == ""
   - signing_key_secret_raw is defined
   - signing_key_secret_raw.resources is defined
@@ -574,12 +580,14 @@
         labels:
           {{ kiali_instance_label_name }}: {{ kiali_instance_label_value }}
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.login_token.signing_key == ""
 
 - name: Point signing key to the generated secret
   set_fact:
     kiali_vars: "{{ kiali_vars | combine({'login_token': {'signing_key': 'secret:kiali-signing-key:key'}}, recursive=True) }}"
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.login_token.signing_key == ""
 
 # Some credentials in the config can be overridden by secrets that are to be mounted on the file system.
@@ -672,6 +680,7 @@
   set_fact:
     kiali_deployment_remote_cluster_secret_volumes: "{{ kiali_deployment_remote_cluster_secret_volumes | combine({ item.metadata.annotations['kiali.io/cluster']|default(item.metadata.name): {'secret_name': item.metadata.name }}) }}"
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.clustering.autodetect_secrets.enabled
 
 - name: Prepare the manually declared remote clusters
@@ -679,6 +688,7 @@
   set_fact:
     kiali_deployment_remote_cluster_secret_volumes: "{{ kiali_deployment_remote_cluster_secret_volumes | combine(({ item.name: {'secret_name': item.secret_name }}) if (item.secret_name is defined and item.secret_name | length > 0) else {}) }}"
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.clustering.clusters | length > 0
 
 # The following few tasks read the current Kiali configmap (if one exists) in order to find out how Kiali is currently configured.
@@ -880,6 +890,7 @@
     state: "present"
     definition: "{{ updated_deployment }}"
   when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool== False
   - deployment_is_new == False
   - processed_resources_dict is defined
   - processed_resources_dict[keyname] is defined

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -109,7 +109,7 @@
   when:
   - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
 
-# Never allow the deployment.instance_name or deployment.namespace to change to avoid leaking resources - to uninstall resources you must delete the Kiali CR
+# Never allow the deployment.instance_name, deployment.namespace, or deployment.remote_cluster_resources_only to change to avoid leaking resources - to uninstall resources you must delete the Kiali CR
 - name: Ensure the deployment.instance_name has not changed
   fail:
     msg: "The deployment.instance_name cannot be changed to a different value. It was [{{ current_cr.status.deployment.instanceName }}] but is now [{{ kiali_vars.deployment.instance_name }}]. In order to install Kiali with a different deployment.instance_name, please uninstall Kiali first."
@@ -127,6 +127,15 @@
   - current_cr.status.deployment is defined
   - current_cr.status.deployment.namespace is defined
   - current_cr.status.deployment.namespace != kiali_vars.deployment.namespace
+
+- name: Ensure the deployment.remote_cluster_resources_only has not changed
+  fail:
+    msg: "The deployment.remote_cluster_resources_only cannot be changed to a different value. It was [{{ current_cr.status.deployment.remoteClusterResourcesOnly }}] but is now [{{ kiali_vars.deployment.remote_cluster_resources_only }}]. In order to change to a different deployment.remote_cluster_resources_only value, please delete the Kiali CR first."
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment.remoteClusterResourcesOnly is defined
+  - current_cr.status.deployment.remoteClusterResourcesOnly is defined
+  - current_cr.status.deployment.remoteClusterResourcesOnly != kiali_vars.deployment.remote_cluster_resources_only
 
 - name: Only allow ad-hoc kiali namespace when appropriate
   fail:
@@ -164,6 +173,7 @@
       deployment:
         instanceName: "{{ kiali_vars.deployment.instance_name }}"
         namespace: "{{ kiali_vars.deployment.namespace }}"
+        remoteClusterResourcesOnly: "{{ kiali_vars.deployment.remote_cluster_resources_only }}"
 
 - name: Validate web_schema configuration
   fail:

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -132,7 +132,6 @@
   fail:
     msg: "The operator is forbidden from installing Kiali in a namespace [{{ kiali_vars.deployment.namespace }}] that is different from the namespace where the CR was created [{{ current_cr.metadata.namespace }}]"
   when:
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.deployment.namespace != current_cr.metadata.namespace
   - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
 

--- a/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -1,23 +1,8 @@
 # All of this is ultimately to obtain the kiali_route_url
 
-- name: Check if kiali_route_url is explicitly configured
-  set_fact:
-    kiali_route_url: "{{ kiali_vars.auth.openshift.kiali_route_url }}"
-  when:
-  - kiali_vars.auth.openshift.kiali_route_url is defined
-  - kiali_vars.auth.openshift.kiali_route_url != ""
-
-- name: Fail if creating remote cluster resources with auth strategy of openshift, but the Kiali Route URL is not defined
-  fail:
-    msg: "The root URL of the Kiali Server route is not specified via auth.openshift.kiali_route_url; this is required when creating remote cluster resources with auth.strategy of openshift."
-  when:
-  - kiali_route_url is not defined
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == True
-  - kiali_vars.auth.strategy == 'openshift'
-
-# We need to auto-discover the Kiali Route URL because the OAuthClient and ConsoleLink resources need it.
-# Note that we perform this auto-discovery only if we expect a Kiali Route to exist on the local cluster,
-# (that is to say, we only perform this auto-discovery if remote_cluster_resources_only is False).
+# We need to auto-discover the Kiali Route URL because the OAuthClient (for redirect URIs) and ConsoleLink resources need it.
+# Note that the user can override redirect URIs in auth.openshift.redirect_uris so this route URL will
+# be ignored in the OAuthClient template in that case.
 
 - name: Get the Kiali Route on OpenShift, which may require waiting some time for it to startup
   k8s_info:
@@ -37,21 +22,18 @@
   delay: 10
   when:
   - is_openshift == True
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
 
 - name: Set Kiali TLS Termination from OpenShift route
   set_fact:
     kiali_route_tls_termination: "{{ kiali_route_raw['resources'][0]['spec']['tls']['termination'] }}"
   when:
   - is_openshift == True
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
 
 - name: Detect HTTP Kiali OpenShift route protocol
   set_fact:
     kiali_route_protocol: "http"
   when:
   - is_openshift == True
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_route_tls_termination == ""
 
 - name: Detect HTTPS Kiali OpenShift route protocol
@@ -59,7 +41,6 @@
     kiali_route_protocol: "https"
   when:
   - is_openshift == True
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_route_tls_termination != ""
 
 - name: Create URL for Kiali OpenShift route
@@ -67,4 +48,3 @@
     kiali_route_url: "{{ kiali_route_protocol }}://{{ kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] }}"
   when:
   - is_openshift == True
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False

--- a/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -1,8 +1,25 @@
 # All of this is ultimately to obtain the kiali_route_url
 
-# Give some time for the route to come up
+- name: Check if kiali_route_url is explicitly configured
+  set_fact:
+    kiali_route_url: "{{ kiali_vars.auth.openshift.kiali_route_url }}"
+  when:
+  - kiali_vars.auth.openshift.kiali_route_url is defined
+  - kiali_vars.auth.openshift.kiali_route_url != ""
 
-- name: Detect Kiali route on OpenShift
+- name: Fail if creating remote cluster resources with auth strategy of openshift, but the Kiali Route URL is not defined
+  fail:
+    msg: "The root URL of the Kiali Server route is not specified via auth.openshift.kiali_route_url; this is required when creating remote cluster resources with auth.strategy of openshift."
+  when:
+  - kiali_route_url is not defined
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == True
+  - kiali_vars.auth.strategy == 'openshift'
+
+# We need to auto-discover the Kiali Route URL because the OAuthClient and ConsoleLink resources need it.
+# Note that we perform this auto-discovery only if we expect a Kiali Route to exist on the local cluster,
+# (that is to say, we only perform this auto-discovery if remote_cluster_resources_only is False).
+
+- name: Get the Kiali Route on OpenShift, which may require waiting some time for it to startup
   k8s_info:
     api_version: route.openshift.io/v1
     kind: Route
@@ -20,18 +37,21 @@
   delay: 10
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
 
 - name: Set Kiali TLS Termination from OpenShift route
   set_fact:
     kiali_route_tls_termination: "{{ kiali_route_raw['resources'][0]['spec']['tls']['termination'] }}"
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
 
 - name: Detect HTTP Kiali OpenShift route protocol
   set_fact:
     kiali_route_protocol: "http"
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_route_tls_termination == ""
 
 - name: Detect HTTPS Kiali OpenShift route protocol
@@ -39,6 +59,7 @@
     kiali_route_protocol: "https"
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_route_tls_termination != ""
 
 - name: Create URL for Kiali OpenShift route
@@ -46,3 +67,4 @@
     kiali_route_url: "{{ kiali_route_protocol }}://{{ kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] }}"
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -31,16 +31,16 @@
     role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
     process_resource_templates:
     - "templates/openshift/serviceaccount.yaml"
-    - "templates/openshift/configmap.yaml"
-    - "templates/openshift/cabundle.yaml"
+    - "{{ 'templates/openshift/configmap.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/openshift/cabundle.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
     - "templates/openshift/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
     - "templates/openshift/rolebinding.yaml"
     - "{{ 'templates/openshift/clusterrole-oauth.yaml' if kiali_vars.auth.strategy == 'openshift' else '' }}"
     - "{{ 'templates/openshift/clusterrolebinding-oauth.yaml' if kiali_vars.auth.strategy == 'openshift' else '' }}"
-    - "templates/openshift/deployment.yaml"
-    - "templates/openshift/service.yaml"
-    - "{{ 'templates/openshift/hpa.yaml' if kiali_vars.deployment.hpa.spec | length > 0 else '' }}"
-    - "{{ 'templates/openshift/route.yaml' if kiali_vars.deployment.ingress.enabled|bool == True else '' }}"
+    - "{{ 'templates/openshift/deployment.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/openshift/service.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/openshift/hpa.yaml' if ((kiali_vars.deployment.hpa.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/openshift/route.yaml' if ((kiali_vars.deployment.ingress.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
   when:
   - is_openshift == True
 
@@ -83,12 +83,14 @@
   include_tasks: openshift/os-get-kiali-route-url.yml
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
 
 - name: Process OpenShift OAuth client
   k8s:
     definition: "{{ lookup('template', 'templates/openshift/oauth.yaml') }}"
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.auth.strategy == "openshift"
 
 - name: Delete all ConsoleLinks for namespaces that are no longer accessible
@@ -116,5 +118,6 @@
     namespaces: "{{ discovery_selector_namespaces }}"
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.deployment.cluster_wide_access == False
   - openshift_version is version('4.3', '>=')

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -83,14 +83,12 @@
   include_tasks: openshift/os-get-kiali-route-url.yml
   when:
   - is_openshift == True
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
 
 - name: Process OpenShift OAuth client
   k8s:
     definition: "{{ lookup('template', 'templates/openshift/oauth.yaml') }}"
   when:
   - is_openshift == True
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
   - kiali_vars.auth.strategy == "openshift"
 
 - name: Delete all ConsoleLinks for namespaces that are no longer accessible

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -97,7 +97,7 @@
   fail:
     msg: "Redirect URIs for the Kiali Server OAuthClient are not specified via auth.openshift.redirect_uris; this is required when creating remote cluster resources with auth.strategy of openshift."
   when:
-  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == True
   - kiali_vars.auth.strategy == 'openshift'
   - kiali_vars.auth.openshift.redirect_uris | default([]) | length == 0
 

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -90,10 +90,30 @@
   - is_openshift == True
   - kiali_vars.auth.strategy != "openshift"
 
+# For now, when creating remote cluster resources only, we are going to assume there is no way for us to determine what the redirect URIs are
+# going to be other than having the user explicitly configure them. So fail immediately if the user did not tell us what redirect URI[s] to use.
+# Note that this only comes into play when auth.strategy is "openshift".
+- name: Fail if creating remote cluster resources with auth strategy of openshift, but the Kiali redirect URIs are not defined
+  fail:
+    msg: "Redirect URIs for the Kiali Server OAuthClient are not specified via auth.openshift.redirect_uris; this is required when creating remote cluster resources with auth.strategy of openshift."
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.auth.strategy == 'openshift'
+  - kiali_vars.auth.openshift.redirect_uris | default([]) | length == 0
+
+# We only need to auto-discover the Kiali route if (a) we know it will exist and (b) we know we need it.
+# We know it will exist if we are creating the Kiali Server itself (i.e. remote_cluster_resources_only == False).
+# We know we need it for ConsoleLinks (and those are only created when we are creating the Kiali Server itself).
+# We know we need it for OAuthClient, too. That is also created when we are creating the Kiali Server itself. But it is also
+# created when creating only remote cluster resources - however, in that case, we are going to require the user to tell us
+# what redirect URIs to use (see the above fail task to ensure the user does that).
+# All of this is to say: we only need to auto-discover the route when we are creating the Kiali Server itself (we do not
+# auto-discover the route when we are creating only the remote cluster resources).
 - name: Get the Kiali Route URL
   include_tasks: openshift/os-get-kiali-route-url.yml
   when:
   - is_openshift == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
 
 - name: Process OpenShift OAuth client
   k8s:

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -31,7 +31,7 @@
     role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
     process_resource_templates:
     - "templates/openshift/serviceaccount.yaml"
-    - "{{ 'templates/openshift/configmap.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "templates/openshift/configmap.yaml"
     - "{{ 'templates/openshift/cabundle.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
     - "templates/openshift/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
     - "templates/openshift/rolebinding.yaml"

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -79,6 +79,17 @@
   when:
   - is_openshift == True
 
+- name: Delete OAuthClient on OpenShift if not using auth.strategy openshift
+  k8s:
+    state: absent
+    api_version: "oauth.openshift.io/v1"
+    kind: "OAuthClient"
+    label_selectors:
+    - "app.kubernetes.io/instance = {{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.auth.strategy != "openshift"
+
 - name: Get the Kiali Route URL
   include_tasks: openshift/os-get-kiali-route-url.yml
   when:

--- a/roles/default/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/oauth.yaml
@@ -4,9 +4,15 @@ metadata:
   name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}
   labels: {{ kiali_resource_metadata_labels }}
 redirectURIs:
-  - {{ kiali_route_url }}/api/auth/callback
+{% if kiali_vars.auth.openshift.redirect_uris | default([]) | length > 0 %}
+{% for uri in kiali_vars.auth.openshift.redirect_uris %}
+- "{{ uri }}"
+{% endfor %}
+{% else %}
+- {{ kiali_route_url }}/api/auth/callback
 {% if kiali_vars.server.web_port | length > 0 %}
-  - {{ kiali_route_url }}:{{ kiali_vars.server.web_port }}/api/auth/callback
+- {{ kiali_route_url }}:{{ kiali_vars.server.web_port }}/api/auth/callback
+{% endif %}
 {% endif %}
 grantMethod: auto
 {% if kiali_vars.auth.openshift.token_inactivity_timeout is defined %}

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -131,7 +131,7 @@
   - namespaces_with_kiali_roles is defined
   - namespaces_with_kiali_roles | length > 0
 
-- name: Remote Kiali label from namespaces that are currently accessible
+- name: Remove Kiali label from namespaces that are currently accessible
   ignore_errors: yes
   k8s:
     state: patched
@@ -173,7 +173,7 @@
 - name: Unlabel the signing key secret if it exists to indicate this Kiali instance no longer uses it
   ignore_errors: yes
   k8s:
-    state: present
+    state: patched
     definition: |
       apiVersion: v1
       kind: Secret


### PR DESCRIPTION
This adds a new deployment flag in Kiali CR:

```yaml
spec:
  deployment:
    remote_cluster_resources_only: false
```

The default is `false`, which means it all behaves like before. But when set to `true`, only the remote cluster resources are created by the operator (only SA, role/bindings, configmap - no secrets, deployment/pod, ingress/route, or service resources are created; also, no OpenShift specific resources (ConsoleLink, OAuthClient) are created).

The ConfigMap, while not needed by the server when accessing the remote cluster, it is needed by the operator for future reconciliation of the CR, hence that is why the ConfigMap is created along with the SA and roles/bindings.

This supports the typical `deployment.discovery_selectors.default` and `deployment.cluster_wide_access` behavior - they determine which roles/bindings are created - if CWA is false the accessible namespaces defined by discovery selectors will get Role / RoleBindings created. If CWA is true, the cluster role/binding pair are created. This is no different than when deploying the server normally (it's all the same code).


fixes: https://github.com/kiali/kiali/issues/7861