### PR TITLE
Disable version check for tracing

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -380,6 +380,7 @@ spec:
       # default: custom_headers is empty
       custom_headers:
         customHeader1: "customHeader1Value"
+      disable_version_check: false
       enabled: false
       external_url: ""
       grpc_port: 9095

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1069,6 +1069,9 @@ spec:
                         description: "A set of name/value settings that will be passed as headers when requests are sent to the Tracing backend."
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      disable_version_check:
+                        description: "When true, version won't be checked. Defaults to `false`"
+                        type: boolean
                       enabled:
                         description: "When true, connections to the Tracing server are enabled. `internal_url` and/or `external_url` need to be provided."
                         type: boolean

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -216,6 +216,7 @@ kiali_defaults:
         use_kiali_token: false
         username: ""
       custom_headers: {}
+      disable_version_check: false
       enabled: false
       external_url: ""
       grpc_port: 9095


### PR DESCRIPTION
Ref. https://github.com/kiali/kiali/pull/8131 & https://github.com/kiali/kiali/issues/8100

Add a new setting to disable the version check. 

I've added the default to false, because it should work unless the Jaeger defaults are changed.