### PR TITLE
fix pod_annotations null test - needs to fallback to the default

### DIFF
--- a/molecule/null-cr-values-test/converge.yml
+++ b/molecule/null-cr-values-test/converge.yml
@@ -16,12 +16,12 @@
   # Assert that we have defaults since the CR set most settings to null.
   # The defaults come from the operator's roles/kiali-deploy/defaults/main.yaml
   # This just checks some of the settings to see that defaults are getting set.
-  # Note that accessible namespaces is being set to "[**]" so some settings depend on that.
   - assert:
       that:
       - kiali_configmap.installation_tag == ""
       - kiali_configmap.additional_display_details | length == 1
       - kiali_configmap.custom_dashboards | length == 0
+      - kiali_configmap.deployment.configmap_annotations | length == 0
       - kiali_configmap.deployment.discovery_selectors | length == 0
       - kiali_configmap.deployment.replicas == 1
       - kiali_configmap.deployment.secret_name == "kiali"
@@ -29,10 +29,14 @@
       - kiali_configmap.deployment.logger.log_level == "info"
       - kiali_configmap.deployment.logger.time_field_format == "2006-01-02T15:04:05Z07:00"
       - kiali_configmap.deployment.logger.sampler_rate == "1"
+      - kiali_configmap.deployment.pod_annotations | length == 1
+      - kiali_configmap.deployment.pod_annotations['proxy.istio.io/config'] == '{ "holdApplicationUntilProxyStarts": true }'
+      - kiali_configmap.deployment.pod_labels | length == 0
       - kiali_configmap.deployment.resources | length == 2
       - kiali_configmap.deployment.resources.requests.cpu == "10m"
       - kiali_configmap.deployment.resources.requests.memory == "64Mi"
       - kiali_configmap.deployment.resources.limits.memory == "1Gi"
+      - kiali_configmap.deployment.service_annotations | length == 0
       - kiali_configmap.external_services.custom_dashboards.prometheus.custom_headers | length == 0
       - kiali_configmap.external_services.custom_dashboards.prometheus.query_scope | length == 0
       - kiali_configmap.external_services.istio.istio_identity_domain == "svc.cluster.local"

--- a/molecule/null-cr-values-test/kiali-cr.yaml
+++ b/molecule/null-cr-values-test/kiali-cr.yaml
@@ -25,7 +25,9 @@ spec:
       pod: null
       pod_anti: null
     cluster_wide_access: {{ kiali.cluster_wide_access|bool }}
+    configmap_annotations: null
     discovery_selectors: null
+    extra_labels: null
     image_name: "{{ kiali.image_name }}"
     image_pull_policy: {{ kiali.image_pull_policy }}
     image_pull_secrets: null

--- a/roles/default/kiali-deploy/tasks/snake_camel_case.yaml
+++ b/roles/default/kiali-deploy/tasks/snake_camel_case.yaml
@@ -60,7 +60,7 @@
       {% endif %}
       {# #}
       {# deployment.pod_annotations #}
-      {% if kiali_vars.deployment.pod_annotations is defined and kiali_vars.deployment.pod_annotations | length > 0 and current_cr.spec.deployment.pod_annotations is defined %}
+      {% if kiali_vars.deployment.pod_annotations is defined and kiali_vars.deployment.pod_annotations | length > 0 and current_cr.spec.deployment.pod_annotations is defined and current_cr.spec.deployment.pod_annotations is not none %}
       {%   set _=kiali_vars['deployment'].pop('pod_annotations') %}
       {%   set kiali_vars=kiali_vars | combine({'deployment': {'pod_annotations': current_cr.spec.deployment.pod_annotations }}, recursive=True) %}
       {% endif %}


### PR DESCRIPTION
This fixes the problem detected by the null-values-test molecule test. When a user wants to delete their pod_annotations from the Kiali CR, we need to ensure we fallback to the default value (which is the new annotation we just added).

To see this work now:

1. Start minikube, install Istio:
```
./hack/k8s-minikube.sh start && hack/k8s-minikube.sh istio
```
2. Build and push the dev images into minikube (make sure this operator PR is checked out into your local operator branch):
```
make CLUSTER_TYPE=minikube build build-ui test cluster-push
```
3. Now run the molecule test, making sure to pass `-udi true` so the test uses the dev image you just pushed. If you set `-udi false` you will see the test fail (because its using the latest image which doesn't have the fix).
```
./hack/run-molecule-tests.sh --client-exe "$(which kubectl)" --cluster-type minikube -at "null-cr-values-test" -udi true
```