### PR TITLE
[operator] bump operator base image to 1.36.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ OPERATOR_QUAY_TAG ?= ${OPERATOR_QUAY_NAME}:${OPERATOR_CONTAINER_VERSION}
 DORP ?= docker
 
 # The version of the SDK this Makefile will download if needed, and the corresponding base image
-OPERATOR_SDK_VERSION ?= 1.35.0
+OPERATOR_SDK_VERSION ?= 1.36.0
 OPERATOR_BASE_IMAGE_VERSION ?= v${OPERATOR_SDK_VERSION}
 OPERATOR_BASE_IMAGE_REPO ?= quay.io/operator-framework/ansible-operator
 

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -261,6 +261,7 @@ spec:
                 - "--leader-election-id=kiali-operator"
                 - "--watches-file=./$(WATCHES_FILE)"
                 - "--health-probe-bind-address=:6789"
+                - "--metrics-bind-address=:8080"
                 terminationMessagePolicy: FallbackToLogsOnError
                 readinessProbe:
                   httpGet:

--- a/manifests/kiali-upstream/2.4.0/manifests/kiali.v2.4.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.4.0/manifests/kiali.v2.4.0.clusterserviceversion.yaml
@@ -202,6 +202,7 @@ spec:
                 - "--leader-election-id=kiali-operator"
                 - "--watches-file=./$(WATCHES_FILE)"
                 - "--health-probe-bind-address=:6789"
+                - "--metrics-bind-address=:8080"
                 terminationMessagePolicy: FallbackToLogsOnError
                 readinessProbe:
                   httpGet:


### PR DESCRIPTION
It is easier now to bump to the upstream image because the upstream image doesn't have collections; our Dockerfile installs the collections we want and that match downstream.

To test, first you need to check out this PR and the associated [helm chart PR 304](https://github.com/kiali/helm-charts/pull/304). Then run this set of commands to install minikube with test infrastructure, build/push/deploy the dev images to the cluster, and run the molecule tests:

```
./hack/k8s-minikube.sh --dex-enabled true -mp ci start \
&& ./hack/k8s-minikube.sh -mp ci istio \
&& make CLUSTER_TYPE=minikube MINIKUBE_PROFILE=ci HELM_CHARTS_REPO_PULL=false build build-ui cluster-push \
&& ./hack/run-molecule-tests.sh --helm-charts-repo-pull false --client-exe "$(which kubectl)" --minikube-exe $(which minikube) --minikube-profile ci --cluster-type minikube -udi true
```

NOTE! If you do not want to wait for the entire test suite to pass (it will take about an hour), you can pass in the operation `-at <tests>` to that last command `./hack/run-molecule-tests.sh` to just run a few tests. For example, a good set of tests to exercise the operator will be `-at "accessible-namespaces-test metrics-test roles-tests"`

An important test to look at is "metrics-test" - that originally failed because ansible operator base image 1.36 changed its metrics port default value from the previous 1.35 (for details, see the PR comments below). The operator and helm chart PRs addresses this. So the metrics-test should pass now.

NOTE 2! If you don't even want to run the molecule tests, just install the operator and kiali server via `make cluster-push operator-create kiali-create` and if kiali server installs successfully, then things are working. You could also see that the operator's metrics endpoint is still at 8080 by running this command and getting prometheus metrics successfully: `kubectl exec -it -n kiali-operator deployments/kiali-operator -- curl http://localhost:8080/metrics`