### PR TITLE
[v2.4] be able to configure /api endpoint to require credentials

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -522,6 +522,7 @@ spec:
     port: 20001
     profiler:
       enabled: false
+    require_auth: false
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1490,6 +1490,9 @@ spec:
                       enabled:
                         description: "When 'true', the profiler will be enabled and accessible at /debug/pprof/ on the Kiali endpoint."
                         type: boolean
+                  require_auth:
+                    description: "When true, the /api endpoint will require users to authenticate themselves. When false, users need not authenticate with Kiali in order to get basic runtime info about the server via the /api endpoint. This setting is ignored if auth.strategy is 'anonymous'."
+                    type: boolean
                   web_fqdn:
                     description: "Defines the public domain where Kiali is being served. This is the 'domain' part of the URL (usually it's a fully-qualified domain name). For example, `kiali.example.org`. When empty, Kiali will try to guess this value from HTTP headers. On non-OpenShift clusters, you must populate this value if you want to enable cross-linking between Kiali instances in a multi-cluster setup."
                     type: string

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -343,6 +343,7 @@ kiali_defaults:
     port: 20001
     profiler:
       enabled: false
+    require_auth: false
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""

--- a/roles/v2.4/kiali-deploy/defaults/main.yml
+++ b/roles/v2.4/kiali-deploy/defaults/main.yml
@@ -343,6 +343,7 @@ kiali_defaults:
     port: 20001
     profiler:
       enabled: false
+    require_auth: false
     web_fqdn: ""
     web_history_mode: ""
     web_port: ""


### PR DESCRIPTION
When auth.strategy is not anonymous, users can still see the /api endpoint version and config information. This new config allows users to disable that unauthenticated access, requiring users to authenticate with the server in order to see the /api info.

cherry pick of https://github.com/kiali/kiali-operator/pull/865