### PR TITLE
add 2.1.0 to catalogs; when creating new versions, update the catalog templates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,10 +251,11 @@ jobs:
     - name: Create or update version branch      
       run: git push origin $(git rev-parse HEAD):refs/heads/$BRANCH_VERSION
 
-    - name: Configure Operator SDK
+    - name: Configure Operator SDK and OPM
       if: ${{ needs.initialize.outputs.release_type == 'minor' || needs.initialize.outputs.release_type == 'major' }}
       run: |
         make get-operator-sdk
+        make get-opm
 
     - name: Create a PR to prepare for next version
       env:

--- a/manifests/kiali-community/catalog-templates/v4.12.yaml
+++ b/manifests/kiali-community/catalog-templates/v4.12.yaml
@@ -1,375 +1,381 @@
 ---
 entries:
-- defaultChannel: stable
-  icon:
-    base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
-  name: kiali
-  schema: olm.package
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: alpha
-  package: kiali
-  schema: olm.channel
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: stable
-  package: kiali
-  schema: olm.channel
-- image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
-  schema: olm.bundle
+  - defaultChannel: stable
+    icon:
+      base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+    name: kiali
+    schema: olm.package
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: alpha
+    package: kiali
+    schema: olm.channel
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: stable
+    package: kiali
+    schema: olm.channel
+  - image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
+    schema: olm.bundle
 schema: olm.template.basic

--- a/manifests/kiali-community/catalog-templates/v4.13.yaml
+++ b/manifests/kiali-community/catalog-templates/v4.13.yaml
@@ -1,375 +1,381 @@
 ---
 entries:
-- defaultChannel: stable
-  icon:
-    base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
-  name: kiali
-  schema: olm.package
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: alpha
-  package: kiali
-  schema: olm.channel
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: stable
-  package: kiali
-  schema: olm.channel
-- image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
-  schema: olm.bundle
+  - defaultChannel: stable
+    icon:
+      base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+    name: kiali
+    schema: olm.package
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: alpha
+    package: kiali
+    schema: olm.channel
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: stable
+    package: kiali
+    schema: olm.channel
+  - image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
+    schema: olm.bundle
 schema: olm.template.basic

--- a/manifests/kiali-community/catalog-templates/v4.14.yaml
+++ b/manifests/kiali-community/catalog-templates/v4.14.yaml
@@ -1,375 +1,381 @@
 ---
 entries:
-- defaultChannel: stable
-  icon:
-    base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
-  name: kiali
-  schema: olm.package
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: alpha
-  package: kiali
-  schema: olm.channel
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: stable
-  package: kiali
-  schema: olm.channel
-- image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
-  schema: olm.bundle
+  - defaultChannel: stable
+    icon:
+      base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+    name: kiali
+    schema: olm.package
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: alpha
+    package: kiali
+    schema: olm.channel
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: stable
+    package: kiali
+    schema: olm.channel
+  - image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
+    schema: olm.bundle
 schema: olm.template.basic

--- a/manifests/kiali-community/catalog-templates/v4.15.yaml
+++ b/manifests/kiali-community/catalog-templates/v4.15.yaml
@@ -1,375 +1,381 @@
 ---
 entries:
-- defaultChannel: stable
-  icon:
-    base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
-  name: kiali
-  schema: olm.package
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: alpha
-  package: kiali
-  schema: olm.channel
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: stable
-  package: kiali
-  schema: olm.channel
-- image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
-  schema: olm.bundle
+  - defaultChannel: stable
+    icon:
+      base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+    name: kiali
+    schema: olm.package
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: alpha
+    package: kiali
+    schema: olm.channel
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: stable
+    package: kiali
+    schema: olm.channel
+  - image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
+    schema: olm.bundle
 schema: olm.template.basic

--- a/manifests/kiali-community/catalog-templates/v4.16.yaml
+++ b/manifests/kiali-community/catalog-templates/v4.16.yaml
@@ -1,375 +1,381 @@
 ---
 entries:
-- defaultChannel: stable
-  icon:
-    base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
-  name: kiali
-  schema: olm.package
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: alpha
-  package: kiali
-  schema: olm.channel
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: stable
-  package: kiali
-  schema: olm.channel
-- image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
-  schema: olm.bundle
+  - defaultChannel: stable
+    icon:
+      base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+    name: kiali
+    schema: olm.package
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: alpha
+    package: kiali
+    schema: olm.channel
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: stable
+    package: kiali
+    schema: olm.channel
+  - image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
+    schema: olm.bundle
 schema: olm.template.basic

--- a/manifests/kiali-community/catalog-templates/v4.17.yaml
+++ b/manifests/kiali-community/catalog-templates/v4.17.yaml
@@ -1,375 +1,381 @@
 ---
 entries:
-- defaultChannel: stable
-  icon:
-    base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
-  name: kiali
-  schema: olm.package
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: alpha
-  package: kiali
-  schema: olm.channel
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: stable
-  package: kiali
-  schema: olm.channel
-- image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
-  schema: olm.bundle
+  - defaultChannel: stable
+    icon:
+      base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+    name: kiali
+    schema: olm.package
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: alpha
+    package: kiali
+    schema: olm.channel
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: stable
+    package: kiali
+    schema: olm.channel
+  - image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
+    schema: olm.bundle
 schema: olm.template.basic

--- a/manifests/kiali-community/catalog-templates/v4.18.yaml
+++ b/manifests/kiali-community/catalog-templates/v4.18.yaml
@@ -1,375 +1,381 @@
 ---
 entries:
-- defaultChannel: stable
-  icon:
-    base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
-    mediatype: image/svg+xml
-  name: kiali
-  schema: olm.package
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: alpha
-  package: kiali
-  schema: olm.channel
-- entries:
-  - name: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.47.0'
-  - name: kiali-operator.v1.48.0
-    replaces: kiali-operator.v1.47.0
-    skipRange: '>=1.0.0 <1.48.0'
-  - name: kiali-operator.v1.49.0
-    replaces: kiali-operator.v1.48.0
-    skipRange: '>=1.0.0 <1.49.0'
-  - name: kiali-operator.v1.50.0
-    replaces: kiali-operator.v1.49.0
-    skipRange: '>=1.0.0 <1.50.0'
-  - name: kiali-operator.v1.51.0
-    replaces: kiali-operator.v1.50.0
-    skipRange: '>=1.0.0 <1.51.0'
-  - name: kiali-operator.v1.52.0
-    replaces: kiali-operator.v1.51.0
-    skipRange: '>=1.0.0 <1.52.0'
-  - name: kiali-operator.v1.53.0
-    replaces: kiali-operator.v1.52.0
-    skipRange: '>=1.0.0 <1.53.0'
-  - name: kiali-operator.v1.54.0
-    replaces: kiali-operator.v1.53.0
-    skipRange: '>=1.0.0 <1.54.0'
-  - name: kiali-operator.v1.55.0
-    replaces: kiali-operator.v1.54.0
-    skipRange: '>=1.0.0 <1.55.0'
-  - name: kiali-operator.v1.56.0
-    replaces: kiali-operator.v1.55.0
-    skipRange: '>=1.0.0 <1.56.0'
-  - name: kiali-operator.v1.57.0
-    replaces: kiali-operator.v1.56.0
-    skipRange: '>=1.0.0 <1.57.0'
-  - name: kiali-operator.v1.58.0
-    replaces: kiali-operator.v1.57.0
-    skipRange: '>=1.0.0 <1.58.0'
-  - name: kiali-operator.v1.59.0
-    replaces: kiali-operator.v1.58.0
-    skipRange: '>=1.0.0 <1.59.0'
-  - name: kiali-operator.v1.60.0
-    replaces: kiali-operator.v1.59.0
-    skipRange: '>=1.0.0 <1.60.0'
-  - name: kiali-operator.v1.61.0
-    replaces: kiali-operator.v1.60.0
-    skipRange: '>=1.0.0 <1.61.0'
-  - name: kiali-operator.v1.62.0
-    replaces: kiali-operator.v1.61.0
-    skipRange: '>=1.0.0 <1.62.0'
-  - name: kiali-operator.v1.63.0
-    replaces: kiali-operator.v1.62.0
-    skipRange: '>=1.0.0 <1.63.0'
-  - name: kiali-operator.v1.63.1
-    replaces: kiali-operator.v1.63.0
-    skipRange: '>=1.0.0 <1.63.1'
-  - name: kiali-operator.v1.64.0
-    replaces: kiali-operator.v1.63.1
-    skipRange: '>=1.0.0 <1.64.0'
-  - name: kiali-operator.v1.65.0
-    replaces: kiali-operator.v1.64.0
-    skipRange: '>=1.0.0 <1.65.0'
-  - name: kiali-operator.v1.66.0
-    replaces: kiali-operator.v1.65.0
-    skipRange: '>=1.0.0 <1.66.0'
-  - name: kiali-operator.v1.67.0
-    replaces: kiali-operator.v1.66.0
-    skipRange: '>=1.0.0 <1.67.0'
-  - name: kiali-operator.v1.68.0
-    replaces: kiali-operator.v1.67.0
-    skipRange: '>=1.0.0 <1.68.0'
-  - name: kiali-operator.v1.69.0
-    replaces: kiali-operator.v1.68.0
-    skipRange: '>=1.0.0 <1.69.0'
-  - name: kiali-operator.v1.70.0
-    replaces: kiali-operator.v1.69.0
-    skipRange: '>=1.0.0 <1.70.0'
-  - name: kiali-operator.v1.71.0
-    replaces: kiali-operator.v1.70.0
-    skipRange: '>=1.0.0 <1.71.0'
-  - name: kiali-operator.v1.72.0
-    replaces: kiali-operator.v1.71.0
-    skipRange: '>=1.0.0 <1.72.0'
-  - name: kiali-operator.v1.73.0
-    replaces: kiali-operator.v1.72.0
-    skipRange: '>=1.0.0 <1.73.0'
-  - name: kiali-operator.v1.74.0
-    replaces: kiali-operator.v1.73.0
-    skipRange: '>=1.0.0 <1.74.0'
-  - name: kiali-operator.v1.75.0
-    replaces: kiali-operator.v1.74.0
-    skipRange: '>=1.0.0 <1.75.0'
-  - name: kiali-operator.v1.76.0
-    replaces: kiali-operator.v1.75.0
-    skipRange: '>=1.0.0 <1.76.0'
-  - name: kiali-operator.v1.77.0
-    replaces: kiali-operator.v1.76.0
-    skipRange: '>=1.0.0 <1.77.0'
-  - name: kiali-operator.v1.78.0
-    replaces: kiali-operator.v1.77.0
-    skipRange: '>=1.0.0 <1.78.0'
-  - name: kiali-operator.v1.79.0
-    replaces: kiali-operator.v1.78.0
-    skipRange: '>=1.0.0 <1.79.0'
-  - name: kiali-operator.v1.80.0
-    replaces: kiali-operator.v1.79.0
-    skipRange: '>=1.0.0 <1.80.0'
-  - name: kiali-operator.v1.81.0
-    replaces: kiali-operator.v1.80.0
-    skipRange: '>=1.0.0 <1.81.0'
-  - name: kiali-operator.v1.82.0
-    replaces: kiali-operator.v1.81.0
-    skipRange: '>=1.0.0 <1.82.0'
-  - name: kiali-operator.v1.83.0
-    replaces: kiali-operator.v1.82.0
-    skipRange: '>=1.0.0 <1.83.0'
-  - name: kiali-operator.v1.84.0
-    replaces: kiali-operator.v1.83.0
-    skipRange: '>=1.0.0 <1.84.0'
-  - name: kiali-operator.v1.85.0
-    replaces: kiali-operator.v1.84.0
-    skipRange: '>=1.0.0 <1.85.0'
-  - name: kiali-operator.v1.86.0
-    replaces: kiali-operator.v1.85.0
-    skipRange: '>=1.0.0 <1.86.0'
-  - name: kiali-operator.v1.87.0
-    replaces: kiali-operator.v1.86.0
-    skipRange: '>=1.0.0 <1.87.0'
-  - name: kiali-operator.v1.88.0
-    replaces: kiali-operator.v1.87.0
-    skipRange: '>=1.0.0 <1.88.0'
-  - name: kiali-operator.v1.89.0
-    replaces: kiali-operator.v1.88.0
-    skipRange: '>=1.0.0 <1.89.0'
-  - name: kiali-operator.v2.0.0
-    replaces: kiali-operator.v1.89.0
-    skipRange: '>=1.0.0 <2.0.0'
-  name: stable
-  package: kiali
-  schema: olm.channel
-- image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
-  schema: olm.bundle
-- image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
-  schema: olm.bundle
-- image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
-  schema: olm.bundle
+  - defaultChannel: stable
+    icon:
+      base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIyLjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAxMjgwIDEyODAiIHN0eWxlPSJlbmFibGUtYmFja2dyb3VuZDpuZXcgMCAwIDEyODAgMTI4MDsiIHhtbDpzcGFjZT0icHJlc2VydmUiPgo8c3R5bGUgdHlwZT0idGV4dC9jc3MiPgoJLnN0MHtmaWxsOiMwMTMxNDQ7fQoJLnN0MXtmaWxsOiMwMDkzREQ7fQo8L3N0eWxlPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik04MTAuOSwxODAuOWMtMjUzLjYsMC00NTkuMSwyMDUuNS00NTkuMSw0NTkuMXMyMDUuNSw0NTkuMSw0NTkuMSw0NTkuMVMxMjcwLDg5My42LDEyNzAsNjQwCgkJUzEwNjQuNSwxODAuOSw4MTAuOSwxODAuOXogTTgxMC45LDEwMjkuMmMtMjE1LDAtMzg5LjItMTc0LjMtMzg5LjItMzg5LjJjMC0yMTUsMTc0LjMtMzg5LjIsMzg5LjItMzg5LjJTMTIwMC4xLDQyNSwxMjAwLjEsNjQwCgkJUzEwMjUuOSwxMDI5LjIsODEwLjksMTAyOS4yeiIvPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTY1My4zLDI4NGMtMTM2LjQsNjAuNS0yMzEuNiwxOTcuMS0yMzEuNiwzNTZjMCwxNTguOCw5NS4yLDI5NS41LDIzMS42LDM1NmM5OC40LTg3LjEsMTYwLjQtMjE0LjMsMTYwLjQtMzU2CgkJQzgxMy43LDQ5OC4zLDc1MS42LDM3MS4xLDY1My4zLDI4NHoiLz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0zNTEuOCw2NDBjMC0xMDkuOCwzOC42LTIxMC41LDEwMi44LTI4OS41Yy0zOS42LTE4LjItODMuNi0yOC4zLTEzMC0yOC4zQzE1MC45LDMyMi4yLDEwLDQ2NC41LDEwLDY0MAoJCXMxNDAuOSwzMTcuOCwzMTQuNiwzMTcuOGM0Ni4zLDAsOTAuNC0xMC4xLDEzMC0yOC4zQzM5MC4zLDg1MC41LDM1MS44LDc0OS44LDM1MS44LDY0MHoiLz4KPC9nPgo8L3N2Zz4K
+      mediatype: image/svg+xml
+    name: kiali
+    schema: olm.package
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: alpha
+    package: kiali
+    schema: olm.channel
+  - entries:
+      - name: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.47.0'
+      - name: kiali-operator.v1.48.0
+        replaces: kiali-operator.v1.47.0
+        skipRange: '>=1.0.0 <1.48.0'
+      - name: kiali-operator.v1.49.0
+        replaces: kiali-operator.v1.48.0
+        skipRange: '>=1.0.0 <1.49.0'
+      - name: kiali-operator.v1.50.0
+        replaces: kiali-operator.v1.49.0
+        skipRange: '>=1.0.0 <1.50.0'
+      - name: kiali-operator.v1.51.0
+        replaces: kiali-operator.v1.50.0
+        skipRange: '>=1.0.0 <1.51.0'
+      - name: kiali-operator.v1.52.0
+        replaces: kiali-operator.v1.51.0
+        skipRange: '>=1.0.0 <1.52.0'
+      - name: kiali-operator.v1.53.0
+        replaces: kiali-operator.v1.52.0
+        skipRange: '>=1.0.0 <1.53.0'
+      - name: kiali-operator.v1.54.0
+        replaces: kiali-operator.v1.53.0
+        skipRange: '>=1.0.0 <1.54.0'
+      - name: kiali-operator.v1.55.0
+        replaces: kiali-operator.v1.54.0
+        skipRange: '>=1.0.0 <1.55.0'
+      - name: kiali-operator.v1.56.0
+        replaces: kiali-operator.v1.55.0
+        skipRange: '>=1.0.0 <1.56.0'
+      - name: kiali-operator.v1.57.0
+        replaces: kiali-operator.v1.56.0
+        skipRange: '>=1.0.0 <1.57.0'
+      - name: kiali-operator.v1.58.0
+        replaces: kiali-operator.v1.57.0
+        skipRange: '>=1.0.0 <1.58.0'
+      - name: kiali-operator.v1.59.0
+        replaces: kiali-operator.v1.58.0
+        skipRange: '>=1.0.0 <1.59.0'
+      - name: kiali-operator.v1.60.0
+        replaces: kiali-operator.v1.59.0
+        skipRange: '>=1.0.0 <1.60.0'
+      - name: kiali-operator.v1.61.0
+        replaces: kiali-operator.v1.60.0
+        skipRange: '>=1.0.0 <1.61.0'
+      - name: kiali-operator.v1.62.0
+        replaces: kiali-operator.v1.61.0
+        skipRange: '>=1.0.0 <1.62.0'
+      - name: kiali-operator.v1.63.0
+        replaces: kiali-operator.v1.62.0
+        skipRange: '>=1.0.0 <1.63.0'
+      - name: kiali-operator.v1.63.1
+        replaces: kiali-operator.v1.63.0
+        skipRange: '>=1.0.0 <1.63.1'
+      - name: kiali-operator.v1.64.0
+        replaces: kiali-operator.v1.63.1
+        skipRange: '>=1.0.0 <1.64.0'
+      - name: kiali-operator.v1.65.0
+        replaces: kiali-operator.v1.64.0
+        skipRange: '>=1.0.0 <1.65.0'
+      - name: kiali-operator.v1.66.0
+        replaces: kiali-operator.v1.65.0
+        skipRange: '>=1.0.0 <1.66.0'
+      - name: kiali-operator.v1.67.0
+        replaces: kiali-operator.v1.66.0
+        skipRange: '>=1.0.0 <1.67.0'
+      - name: kiali-operator.v1.68.0
+        replaces: kiali-operator.v1.67.0
+        skipRange: '>=1.0.0 <1.68.0'
+      - name: kiali-operator.v1.69.0
+        replaces: kiali-operator.v1.68.0
+        skipRange: '>=1.0.0 <1.69.0'
+      - name: kiali-operator.v1.70.0
+        replaces: kiali-operator.v1.69.0
+        skipRange: '>=1.0.0 <1.70.0'
+      - name: kiali-operator.v1.71.0
+        replaces: kiali-operator.v1.70.0
+        skipRange: '>=1.0.0 <1.71.0'
+      - name: kiali-operator.v1.72.0
+        replaces: kiali-operator.v1.71.0
+        skipRange: '>=1.0.0 <1.72.0'
+      - name: kiali-operator.v1.73.0
+        replaces: kiali-operator.v1.72.0
+        skipRange: '>=1.0.0 <1.73.0'
+      - name: kiali-operator.v1.74.0
+        replaces: kiali-operator.v1.73.0
+        skipRange: '>=1.0.0 <1.74.0'
+      - name: kiali-operator.v1.75.0
+        replaces: kiali-operator.v1.74.0
+        skipRange: '>=1.0.0 <1.75.0'
+      - name: kiali-operator.v1.76.0
+        replaces: kiali-operator.v1.75.0
+        skipRange: '>=1.0.0 <1.76.0'
+      - name: kiali-operator.v1.77.0
+        replaces: kiali-operator.v1.76.0
+        skipRange: '>=1.0.0 <1.77.0'
+      - name: kiali-operator.v1.78.0
+        replaces: kiali-operator.v1.77.0
+        skipRange: '>=1.0.0 <1.78.0'
+      - name: kiali-operator.v1.79.0
+        replaces: kiali-operator.v1.78.0
+        skipRange: '>=1.0.0 <1.79.0'
+      - name: kiali-operator.v1.80.0
+        replaces: kiali-operator.v1.79.0
+        skipRange: '>=1.0.0 <1.80.0'
+      - name: kiali-operator.v1.81.0
+        replaces: kiali-operator.v1.80.0
+        skipRange: '>=1.0.0 <1.81.0'
+      - name: kiali-operator.v1.82.0
+        replaces: kiali-operator.v1.81.0
+        skipRange: '>=1.0.0 <1.82.0'
+      - name: kiali-operator.v1.83.0
+        replaces: kiali-operator.v1.82.0
+        skipRange: '>=1.0.0 <1.83.0'
+      - name: kiali-operator.v1.84.0
+        replaces: kiali-operator.v1.83.0
+        skipRange: '>=1.0.0 <1.84.0'
+      - name: kiali-operator.v1.85.0
+        replaces: kiali-operator.v1.84.0
+        skipRange: '>=1.0.0 <1.85.0'
+      - name: kiali-operator.v1.86.0
+        replaces: kiali-operator.v1.85.0
+        skipRange: '>=1.0.0 <1.86.0'
+      - name: kiali-operator.v1.87.0
+        replaces: kiali-operator.v1.86.0
+        skipRange: '>=1.0.0 <1.87.0'
+      - name: kiali-operator.v1.88.0
+        replaces: kiali-operator.v1.87.0
+        skipRange: '>=1.0.0 <1.88.0'
+      - name: kiali-operator.v1.89.0
+        replaces: kiali-operator.v1.88.0
+        skipRange: '>=1.0.0 <1.89.0'
+      - name: kiali-operator.v2.0.0
+        replaces: kiali-operator.v1.89.0
+        skipRange: '>=1.0.0 <2.0.0'
+      - name: kiali-operator.v2.1.0
+        replaces: kiali-operator.v2.0.0
+        skipRange: '>=1.0.0 <2.1.0'
+    name: stable
+    package: kiali
+    schema: olm.channel
+  - image: quay.io/openshift-community-operators/kiali@sha256:6148265b750ab4e926f7a9f9dfc6a28d43fb8f9db6405f49e84310170aee55bc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:8f358c45fd63ae897371687c46246119d922691d3adb646687474bdc64790b26
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:67135380e859126130a1ea0d3e9f506304029e5d304e76017e4f49b1a8c72455
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:24a8b9c42097e2adc37b15639b69ef2b83f6befab9b2d6b7301690f77ed60536
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3515a95cc16c4606332b53c6a3427729998467f4f7e32c30115cc786648386c4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:742ccb03a209425e3e3f55d4947d2d4cb7ffc807ff8869f62aed2e1f60055d9e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:348689a65ea5cba8f2b983fe376030a9c2600759f136883b5da263512fdaa9a0
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5bf5f732163b11a8b9b48d2625f1f2a683c1dbd3bdc1c9198374f89d810f3e1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5c083be425e2023edc02e7ed3ea4a6fcf40457474693168ca2f9ff27dddebea3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:72006a384a48d776c97bb7670598351d7f20739b50453c32ba9f47b055f0a9e3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d66da70fb875940d0e261dd0e3b467149edd8e4690b3aad50302bb620f270aa8
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:3e1ad97086d083becd8b6d4c354f106a967d63bd531e8da54f8fb6c41819ee7f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:203055089a37e3e09de4f5ff2b14ca60d5bf749747d8caaeec6584d769837444
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:af45bba8df55246d0182a07ee53089bba0bad71d20b8b6245fc4c59cc98af4a5
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f2ee7531d60d48658c7a5066e9321e7a93fdeb3965aa33b0ad2ee96eb756d26e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d38efde9967bfc163d7937028128cbb60fb897f2066d4dc3617226322e4edbde
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:b3841abacab5e0fb8c8d5ba2f925835fe7fe745f68bfc1fde1e798f7114b54b1
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:2c09005af4592bef4843a7e20eeb5b504219a817235f1e1dacb340791241df36
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:7700391822f4a6ec8e00305341124790af26a2e6c663a763931141f7e652f8ab
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:98a48b7526f71e8fd1b934b99de4a6b6098436ba80a8cbd4c4f4239c6af132a4
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:561c6caeb325d2d81e74176fee10bc8f251f6a929907e7e008c4164ca5d41dd9
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:827a81d404a6308d929ada22340dfd07beeed80734e7fe8692d2250e4ea34b52
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:6620bb038700bc61265adff2e43a15241b366fe3c7859b652abdfdd9b9d61ef3
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:5938df59c2bc82da20a7baf10c73a5d87a8883903d80612a6f89a7ba91afc092
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d5c6a4829a2b089035c9d9bb2fc93deb89e16b7844b371ae2d36d413d96b287e
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:d3a0679135bfb43eea7746e40063d858bd7b781c53910d22c9decbe6cbdfba14
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:4b103ee7fe4b39bf97b671edc1d884b0928217d08e29a81de2fa23464c70f0d6
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:312a0cbc399fa4abcc02f96e5df1f41cff4d72ccf8c2794520d7512731b5c8db
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e8af5453320a398262d550c7f90c6502390418a79232d65c317b5b7d6f15b8d7
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:f39e5412047eb0b14af4b81fcb8f1a9510dd3d168429c35f3f68454f42145bbd
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:c23df0a35c3b00ef15bd0a6dfb83a1182ee3cd1f521601e2441fb2aa69c14cbc
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:e4ca63d2193237c42bfcfc18b2d13cab929fa7bf577688754fdcac2fd369c91f
+    schema: olm.bundle
+  - image: quay.io/openshift-community-operators/kiali@sha256:9b181366961783987f8be079e8082cb52172751e403ae15930aad7d8ced88e3c
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:8766525edc0450128fb41b212f09b3e25a12bed7fcf7214f7984d646e22bd154
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:509711f2426bba107899fec9930b0d25011157e03502af20fe89146b1c5db263
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:efdb12716f62ad0fc5bf0f8b6926ef6d293fb5a0eb0cf7c2f39a37bab3b974d2
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:7a09269466c42ce471d152daf045febc86bbcbfcb3f6e69c622300c2280de640
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:3af955be39d83b46d448aeb09faf21fbdc089670de274ef3a3f5e3a8b244d3bd
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:07ac331a600c8a5180404e8fd930c0259d8c4b69a8782fb93ca8aa7c49f6a9e8
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2ffdfb20368b2fca592b2be36aff027fdf0b86a59654189ef0147e820d151d20
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:46504665e293171a726f1155d0e3fa4608235f06c747ca9544994ba53f028b57
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:190bd2a0aa683f6792de61f4cc035559238773d4f97b77e6e3eee5efa25794c3
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:2a7db381b652d54370249e65fe8076d9c6908b645dcaf257681bea4e02d26d19
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:b3c0660220dbe4d8afaf182486a5b41a655b0d280c6e61f69adcbfaa41972bf7
+    schema: olm.bundle
+  - image: quay.io/community-operator-pipeline-prod/kiali@sha256:ade8272dd7a3b86ddfa0602a3d4bc467f6c28c06985f30c89d94de10a9815ee8
+    schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
This is to support FBC (file-based catalogs) which is being forced upon us.

Note: yq was used to generate the new stuff in the templates; yq indents differently than the on-boarding make target that was used to originally generate the templates. That's why there looks to be a large diff here, but its mainly whitespace. Do a "git diff -w" to see the true diff which simply adds 2.1.0 metadata. Note that the use of `yq` is taken directly from the [OLM FBC documentation here](https://olm.operatorframework.io/docs/advanced-tasks/catalog-update-formulary/#adding-a-new-replaces-link-between-two-existing-bundles), hence why it will be used moving forward to update the catalog templates.

