### PR TITLE
Added holdApplicationUntilProxyStarts in pod_annotations

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -215,7 +215,7 @@ spec:
       nodeSelector: "nodeSelectorValue"
     # default: pod_annotations is empty
     pod_annotations:
-      podAnnotation: "podAnnotationValue"
+      proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     # default: pod_labels is empty
     pod_labels:
       sidecar.istio.io/inject: "true"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -607,7 +607,15 @@ spec:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   pod_annotations:
-                    description: "Custom annotations to be created on the Kiali pod."
+                    description: |
+                      Custom annotations to be created on the Kiali pod.
+                      By default, the following annotation is applied:
+                      ```
+                      proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+                      ```
+                      If you define your own pod_annotations, they will overwrite this default.
+                      To retain the default behavior while adding your own annotations,
+                      make sure to include this value alongside your custom annotations.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   pod_labels:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -86,7 +86,8 @@ kiali_defaults:
       time_field_format: "2006-01-02T15:04:05Z07:00"
     namespace: ""
     node_selector: {}
-    pod_annotations: {}
+    pod_annotations:
+      proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
     pod_labels: {}
     priority_class_name: ""
     probes:


### PR DESCRIPTION
Make sure pod_annotations `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'` is always set to be ready to install Kiali on auto-injection=enabled namespaces.

Issue https://github.com/kiali/kiali/issues/8259