### PR TITLE
make some changes for best practices

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -260,6 +260,7 @@ spec:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
                 - "--watches-file=./$(WATCHES_FILE)"
+                terminationMessagePolicy: FallbackToLogsOnError
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -260,7 +260,25 @@ spec:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
                 - "--watches-file=./$(WATCHES_FILE)"
+                - "--health-probe-bind-address=:6789"
                 terminationMessagePolicy: FallbackToLogsOnError
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 6789
+                  periodSeconds: 30
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  periodSeconds: 30
+                startupProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 6
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false

--- a/manifests/kiali-upstream/2.2.0/manifests/kiali.v2.2.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.2.0/manifests/kiali.v2.2.0.clusterserviceversion.yaml
@@ -201,7 +201,25 @@ spec:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
                 - "--watches-file=./$(WATCHES_FILE)"
+                - "--health-probe-bind-address=:6789"
                 terminationMessagePolicy: FallbackToLogsOnError
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 6789
+                  periodSeconds: 30
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  periodSeconds: 30
+                startupProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 6789
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 6
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false

--- a/manifests/kiali-upstream/2.2.0/manifests/kiali.v2.2.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.2.0/manifests/kiali.v2.2.0.clusterserviceversion.yaml
@@ -201,6 +201,7 @@ spec:
                 - "--zap-log-level=info"
                 - "--leader-election-id=kiali-operator"
                 - "--watches-file=./$(WATCHES_FILE)"
+                terminationMessagePolicy: FallbackToLogsOnError
                 securityContext:
                   allowPrivilegeEscalation: false
                   privileged: false

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -101,6 +101,14 @@ spec:
             scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
           initialDelaySeconds: 5
           periodSeconds: 30
+        startupProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 6
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:

--- a/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -66,6 +66,7 @@ spec:
         - "/opt/kiali/kiali"
         - "-config"
         - "/kiali-configuration/config.yaml"
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
 {% if kiali_vars.deployment.security_context|length > 0 %}
           {{ kiali_vars.deployment.security_context | to_nice_yaml(indent=0) | trim | indent(10) }}

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -101,6 +101,14 @@ spec:
             scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
           initialDelaySeconds: 5
           periodSeconds: 30
+        startupProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          failureThreshold: 6
         env:
         - name: ACTIVE_NAMESPACE
           valueFrom:

--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -66,6 +66,7 @@ spec:
         - "/opt/kiali/kiali"
         - "-config"
         - "/kiali-configuration/config.yaml"
+        terminationMessagePolicy: FallbackToLogsOnError
         securityContext:
 {% if kiali_vars.deployment.security_context|length > 0 %}
           {{ kiali_vars.deployment.security_context | to_nice_yaml(indent=0) | trim | indent(10) }}


### PR DESCRIPTION
1. Defines ` terminationMessagePolicy: FallbackToLogsOnError` for operator and server.
2. Ensures liveness, readiness, and startup probes are defined for operator and server.

This PR goes with the helm chart PR https://github.com/kiali/helm-charts/pull/298

https://issues.redhat.com/browse/OSSM-8356