### PR TITLE
Fix for the update status task due to changes in kubernetes 1.33.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -43,9 +43,7 @@ collections:
 - name: community.general
   version: 9.0.0
 - name: kubernetes.core
-  version: 4.0.0
-- name: operator_sdk.util
-  version: 0.5.0
+  version: 6.0.0
 - name: ansible.posix
   version: 1.6.2
 

--- a/roles/default/kiali-deploy/tasks/update-status-progress.yml
+++ b/roles/default/kiali-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/default/kiali-deploy/tasks/update-status.yml
+++ b/roles/default/kiali-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/default/ossmconsole-deploy/tasks/update-status-progress.yml
+++ b/roles/default/ossmconsole-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/default/ossmconsole-deploy/tasks/update-status.yml
+++ b/roles/default/ossmconsole-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v1.65/kiali-deploy/tasks/update-status-progress.yml
+++ b/roles/v1.65/kiali-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v1.65/kiali-deploy/tasks/update-status.yml
+++ b/roles/v1.65/kiali-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v1.73/kiali-deploy/tasks/update-status-progress.yml
+++ b/roles/v1.73/kiali-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v1.73/kiali-deploy/tasks/update-status.yml
+++ b/roles/v1.73/kiali-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v1.73/ossmconsole-deploy/tasks/update-status-progress.yml
+++ b/roles/v1.73/ossmconsole-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v1.73/ossmconsole-deploy/tasks/update-status.yml
+++ b/roles/v1.73/ossmconsole-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.11/kiali-deploy/tasks/update-status-progress.yml
+++ b/roles/v2.11/kiali-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.11/kiali-deploy/tasks/update-status.yml
+++ b/roles/v2.11/kiali-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.11/ossmconsole-deploy/tasks/update-status-progress.yml
+++ b/roles/v2.11/ossmconsole-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.11/ossmconsole-deploy/tasks/update-status.yml
+++ b/roles/v2.11/ossmconsole-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.4/kiali-deploy/tasks/update-status-progress.yml
+++ b/roles/v2.4/kiali-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.4/kiali-deploy/tasks/update-status.yml
+++ b/roles/v2.4/kiali-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.4/ossmconsole-deploy/tasks/update-status-progress.yml
+++ b/roles/v2.4/ossmconsole-deploy/tasks/update-status-progress.yml
@@ -8,9 +8,14 @@
   ignore_errors: yes
   vars:
     duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]

--- a/roles/v2.4/ossmconsole-deploy/tasks/update-status.yml
+++ b/roles/v2.4/ossmconsole-deploy/tasks/update-status.yml
@@ -1,8 +1,13 @@
 - name: Update CR status field
   ignore_errors: yes
-  operator_sdk.util.k8s_status:
-    api_version: "{{ current_cr.apiVersion }}"
-    kind: "{{ current_cr.kind }}"
-    name: "{{ current_cr.metadata.name }}"
-    namespace: "{{ current_cr.metadata.namespace }}"
-    status: "{{ status_vars }}"
+  uri:
+    url: "https://{{ lookup('env', 'KUBERNETES_SERVICE_HOST') }}:{{ lookup('env', 'KUBERNETES_SERVICE_PORT_HTTPS') | default(lookup('env', 'KUBERNETES_SERVICE_PORT')) }}/apis/{{ current_cr.apiVersion }}/namespaces/{{ current_cr.metadata.namespace }}/{{ current_cr.kind | lower }}s/{{ current_cr.metadata.name }}/status"
+    method: PATCH
+    headers:
+      Authorization: "Bearer {{ lookup('file', '/var/run/secrets/kubernetes.io/serviceaccount/token') }}"
+      Content-Type: "application/merge-patch+json"
+    body_format: json
+    body:
+      status: "{{ status_vars }}"
+    ca_path: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    status_code: [200]


### PR DESCRIPTION
This moves away from operator_sdk collection. Note that kubernetes.core versions 4 and 6 both support Kubernetes 1.24 and up (with v6 supporting more current versions), thus we should not have any backward compat issues.

The code changes in this PR were generated by Cursor/claude-4-sonnet

fixes: https://github.com/kiali/kiali/issues/8593

NOTE: this may not be needed. See comments in the issue