### PR TITLE
[v1.89] put back permissions needed for 1.73 server installs

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -372,6 +372,15 @@ spec:
           - create
           - list
           - watch
+        # the following get-secrets can be removed after 1.73 is no longer supported
+        - apiGroups: [""]
+          resourceNames:
+          - cacerts
+          - istio-ca-secret
+          resources:
+          - secrets
+          verbs:
+          - get
         - apiGroups: [""]
           resourceNames:
           - cacerts


### PR DESCRIPTION
cherry pick of
* https://github.com/kiali/kiali-operator/pull/869

part of fix for
*  https://github.com/kiali/kiali/issues/8071

(cherry picked from commit 7ed440e5591eb7411210c773283e2a196432a718)