### PR TITLE
Add validation_change_detection_enabled option

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -342,6 +342,7 @@ spec:
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
       url_service_version: ""
+      validation_change_detection_enabled: true
       validation_reconcile_interval: "1m"
     prometheus:
       auth:

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -985,6 +985,9 @@ spec:
                       url_service_version:
                         description: "The Istio service used to determine the Istio version. If empty, assumes the URL for the well-known Istio version endpoint."
                         type: string
+                      validation_change_detection_enabled:
+                        description: "Configures whether to perform configuration change detection. Validation checks will be skipped when no changes are detected. true by default."
+                        type: boolean
                       validation_reconcile_interval:
                         description: "Configures how often Kiali will validate Istio configuration. Validations cannot be disabled at the moment but you can set this to a long period of time. Accepts a golang duration string e.g. '1h' or '30m'."
                         type: string

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -184,6 +184,7 @@ kiali_defaults:
       istio_sidecar_annotation: "sidecar.istio.io/status"
       istiod_pod_monitoring_port: 15014
       root_namespace: ""
+      validation_change_detection_enabled: true
       validation_reconcile_interval: 1m
     prometheus:
       auth:


### PR DESCRIPTION
part of #8007

Supports a new configuration option as part of validation logic.

Server PR: https://github.com/kiali/kiali/pull/8206