### PR TITLE
Remove sidecar injector setting from defaults

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -337,7 +337,7 @@ spec:
       istio_identity_domain: "svc.cluster.local"
       istio_injection_annotation: "sidecar.istio.io/inject"
       istio_sidecar_annotation: "sidecar.istio.io/status"
-      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
+      # default: istio_sidecar_injector_config_map_name is undefined
       istiod_deployment_name: "istiod"
       istiod_pod_monitoring_port: 15014
       root_namespace: ""

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -182,7 +182,6 @@ kiali_defaults:
       istio_identity_domain: "svc.cluster.local"
       istio_injection_annotation: "sidecar.istio.io/inject"
       istio_sidecar_annotation: "sidecar.istio.io/status"
-      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
     prometheus:

--- a/roles/v2.4/kiali-deploy/defaults/main.yml
+++ b/roles/v2.4/kiali-deploy/defaults/main.yml
@@ -181,7 +181,6 @@ kiali_defaults:
       istio_identity_domain: "svc.cluster.local"
       istio_injection_annotation: "sidecar.istio.io/inject"
       istio_sidecar_annotation: "sidecar.istio.io/status"
-      istio_sidecar_injector_config_map_name: "istio-sidecar-injector"
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
     prometheus:


### PR DESCRIPTION
This should not be hardcoded. It is autodetected and when you set this to a specific value, Kiali can only get the sidecar injector configmap for a single revision at a time.