### PR TITLE
Kiali operator version bumping and release tag creator

### DIFF
--- a/.github/workflows/tag-bump-version.yml
+++ b/.github/workflows/tag-bump-version.yml
@@ -1,0 +1,65 @@
+name: Tag Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: Branch to bump version
+        required: true
+        default: v2.11
+        type: string
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.tag_branch }}
+
+    - name: Prepare scripts
+      run: |
+        cat <<-EOF > bump.py
+        import sys
+        release_type = sys.argv[1]
+        version = sys.argv[2]
+        parts = version.split('.')
+        major = int(parts[0][1:])
+        minor = int(parts[1])
+        patch = int(parts[2])
+        if release_type == 'major':
+            major = major + 1
+            minor = 0
+            patch = 0
+        elif release_type == 'minor':
+            minor = minor + 1
+            patch = 0
+        elif release_type == 'patch':
+            patch = patch + 1
+        print('.'.join(['v' + str(major), str(minor), str(patch)]))
+        EOF
+
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+        git config user.name 'kiali-bot'
+
+    - name: Create Bump Version Tag in kiali/kiali-operator
+      env:
+        BRANCH: ${{ github.event.inputs.tag_branch }}
+      run: |
+        RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+
+        RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
+
+        # Update the version in Kiali-operator repository
+        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
+
+        # Commit the changes
+        git add Makefile
+        git commit -m "Bump to version $RELEASE_VERSION"
+        git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
+
+        # Create the bump version tag
+        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -1,0 +1,62 @@
+name: Tag Release Creator
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: Branch to tag
+        required: true
+        default: v2.11
+        type: string
+      target_commit:
+        description: Commit hash to tag (if empty, uses HEAD of the branch)
+        required: false
+        type: string
+
+jobs:
+  release_tag:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.tag_branch }}
+        # We need to fetch the full history to check if the commit exists
+        fetch-depth: 0
+
+    - name: Configure git
+      run: |
+        git config user.email 'kiali-dev@googlegroups.com'
+        git config user.name 'kiali-bot'
+
+    - name: Validate target commit
+      run: |
+        # Set target commit to HEAD if empty
+        if [ -z "${{ inputs.target_commit }}" ]; then
+          TARGET_COMMIT=$(git rev-parse HEAD)
+          echo "No target commit specified, using HEAD: $TARGET_COMMIT"
+        else
+          TARGET_COMMIT="${{ inputs.target_commit }}"
+          echo "Using specified target commit: $TARGET_COMMIT"
+        fi
+
+        # Check if commit exists in the specified branch
+        if ! git merge-base --is-ancestor $TARGET_COMMIT HEAD 2>/dev/null; then
+          echo "Error: Commit $TARGET_COMMIT not found in branch ${{ github.event.inputs.tag_branch }}"
+          exit 1
+        fi
+
+        echo "Commit $TARGET_COMMIT is valid and exists in branch ${{ github.event.inputs.tag_branch }}"
+        echo "TARGET_COMMIT=$TARGET_COMMIT" >> $GITHUB_ENV
+
+    - name: Create Release Tag in kiali/kiali-operator
+      run: |
+        RELEASE_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
+
+        echo "Creating release tag $RELEASE_VERSION for commit $TARGET_COMMIT"
+
+        # Create the release tag
+        git push origin $TARGET_COMMIT:refs/tags/$RELEASE_VERSION
+
+        # Delete the bump version tag if it exists
+        git push origin --delete refs/tags/$RELEASE_VERSION-ossm || true


### PR DESCRIPTION
### Describe the change

This PR removes previous tag-creator workflow and introduces two GitHub workflows that streamline the Kiali version bumping and tagging process:

- `tag-bump-version.yaml`
  -  Bump the patch version of release branch
  - Creates the tag `<patch-version>-ossm`

- `tag-release-creator.yaml`
  - Creates the tag `<patch-version>` to specific commit within the release branch
  - Removes the tag `<patch-version>-ossm`

In this case, Kiali operator only needs to bump version and create release tag in one branch, so I removed the possibility to apply the workflow in multiple branches.

### Steps to test the PR

Testing GitHub workflows in a fork requires some setup and careful planning. Here's a comprehensive guide to test these workflows safely:

1. **Fork Repository & Enable Actions**
```bash
# Fork the repository on GitHub, then clone your fork
git clone https://github.com/YOUR_USERNAME/kiali.git
cd kiali

# Add upstream remote
git remote add upstream https://github.com/kiali/kiali.git
```

2. **Enable GitHub Actions in Your Fork**
- Go to your fork on GitHub
- Navigate to **Settings** → **Actions** → **General**
- Enable "Allow all actions and reusable workflows"

3. **Create Test Branches**
```bash
# Create test branches from existing release branches
git checkout -b test-v2.4 origin/v2.4
git push origin test-v2.4
```
### Testing the Tag Bump Version Workflow

**Test Case 1: Bump version**
1. Go to **Actions** → **Tag Bump Version** → **Run workflow**
2. Fill inputs:
   ```
   Branch to bump version: test-v2.4
   ```
3. **Expected Results:**
   - New commit with version bump (e.g., v2.4.1)
   - Tag created: `v2.4.1-ossm`
   - `Makefile` and `frontend/package.json` updated

**Test Case 2: Error Handling**
1. Run with non-existent branch:
   ```
   Branch to bump version: nonexistent-branch
   ```
2. **Expected Results:**
   - Workflow fails with checkout error
   - No tags created

---

### Testing the Tag Release Creator Workflow

**Test Case 1: Valid Commit**
1. First, get a recent commit hash from your test branch:
   ```bash
   git log --oneline test-v2.4 -n 5
   ```
2. Run **Tag Release Creator** workflow:
   ```
   Branch to tag: test-v2.4
   Commit hash to tag: [copy a recent commit hash]
   ```
3. **Expected Results:**
   - Clean release tag created (e.g., `v2.4.1`)
   - Corresponding `-ossm` tag removed (if exists)

**Test Case 2: Invalid Commit**
1. Run workflow with:
   ```
   Branch to tag: test-v2.4
   Commit hash to tag: invalid123abc
   ```
2. **Expected Results:**
   - Workflow fails at validation step
   - Clear error message about missing commit

**Test Case 3: Commit from Different Branch**
1. Get commit hash from `main` branch
2. Try to tag it using `test-v2.4` branch
3. **Expected Results:**
   - Workflow fails at validation step
   - Clear error message about missing commit in that branch

### Cleanup After Testing

**Remove Test Tags**
```bash
# Remove specific tags
git push origin --delete refs/tags/v2.4.1-ossm
git push origin --delete refs/tags/v2.4.1

# Remove all test tags (if following naming pattern)
git ls-remote --tags origin | grep -E "v[0-9]+\.[0-9]+\.[0-9]+" | \
while read hash ref; do
    tag=${ref##*/}
    git push origin --delete refs/tags/$tag
done
```

**Clean Up Test Branches**
```bash
# Remove test branches
git push origin --delete test-v2.4

# Clean up local branches
git branch -D test-v2.4
```