### PR TITLE
operator-route-playbook: add check for auth.strategey if running on openshift (OSSM8665)

### DIFF
--- a/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -22,12 +22,14 @@
   delay: 10
   when:
   - is_openshift == True
+  - kiali_vars.auth.strategy == "openshift"
 
 - name: Set Kiali TLS Termination from OpenShift route
   set_fact:
     kiali_route_tls_termination: "{{ kiali_route_raw['resources'][0]['spec']['tls']['termination'] }}"
   when:
-  - is_openshift == True
+  - is_openshift == True 
+  - kiali_vars.auth.strategy == "openshift"
 
 - name: Detect HTTP Kiali OpenShift route protocol
   set_fact:
@@ -35,6 +37,7 @@
   when:
   - is_openshift == True
   - kiali_route_tls_termination == ""
+  - kiali_vars.auth.strategy == "openshift"
 
 - name: Detect HTTPS Kiali OpenShift route protocol
   set_fact:
@@ -42,9 +45,11 @@
   when:
   - is_openshift == True
   - kiali_route_tls_termination != ""
+  - kiali_vars.auth.strategy == "openshift"
 
 - name: Create URL for Kiali OpenShift route
   set_fact:
     kiali_route_url: "{{ kiali_route_protocol }}://{{ kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] }}"
   when:
   - is_openshift == True
+  - kiali_vars.auth.strategy == "openshift"


### PR DESCRIPTION
### The Kiali operator does not honor a custom route even when 

```
spec:
  auth:
    strategy: !openshift
```
with reconciliation errors

```
TASK [v1.73/kiali-deploy : Get the Kiali Route URL] ****************************
included: /opt/ansible/roles/v1.73/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml for localhost

TASK [v1.73/kiali-deploy : Detect Kiali route on OpenShift] ********************
FAILED - RETRYING: Detect Kiali route on OpenShift (30 retries left).

PLAY RECAP *********************************************************************
localhost                  : ok=76   changed=8    unreachable=0    failed=1    skipped=50   rescued=0    ignored=0   

{"level":"error","ts":"2024-12-25T19:53:44Z","msg":"Reconciler error","controller":"kiali-controller","object":{"name":"kiali","namespace":"istio-system"},"namespace":"istio-system","name":"kiali","reconcileID":"c242cc58-3a09-4331-9310-652ca7947a9b","error":"event runner on failed","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\toperator-sdk/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:329\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\toperator-sdk/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:274\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2\n\toperator-sdk/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:235"} 
```
Reason for that is the playbook only checks for **is_openshift** but does not account for a different auth strategy.