### PR TITLE
[molecule] skip the OpenShift part of the test if not on OpenShift

### DIFF
--- a/molecule/common/tasks.yml
+++ b/molecule/common/tasks.yml
@@ -3,8 +3,8 @@
     api_groups: "{{ lookup('kubernetes.core.k8s', cluster_info='api_groups') }}"
 - name: Determine the cluster type
   set_fact:
-    is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
-    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+    is_openshift: "{{ True if 'operator.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'operator.openshift.io' in api_groups else True }}"
     is_minikube: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'minikube' else False }}"
     is_kind: "{{ True if lookup('env', 'MOLECULE_CLUSTER_TYPE') == 'kind' else False }}"
 

--- a/molecule/remote-cluster-resources-test/converge.yml
+++ b/molecule/remote-cluster-resources-test/converge.yml
@@ -250,6 +250,12 @@
       - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
       - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
 
+  ###
+  ### The below tests are ONLY executed if on OpenShift; if not OpenShift, exit the test now.
+  ###
+  - meta: end_play
+    when: is_openshift == False
+
   - debug: msg="Change auth strategy to openshift to confirm OAuthClient is created"
   - include_tasks: ../common/set_kiali_cr.yml
     vars:


### PR DESCRIPTION
I tested on both minikube and openshift and all works now - molecule test now passes for both:

### Minikube

```
./hack/k8s-minikube.sh start

./hack/k8s-minikube.sh istio 

./hack/run-molecule-tests.sh --client-exe "$(which kubectl)" -dorp podman --cluster-type minikube -at "remote-cluster-resources-test"
```

### OpenShift

```
./hack/crc-openshift.sh start -p <path to your pull-secret.txt>

oc login -u kubeadmin -p kiali https://api.crc.testing:6443 --insecure-skip-tls-verify

./hack/istio/install-istio-via-istioctl.sh -cp openshift

./hack/run-molecule-tests.sh --client-exe "$(which oc)" -dorp podman --cluster-type openshift -at "remote-cluster-resources-test"
```