### PR TITLE
fix the tracing observability defaults to something more sensible

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -515,8 +515,8 @@ spec:
         enabled: true
         port: 9090
       tracing:
-        collector_type: "jaeger"
-        collector_url: "http://jaeger-collector.istio-system:14268/api/traces"
+        collector_type: "otel"
+        collector_url: "jaeger-collector.istio-system:4317"
         enabled: false
         otel:
           ca_name: ""

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -516,7 +516,7 @@ spec:
         port: 9090
       tracing:
         collector_type: "otel"
-        collector_url: "jaeger-collector.istio-system:4317"
+        collector_url: "jaeger-collector.istio-system:4318"
         enabled: false
         otel:
           ca_name: ""

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -336,7 +336,7 @@ kiali_defaults:
         port: 9090
       tracing:
         collector_type: "otel"
-        collector_url: "jaeger-collector.istio-system:4317"
+        collector_url: "jaeger-collector.istio-system:4318"
         enabled: false
         otel:
           ca_name: ""

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -335,8 +335,8 @@ kiali_defaults:
         enabled: true
         port: 9090
       tracing:
-        collector_type: "jaeger"
-        collector_url: http://jaeger-collector.istio-system:14268/api/traces
+        collector_type: "otel"
+        collector_url: "jaeger-collector.istio-system:4317"
         enabled: false
         otel:
           ca_name: ""


### PR DESCRIPTION
@josunect I have no idea if this is a good default (the default should allow access to the jaeger Istio addon). Please correct this as you think is necessary.