### PR TITLE
Add relatedImages section in clusterserviceversion

### DIFF
--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -223,7 +223,7 @@ NOTE: If you have never run the Molecule tests before, the Molecule container im
 ### Are You Adding Support For a New Ansible Role Version?
 
 - [ ] Add the new role directory by copying the link:./roles[default] role and naming the new role with the form `vX.Y`.
-- [ ] Add the new RELATED_IMAGE reference and relatedImages entry for the version being added to the link:./manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml/[the CSV]
+- [ ] Add the new RELATED_IMAGE reference and the relatedImages entry for the version being added to the link:./manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml/[the CSV]
 - [ ] Add the new version to link:./playbooks/kiali-default-supported-images.yml[kiali-default-supported-images.yml]
 - [ ] Add the new version to link:./playbooks/ossmconsole-default-supported-images.yml[ossmconsole-default-supported-images.yml]
 

--- a/DEVELOPING.adoc
+++ b/DEVELOPING.adoc
@@ -223,7 +223,7 @@ NOTE: If you have never run the Molecule tests before, the Molecule container im
 ### Are You Adding Support For a New Ansible Role Version?
 
 - [ ] Add the new role directory by copying the link:./roles[default] role and naming the new role with the form `vX.Y`.
-- [ ] Add the new RELATED_IMAGE reference for the version being added to the link:./manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml/[the CSV]
+- [ ] Add the new RELATED_IMAGE reference and relatedImages entry for the version being added to the link:./manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml/[the CSV]
 - [ ] Add the new version to link:./playbooks/kiali-default-supported-images.yml[kiali-default-supported-images.yml]
 - [ ] Add the new version to link:./playbooks/ossmconsole-default-supported-images.yml[ossmconsole-default-supported-images.yml]
 

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -225,6 +225,21 @@ spec:
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
   apiservicedefinitions: {}
+  relatedImages:
+  - name: kiali_default
+    image: "${KIALI_2_4}"
+  - name: kiali_v2_4
+    image: "${KIALI_2_4}"
+  - name: kiali_v1_73
+    image: "${KIALI_1_73}"
+  - name: kiali_v1_65
+    image: "${KIALI_1_65}"
+  - name: ossmconsole_default
+    image: "${OSSMCONSOLE_2_4}"
+  - name: ossmconsole_v2_4
+    image: "${OSSMCONSOLE_2_4}"
+  - name: ossmconsole_v1_73
+    image: "${OSSMCONSOLE_1_73}"
   install:
     strategy: deployment
     spec:
@@ -337,15 +352,15 @@ spec:
                 - name: RELATED_IMAGE_kiali_default
                   value: "${KIALI_2_4}"
                 - name: RELATED_IMAGE_kiali_v2_4
-                  value: "${KIALI_2_4}"                 
+                  value: "${KIALI_2_4}"
                 - name: RELATED_IMAGE_kiali_v1_73
                   value: "${KIALI_1_73}"
                 - name: RELATED_IMAGE_kiali_v1_65
-                  value: "${KIALI_1_65}"                
+                  value: "${KIALI_1_65}"
                 - name: RELATED_IMAGE_ossmconsole_default
                   value: "${OSSMCONSOLE_2_4}"
                 - name: RELATED_IMAGE_ossmconsole_v2_4
-                  value: "${OSSMCONSOLE_2_4}"  
+                  value: "${OSSMCONSOLE_2_4}"
                 - name: RELATED_IMAGE_ossmconsole_v1_73
                   value: "${OSSMCONSOLE_1_73}"
                 ports:


### PR DESCRIPTION
The `relatedImages` section is used to create the new FBC catalog instead of the RELATED_IMAGE reference. Both can coexist in the ClusterServiceVersion YAML file, so I don't believe this change would cause any conflicts.

https://sdk.operatorframework.io/docs/olm-integration/generation/#csv-fields

I have modified the checklist to verify the new version in the `relatedImages` section.

Backport in v2.4 branch: https://github.com/kiali/kiali-operator/pull/868