### PR TITLE
Add oauth-cabundle configmap to bundle mount

### DIFF
--- a/roles/default/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/deployment.yaml
@@ -171,8 +171,13 @@ spec:
           secretName: {{ kiali_vars.deployment.secret_name }}
           optional: true
       - name: kiali-cabundle
-        configMap:
-          name: {{ kiali_vars.deployment.instance_name }}-cabundle
+        projected:
+          sources:
+          - configMap:
+              name: {{ kiali_vars.deployment.instance_name }}-cabundle
+          - configMap:
+              name: {{ kiali_vars.deployment.instance_name }}-oauth-cabundle
+              optional: true
 {% for sec in kiali_deployment_secret_volumes %}
       - name: {{ sec }}
         secret:


### PR DESCRIPTION
Turns the `cabundle` configmap volume into a projected volume and adds the optional `oauth-cabundle` configmap to the mount.

To test:

1. Deploy Kiali on openshift
2. Create an `oauth-cabundle` configmap:
    ```
    kubectl create configmap -n istio-system kiali-oauth-cabundle --from-literal=oauth-server-ca.crt=somecrt
    ```
3. Restart Kiali pod
    ```
    kubectl rollout restart deployment -n istio-system kiali
    kubectl rollout status deployment -n istio-system kiali
    ```
4. Ensure file exists on the kiali pod at: `/kiali-cabundle/oauth-server-ca.crt`
    ```
    kubectl exec -it -n istio-system deployments/kiali -- cat /kiali-cabundle/oauth-server-ca.crt
    > somecrt
    ```

Server PR: https://github.com/kiali/kiali/pull/7974
Docs PR: https://github.com/kiali/kiali.io/pull/838