### PR TITLE
bump community.general ansible collection to 9.0.0

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -41,7 +41,7 @@
 
 collections:
 - name: community.general
-  version: 7.5.0
+  version: 9.0.0
 - name: kubernetes.core
   version: 4.0.0
 - name: operator_sdk.util


### PR DESCRIPTION
This is necessary because Snyx is detecting a security error ("hardcoded secret") in the rax library. Kiali doesn't use the rax library at all (it is a Rackspace related library), but just to avoid any issues in the future with CVE / security scans flagging this again, let's just upgrade now.

![cwe-547-rax](https://github.com/user-attachments/assets/324e0ca9-a479-4c9c-ae76-0cb7814990f5)

We bump to v9.0.0 because rax was removed in that version of the collection, see https://docs.ansible.com/ansible/latest/collections/community/general/rax_module.html

