### PR TITLE
Update ubuntu version on GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Check out code
       uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   initialize:
     name: Initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       target_branch: ${{ github.ref_name }}
       quay_tag: ${{ steps.quay_tag.outputs.quay_tag }}
@@ -39,7 +39,7 @@ jobs:
         else
           QUAY_REPO="${{ github.event.inputs.quay_repository }}"
         fi
-        
+
         QUAY_TAG="$QUAY_REPO:latest"
 
         echo "quay_tag=$QUAY_TAG" >> $GITHUB_OUTPUT
@@ -54,7 +54,7 @@ jobs:
     name: Push latest
     # Avoid schedule workflows from forks to push images
     if: ${{ (github.event_name == 'schedule' && github.repository == 'kiali/kiali-operator') || github.event_name != 'schedule' }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [initialize]
     env:
       OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
@@ -62,10 +62,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.release_branch }}  
-        
+        ref: ${{ github.event.inputs.release_branch }}
+
     - name: Build and push image
-      run: |              
+      run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
-        
-        make -e DOCKER_CLI_EXPERIMENTAL=enabled container-multi-arch-push-kiali-operator-quay    
+
+        make -e DOCKER_CLI_EXPERIMENTAL=enabled container-multi-arch-push-kiali-operator-quay

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type'     
+        description: 'Release type'
         required: true
         type: choice
         options:
@@ -20,15 +20,15 @@ on:
         default: master
         type: string
       quay_repository:
-        description: Quay repository    
+        description: Quay repository
         type: string
         default: quay.io/kiali/kiali-operator
         required: true
-  
+
 jobs:
   initialize:
     name: Initialize
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       release_type: ${{ steps.release_type.outputs.release_type }}
       release_version: ${{ steps.release_version.outputs.release_version }}
@@ -56,13 +56,13 @@ jobs:
             minor = 0
             patch = 0
         elif release_type == 'minor':
-            minor = minor + 1 
+            minor = minor + 1
             patch = 0
         elif release_type == 'patch':
             patch = patch + 1
         print('.'.join(['v' + str(major), str(minor), str(patch)]))
         EOF
-        
+
         cat <<-EOF > minor.py
         import datetime
 
@@ -94,7 +94,7 @@ jobs:
         else
           echo "release_type=${{ github.event.inputs.release_type }}" >> $GITHUB_OUTPUT
         fi
-    
+
     - name: Determine release version
       if: ${{ steps.release_type.outputs.release_type != 'skip' }}
       env:
@@ -118,7 +118,7 @@ jobs:
         fi
 
         echo "release_version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
-    
+
     - name: Determine next version
       if: ${{ steps.release_type.outputs.release_type != 'skip' }}
       env:
@@ -130,7 +130,7 @@ jobs:
         then
             NEXT_VERSION=$(python bump.py $RELEASE_TYPE $RELEASE_VERSION)
         elif [[ $RELEASE_TYPE == "minor" ]]
-        then 
+        then
             NEXT_VERSION=$(python bump.py $RELEASE_TYPE $RELEASE_VERSION)
         elif [[ $RELEASE_TYPE == "major" ]]
         then
@@ -162,28 +162,28 @@ jobs:
         fi
 
         QUAY_TAG="$QUAY_REPO:$RELEASE_VERSION $QUAY_REPO:$BRANCH_VERSION"
-        
+
         echo "quay_tag=$QUAY_TAG" >> $GITHUB_OUTPUT
-    
+
     - name: Cleanup
       run: rm bump.py minor.py
 
     - name: Log information
       run: |
         echo "Release type: ${{ steps.release_type.outputs.release_type }}"
-      
+
         echo "Release version: ${{ steps.release_version.outputs.release_version }}"
-     
+
         echo "Next version: ${{ steps.next_version.outputs.next_version }}"
 
         echo "Branch version: ${{ steps.branch_version.outputs.branch_version }}"
-        
+
         echo "Quay tag": ${{ steps.quay_tag.outputs.quay_tag }}
 
   release:
     name: Release
     if: ${{ needs.initialize.outputs.release_type != 'skip' && ((github.event_name == 'schedule' && github.repository == 'kiali/kiali-operator') || github.event_name != 'schedule') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [initialize]
     env:
       RELEASE_TYPE: ${{ needs.initialize.outputs.release_type }}
@@ -197,20 +197,20 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
-    
+
     - name: Set version to release
       run: sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
 
     - name: Build and push image
       run: |
         docker login -u ${{ secrets.QUAY_USER }} -p ${{ secrets.QUAY_PASSWORD }} quay.io
-        
+
         make -e DOCKER_CLI_EXPERIMENTAL=enabled container-multi-arch-push-kiali-operator-quay
-    
+
     - name: Configure git
       run: |
         git config user.email 'kiali-dev@googlegroups.com'
-        
+
         git config user.name 'kiali-bot'
 
     - name: Create tag
@@ -241,18 +241,18 @@ jobs:
         fi
 
         git add Makefile
-        
+
         git commit -m "Release $RELEASE_VERSION"
-        
+
         git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
-        
+
     - name: Create release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh release create $RELEASE_VERSION -t "Kiali Operator $RELEASE_VERSION"
-    
-    - name: Create or update version branch      
+
+    - name: Create or update version branch
       run: git push origin $(git rev-parse HEAD):refs/heads/$BRANCH_VERSION
 
     - name: Configure Operator SDK
@@ -268,9 +268,9 @@ jobs:
       run: |
         export PATH="$PATH:$GITHUB_WORKSPACE/_output/operator-sdk-install"
 
-        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile      
-        
-        # Using versions without the prefix 'v'        
+        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $NEXT_VERSION-SNAPSHOT/" Makefile
+
+        # Using versions without the prefix 'v'
         ./manifests/create-new-version.sh -nv ${NEXT_VERSION:1} -ov ${RELEASE_VERSION:1} -om kiali-upstream/
         ### DO NOT PERFORM COMMUNITY CATALOG WORK
         ### ./manifests/create-new-version.sh -nv ${NEXT_VERSION:1} -ov ${RELEASE_VERSION:1} -om kiali-community/
@@ -278,7 +278,7 @@ jobs:
         git add Makefile manifests/
 
         git commit -m "Prepare for next version"
-        
+
         git push origin $(git rev-parse HEAD):refs/heads/$BUILD_TAG
-        
+
         gh pr create -t "Prepare for next version" -b "Please, merge to update version numbers and prepare for release $NEXT_VERSION." -H $BUILD_TAG -B $RELEASE_BRANCH


### PR DESCRIPTION
### Describe the change

Update ubuntu version on GH actions

### Steps to test the PR

Verify that the CI tests pass, as they will run on the latest Ubuntu version. This will be enough since there are no specific commands in any GitHub Action requiring the previous Ubuntu version.

### Issue reference

Part of https://github.com/kiali/kiali/issues/8175