### PR TITLE
add properties missing in schema that are defined in config.go

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -564,4 +564,4 @@ spec:
     web_port: ""
     web_root: ""
     web_schema: ""
-    write_timeout: 30
+    write_timeout: "60s"

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -447,12 +447,6 @@ spec:
     private_key_file: ""
 
   istio_labels:
-    ambient_namespace_label: "istio.io/dataplane-mode"
-    ambient_namespace_label_value: "ambient"
-    ambient_waypoint_gateway_label: "gateway.networking.k8s.io/gateway-name"
-    ambient_waypoint_label: "gateway.istio.io/managed"
-    ambient_waypoint_label_value: "istio.io-mesh-controller"
-    ambient_waypoint_use_label: "istio.io/use-waypoint"
     app_label_name: ""
     egress_gateway_label: "istio=egressgateway"
     ingress_gateway_label: "istio=ingressgateway"

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -308,11 +308,13 @@ spec:
           datasource: "var-datasource"
           namespace: "var-namespace"
           service: "var-service"
+          version: "var-version"
       - name: "Istio Workload Dashboard"
         variables:
           datasource: "var-datasource"
           namespace: "var-namespace"
           workload: "var-workload"
+          version: "var-version"
       - name: "Istio Mesh Dashboard"
       - name: "Istio Control Plane Dashboard"
       - name: "Istio Performance Dashboard"
@@ -321,8 +323,7 @@ spec:
       enabled: true
       external_url: ""
       health_check_url: ""
-      # default: internal_url is undefined
-      internal_url: ""
+      internal_url: "http://grafana.istio-system:3000"
       is_core: false
     istio:
       component_status:
@@ -331,7 +332,9 @@ spec:
       gateway_api_classes_label_selector: ""
       istio_api_enabled: true
       istio_identity_domain: "svc.cluster.local"
+      istiod_polling_interval_seconds: 20
       root_namespace: ""
+      validation_change_detection_enabled: true
       validation_reconcile_interval: "1m"
     perses:
       auth:
@@ -341,25 +344,26 @@ spec:
         type: "none"
         username: ""
       dashboards:
-        - name: "Istio Service Dashboard"
-          variables:
-            datasource: "var-datasource"
-            namespace: "var-namespace"
-            service: "var-service"
-        - name: "Istio Workload Dashboard"
-          variables:
-            datasource: "var-datasource"
-            namespace: "var-namespace"
-            workload: "var-workload"
-        - name: "Istio Mesh Dashboard"
-        - name: "Istio Control Plane Dashboard"
-        - name: "Istio Performance Dashboard"
-        - name: "Istio Wasm Extension Dashboard"
+      - name: "Istio Service Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          service: "var-service"
+          version: "var-version"
+      - name: "Istio Workload Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          workload: "var-workload"
+          version: "var-version"
+      - name: "Istio Mesh Dashboard"
+      - name: "Istio Control Plane Dashboard"
+      - name: "Istio Performance Dashboard"
+      - name: "Istio Wasm Extension Dashboard"
       enabled: false
       external_url: ""
       health_check_url: ""
-      # default: internal_url is undefined
-      internal_url: ""
+      internal_url: "http://perses.istio-system:4000"
       is_core: false
       project: "istio"
     prometheus:
@@ -443,6 +447,12 @@ spec:
     private_key_file: ""
 
   istio_labels:
+    ambient_namespace_label: "istio.io/dataplane-mode"
+    ambient_namespace_label_value: "ambient"
+    ambient_waypoint_gateway_label: "gateway.networking.k8s.io/gateway-name"
+    ambient_waypoint_label: "gateway.istio.io/managed"
+    ambient_waypoint_label_value: "istio.io-mesh-controller"
+    ambient_waypoint_use_label: "istio.io/use-waypoint"
     app_label_name: ""
     egress_gateway_label: "istio=egressgateway"
     ingress_gateway_label: "istio=ingressgateway"
@@ -484,6 +494,13 @@ spec:
         include_istio_resources: true
         include_validations: true
         show_include_toggles: false
+      mesh:
+        find_options:
+        - description: "Find: unhealthy nodes"
+          expression: "! healthy"
+        hide_options:
+        - description: "Hide: healthy nodes"
+          expression: "healthy"
       # default: metrics_inbound is undefined
       metrics_inbound:
         aggregations:
@@ -543,12 +560,13 @@ spec:
           protocol: "http"
           skip_verify: false
           tls_enabled: false
+        sampling_rate: 0.5
     port: 20001
     profiler:
       enabled: false
     require_auth: false
     web_fqdn: ""
-    web_history_mode: ""
+    web_history_mode: "browser"
     web_port: ""
     web_root: ""
     web_schema: ""

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1986,10 +1986,11 @@ spec:
                     enum: ["", "http", "https"]
                   write_timeout:
                     description: |
-                      The maximum duration, in seconds, before timing out writes of the HTTP response back to the client.
+                      The maximum duration before timing out writes of the HTTP response back to the client.
+                      Can be specified as a number (seconds) or duration string (e.g., "30s", "1h", "2m30s").
 
                       In OpenShift clusters, the route request time out should be also increased.
                       This can be done by annotating the specific route with `haproxy.router.openshift.io/timeout`.
                       See https://docs.openshift.com/container-platform/4.16/networking/routes/route-configuration.html#nw-configuring-route-timeouts_route-configuration for further details.
-                    type: integer
-                    default: 30
+                    x-kubernetes-int-or-string: true
+                    default: "60s"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1485,30 +1485,6 @@ spec:
                 description: "Defines specific labels used by Istio that Kiali needs to know about."
                 type: object
                 properties:
-                  ambient_namespace_label:
-                    description: "The label used to identify ambient namespaces."
-                    type: string
-                    default: "istio.io/dataplane-mode"
-                  ambient_namespace_label_value:
-                    description: "The value of the ambient namespace label."
-                    type: string
-                    default: "ambient"
-                  ambient_waypoint_gateway_label:
-                    description: "The label used to identify ambient waypoint gateways."
-                    type: string
-                    default: "gateway.networking.k8s.io/gateway-name"
-                  ambient_waypoint_label:
-                    description: "The label used to identify ambient waypoint."
-                    type: string
-                    default: "gateway.istio.io/managed"
-                  ambient_waypoint_label_value:
-                    description: "The value of the ambient waypoint label."
-                    type: string
-                    default: "istio.io-mesh-controller"
-                  ambient_waypoint_use_label:
-                    description: "The label used to specify waypoint usage."
-                    type: string
-                    default: "istio.io/use-waypoint"
                   app_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -153,6 +153,7 @@ spec:
                         type: string
                       api_token:
                         type: string
+                        default: "id_token"
                       authentication_timeout:
                         type: integer
                         default: 300
@@ -189,16 +190,20 @@ spec:
                       client_id_prefix:
                         description: "DEPRECATED AFTER v1.73: A prefix that will be applied to the OpenShift OAuth client identifier."
                         type: string
+                      insecure_skip_verify_tls:
+                        description: "Set true to skip verifying certificate validity when Kiali contacts OpenShift over https."
+                        type: boolean
+                        default: false
                       redirect_uris:
-                        description: "The OAuthClient redirect URIs. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `auth.strategy` set to `openshift`."
+                        description: "Custom redirect URIs for the OpenShift OAuth client. These URIs specify where users will be redirected after successful authentication. If not specified, Kiali will automatically generate appropriate redirect URIs based on the Kiali server's route. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `auth.strategy` set to `openshift`."
                         type: array
                         items:
                           type: string
                       token_inactivity_timeout:
-                        description: "Timeout that overrides the default OpenShift token inactivity timeout. This value represents the maximum amount of time in seconds that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. If 0, the Kiali tokens never timeout. OpenShift may have a minimum allowed value - see the OpenShift documentation specific for the version of OpenShift you are using. WARNING: existing tokens will not be affected by changing this setting."
+                        description: "Sets the maximum time in seconds that can elapse between consecutive uses of an OAuth access token before it expires due to inactivity. This helps improve security by automatically expiring unused tokens. If set to 0, tokens will not expire due to inactivity. Note that OpenShift may enforce minimum values for this setting, and existing tokens are not affected by changes to this configuration."
                         type: integer
                       token_max_age:
-                        description: "A time duration in seconds that overrides the default OpenShift access token max age. If 0 then there will be no expiration of tokens."
+                        description: "Sets the absolute maximum lifetime in seconds for OAuth access tokens, regardless of activity. After this time period, tokens will expire and users must re-authenticate. If set to 0, tokens will not have an absolute expiration time and will only expire due to inactivity (if token_inactivity_timeout is configured)."
                         type: integer
 
               clustering:
@@ -538,6 +543,7 @@ spec:
                   image_digest:
                     description: "If `deployment.image_version` is a digest hash, this value indicates what type of digest it is. A typical value would be 'sha256'. Note: do NOT prefix this value with a '@'."
                     type: string
+                    default: ""
                   image_name:
                     description: "Determines which Kiali image to download and install. If you set this to a specific name (i.e. you do not leave it as the default empty string), you must make sure that image is supported by the operator. If empty, the operator will use a known supported image name based on which `version` was defined. Note that, as a security measure, a cluster admin may have configured the Kiali operator to ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs a single, specific Kiali version, thus this setting may have no effect depending on how the operator itself was configured."
                     type: string
@@ -1000,6 +1006,9 @@ spec:
                                 service:
                                   description: "The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)."
                                   type: string
+                                version:
+                                  description: "The name of a variable that holds the version, if used in that dashboard (else it must be omitted)."
+                                  type: string
                                 workload:
                                   description: "The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)."
                                   type: string
@@ -1022,6 +1031,7 @@ spec:
                       internal_url:
                         description: "The URL used by Kiali to perform requests and queries to Grafana. An example would be `http://grafana.istio-system:3000`. This URL can contain query parameters if needed, such as '?orgId=1'. If not defined, it will default to `http://grafana.<istio namespace>:3000`."
                         type: string
+                        default: "http://grafana.istio-system:3000"
                       url:
                         description: "DEPRECATED AFTER v1.73: The URL used to access Grafana from external sources."
                         type: string
@@ -1110,6 +1120,10 @@ spec:
                         description: "The annotation used by Istio to identify domains."
                         type: string
                         default: "svc.cluster.local"
+                      istiod_polling_interval_seconds:
+                        description: "How often in seconds Kiali will poll istiod(s) for proxy status and registry services. Polling is not performed if istio_api_enabled is false."
+                        type: integer
+                        default: 20
                       istio_injection_annotation:
                         description: "DEPRECATED AFTER v2.11: This setting is deprecated and will be ignored. The name of the field that annotates a workload to indicate a sidecar should be automatically injected by Istio is now hardcoded to the standard value."
                         type: string
@@ -1131,6 +1145,10 @@ spec:
                       url_service_version:
                         description: "DEPRECATED AFTER v2.11: This setting is deprecated and will be ignored. The Istio service used to determine the Istio version is now autodetected from services."
                         type: string
+                      validation_change_detection_enabled:
+                        description: "When true, Kiali will detect changes in Istio configuration and trigger validation reconciliation."
+                        type: boolean
+                        default: true
                       validation_reconcile_interval:
                         description: "Configures how often Kiali will validate Istio configuration. Validations cannot be disabled at the moment but you can set this to a long period of time. Accepts a golang duration string e.g. '1h' or '30m'."
                         type: string
@@ -1184,6 +1202,9 @@ spec:
                                 service:
                                   description: "The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)."
                                   type: string
+                                version:
+                                  description: "The name of a variable that holds the version, if used in that dashboard (else it must be omitted)."
+                                  type: string
                                 workload:
                                   description: "The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)."
                                   type: string
@@ -1200,6 +1221,7 @@ spec:
                       internal_url:
                         description: "The URL used by Kiali to perform requests and queries to Perses. An example would be `http://perses.istio-system:4000`. This URL can contain query parameters if needed, such as '?orgId=1'. If not defined, it will default to `http://perses.<istio_namespace>:4000`."
                         type: string
+                        default: "http://perses.istio-system:4000"
                       is_core:
                         description: "Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning."
                         type: boolean
@@ -1463,6 +1485,30 @@ spec:
                 description: "Defines specific labels used by Istio that Kiali needs to know about."
                 type: object
                 properties:
+                  ambient_namespace_label:
+                    description: "The label used to identify ambient namespaces."
+                    type: string
+                    default: "istio.io/dataplane-mode"
+                  ambient_namespace_label_value:
+                    description: "The value of the ambient namespace label."
+                    type: string
+                    default: "ambient"
+                  ambient_waypoint_gateway_label:
+                    description: "The label used to identify ambient waypoint gateways."
+                    type: string
+                    default: "gateway.networking.k8s.io/gateway-name"
+                  ambient_waypoint_label:
+                    description: "The label used to identify ambient waypoint."
+                    type: string
+                    default: "gateway.istio.io/managed"
+                  ambient_waypoint_label_value:
+                    description: "The value of the ambient waypoint label."
+                    type: string
+                    default: "istio.io-mesh-controller"
+                  ambient_waypoint_use_label:
+                    description: "The label used to specify waypoint usage."
+                    type: string
+                    default: "istio.io/use-waypoint"
                   app_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string
@@ -1668,6 +1714,42 @@ spec:
                             description: "If true list pages display checkbox toggles for the include options, Otherwise the configured settings are applied but can not be changed by the user."
                             type: boolean
                             default: false
+                      mesh:
+                        description: "Default settings for the Mesh UI."
+                        type: object
+                        properties:
+                          find_options:
+                            description: "A list of commonly used and useful find expressions that will be provided to the user out-of-box."
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                auto_select:
+                                  description: "If true this option will be selected and take effect automatically. Note that only one option in the list can have this value be set to true."
+                                  type: boolean
+                                  default: false
+                                description:
+                                  description: "Human-readable text to let the user know what the expression does."
+                                  type: string
+                                expression:
+                                  description: "The find expression."
+                                  type: string
+                          hide_options:
+                            description: "A list of commonly used and useful hide expressions that will be provided to the user out-of-box."
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                auto_select:
+                                  description: "If true this option will be selected and take effect automatically. Note that only one option in the list can have this value be set to true."
+                                  type: boolean
+                                  default: false
+                                description:
+                                  description: "Human-readable text to let the user know what the expression does."
+                                  type: string
+                                expression:
+                                  description: "The hide expression."
+                                  type: string
                       metrics_inbound:
                         description: |
                           Additional label aggregation for inbound metric pages in detail pages.
@@ -1886,6 +1968,10 @@ spec:
                                 description: "Enable TLS for the collector. This must be specified when `protocol` is `https` or `grpc`. When you set this to `true`, you must also set a `ca_name` or set `skip_verify` to true."
                                 type: boolean
                                 default: false
+                          sampling_rate:
+                            description: "Sampling rate for Kiali server traces. >= 1.0 always samples and <= 0 never samples."
+                            type: number
+                            default: 0.5
                   port:
                     description: "The port that the server will bind to in order to receive console and API requests."
                     type: integer
@@ -1910,6 +1996,8 @@ spec:
                   web_history_mode:
                     description: "Define the history mode of kiali UI. Value must be one of: `browser` or `hash`."
                     type: string
+                    enum: ["browser", "hash"]
+                    default: "browser"
                   web_port:
                     description: "Defines the ingress port where the connections come from. This is usually necessary when the application responds through a proxy/ingress, and it does not forward the correct headers (when this happens, Kiali cannot guess the port). When empty, Kiali will try to guess this value from HTTP headers."
                     type: string

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1986,10 +1986,11 @@ spec:
                     enum: ["", "http", "https"]
                   write_timeout:
                     description: |
-                      The maximum duration, in seconds, before timing out writes of the HTTP response back to the client.
+                      The maximum duration before timing out writes of the HTTP response back to the client.
+                      Can be specified as a number (seconds) or duration string (e.g., "30s", "1h", "2m30s").
 
                       In OpenShift clusters, the route request time out should be also increased.
                       This can be done by annotating the specific route with `haproxy.router.openshift.io/timeout`.
                       See https://docs.openshift.com/container-platform/4.16/networking/routes/route-configuration.html#nw-configuring-route-timeouts_route-configuration for further details.
-                    type: integer
-                    default: 30
+                    x-kubernetes-int-or-string: true
+                    default: "60s"

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1485,30 +1485,6 @@ spec:
                 description: "Defines specific labels used by Istio that Kiali needs to know about."
                 type: object
                 properties:
-                  ambient_namespace_label:
-                    description: "The label used to identify ambient namespaces."
-                    type: string
-                    default: "istio.io/dataplane-mode"
-                  ambient_namespace_label_value:
-                    description: "The value of the ambient namespace label."
-                    type: string
-                    default: "ambient"
-                  ambient_waypoint_gateway_label:
-                    description: "The label used to identify ambient waypoint gateways."
-                    type: string
-                    default: "gateway.networking.k8s.io/gateway-name"
-                  ambient_waypoint_label:
-                    description: "The label used to identify ambient waypoint."
-                    type: string
-                    default: "gateway.istio.io/managed"
-                  ambient_waypoint_label_value:
-                    description: "The value of the ambient waypoint label."
-                    type: string
-                    default: "istio.io-mesh-controller"
-                  ambient_waypoint_use_label:
-                    description: "The label used to specify waypoint usage."
-                    type: string
-                    default: "istio.io/use-waypoint"
                   app_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -153,6 +153,7 @@ spec:
                         type: string
                       api_token:
                         type: string
+                        default: "id_token"
                       authentication_timeout:
                         type: integer
                         default: 300
@@ -189,16 +190,20 @@ spec:
                       client_id_prefix:
                         description: "DEPRECATED AFTER v1.73: A prefix that will be applied to the OpenShift OAuth client identifier."
                         type: string
+                      insecure_skip_verify_tls:
+                        description: "Set true to skip verifying certificate validity when Kiali contacts OpenShift over https."
+                        type: boolean
+                        default: false
                       redirect_uris:
-                        description: "The OAuthClient redirect URIs. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `auth.strategy` set to `openshift`."
+                        description: "Custom redirect URIs for the OpenShift OAuth client. These URIs specify where users will be redirected after successful authentication. If not specified, Kiali will automatically generate appropriate redirect URIs based on the Kiali server's route. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `auth.strategy` set to `openshift`."
                         type: array
                         items:
                           type: string
                       token_inactivity_timeout:
-                        description: "Timeout that overrides the default OpenShift token inactivity timeout. This value represents the maximum amount of time in seconds that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. If 0, the Kiali tokens never timeout. OpenShift may have a minimum allowed value - see the OpenShift documentation specific for the version of OpenShift you are using. WARNING: existing tokens will not be affected by changing this setting."
+                        description: "Sets the maximum time in seconds that can elapse between consecutive uses of an OAuth access token before it expires due to inactivity. This helps improve security by automatically expiring unused tokens. If set to 0, tokens will not expire due to inactivity. Note that OpenShift may enforce minimum values for this setting, and existing tokens are not affected by changes to this configuration."
                         type: integer
                       token_max_age:
-                        description: "A time duration in seconds that overrides the default OpenShift access token max age. If 0 then there will be no expiration of tokens."
+                        description: "Sets the absolute maximum lifetime in seconds for OAuth access tokens, regardless of activity. After this time period, tokens will expire and users must re-authenticate. If set to 0, tokens will not have an absolute expiration time and will only expire due to inactivity (if token_inactivity_timeout is configured)."
                         type: integer
 
               clustering:
@@ -538,6 +543,7 @@ spec:
                   image_digest:
                     description: "If `deployment.image_version` is a digest hash, this value indicates what type of digest it is. A typical value would be 'sha256'. Note: do NOT prefix this value with a '@'."
                     type: string
+                    default: ""
                   image_name:
                     description: "Determines which Kiali image to download and install. If you set this to a specific name (i.e. you do not leave it as the default empty string), you must make sure that image is supported by the operator. If empty, the operator will use a known supported image name based on which `version` was defined. Note that, as a security measure, a cluster admin may have configured the Kiali operator to ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs a single, specific Kiali version, thus this setting may have no effect depending on how the operator itself was configured."
                     type: string
@@ -1000,6 +1006,9 @@ spec:
                                 service:
                                   description: "The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)."
                                   type: string
+                                version:
+                                  description: "The name of a variable that holds the version, if used in that dashboard (else it must be omitted)."
+                                  type: string
                                 workload:
                                   description: "The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)."
                                   type: string
@@ -1022,6 +1031,7 @@ spec:
                       internal_url:
                         description: "The URL used by Kiali to perform requests and queries to Grafana. An example would be `http://grafana.istio-system:3000`. This URL can contain query parameters if needed, such as '?orgId=1'. If not defined, it will default to `http://grafana.<istio namespace>:3000`."
                         type: string
+                        default: "http://grafana.istio-system:3000"
                       url:
                         description: "DEPRECATED AFTER v1.73: The URL used to access Grafana from external sources."
                         type: string
@@ -1110,6 +1120,10 @@ spec:
                         description: "The annotation used by Istio to identify domains."
                         type: string
                         default: "svc.cluster.local"
+                      istiod_polling_interval_seconds:
+                        description: "How often in seconds Kiali will poll istiod(s) for proxy status and registry services. Polling is not performed if istio_api_enabled is false."
+                        type: integer
+                        default: 20
                       istio_injection_annotation:
                         description: "DEPRECATED AFTER v2.11: This setting is deprecated and will be ignored. The name of the field that annotates a workload to indicate a sidecar should be automatically injected by Istio is now hardcoded to the standard value."
                         type: string
@@ -1131,6 +1145,10 @@ spec:
                       url_service_version:
                         description: "DEPRECATED AFTER v2.11: This setting is deprecated and will be ignored. The Istio service used to determine the Istio version is now autodetected from services."
                         type: string
+                      validation_change_detection_enabled:
+                        description: "When true, Kiali will detect changes in Istio configuration and trigger validation reconciliation."
+                        type: boolean
+                        default: true
                       validation_reconcile_interval:
                         description: "Configures how often Kiali will validate Istio configuration. Validations cannot be disabled at the moment but you can set this to a long period of time. Accepts a golang duration string e.g. '1h' or '30m'."
                         type: string
@@ -1184,6 +1202,9 @@ spec:
                                 service:
                                   description: "The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)."
                                   type: string
+                                version:
+                                  description: "The name of a variable that holds the version, if used in that dashboard (else it must be omitted)."
+                                  type: string
                                 workload:
                                   description: "The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)."
                                   type: string
@@ -1200,6 +1221,7 @@ spec:
                       internal_url:
                         description: "The URL used by Kiali to perform requests and queries to Perses. An example would be `http://perses.istio-system:4000`. This URL can contain query parameters if needed, such as '?orgId=1'. If not defined, it will default to `http://perses.<istio_namespace>:4000`."
                         type: string
+                        default: "http://perses.istio-system:4000"
                       is_core:
                         description: "Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning."
                         type: boolean
@@ -1463,6 +1485,30 @@ spec:
                 description: "Defines specific labels used by Istio that Kiali needs to know about."
                 type: object
                 properties:
+                  ambient_namespace_label:
+                    description: "The label used to identify ambient namespaces."
+                    type: string
+                    default: "istio.io/dataplane-mode"
+                  ambient_namespace_label_value:
+                    description: "The value of the ambient namespace label."
+                    type: string
+                    default: "ambient"
+                  ambient_waypoint_gateway_label:
+                    description: "The label used to identify ambient waypoint gateways."
+                    type: string
+                    default: "gateway.networking.k8s.io/gateway-name"
+                  ambient_waypoint_label:
+                    description: "The label used to identify ambient waypoint."
+                    type: string
+                    default: "gateway.istio.io/managed"
+                  ambient_waypoint_label_value:
+                    description: "The value of the ambient waypoint label."
+                    type: string
+                    default: "istio.io-mesh-controller"
+                  ambient_waypoint_use_label:
+                    description: "The label used to specify waypoint usage."
+                    type: string
+                    default: "istio.io/use-waypoint"
                   app_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string
@@ -1668,6 +1714,42 @@ spec:
                             description: "If true list pages display checkbox toggles for the include options, Otherwise the configured settings are applied but can not be changed by the user."
                             type: boolean
                             default: false
+                      mesh:
+                        description: "Default settings for the Mesh UI."
+                        type: object
+                        properties:
+                          find_options:
+                            description: "A list of commonly used and useful find expressions that will be provided to the user out-of-box."
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                auto_select:
+                                  description: "If true this option will be selected and take effect automatically. Note that only one option in the list can have this value be set to true."
+                                  type: boolean
+                                  default: false
+                                description:
+                                  description: "Human-readable text to let the user know what the expression does."
+                                  type: string
+                                expression:
+                                  description: "The find expression."
+                                  type: string
+                          hide_options:
+                            description: "A list of commonly used and useful hide expressions that will be provided to the user out-of-box."
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                auto_select:
+                                  description: "If true this option will be selected and take effect automatically. Note that only one option in the list can have this value be set to true."
+                                  type: boolean
+                                  default: false
+                                description:
+                                  description: "Human-readable text to let the user know what the expression does."
+                                  type: string
+                                expression:
+                                  description: "The hide expression."
+                                  type: string
                       metrics_inbound:
                         description: |
                           Additional label aggregation for inbound metric pages in detail pages.
@@ -1886,6 +1968,10 @@ spec:
                                 description: "Enable TLS for the collector. This must be specified when `protocol` is `https` or `grpc`. When you set this to `true`, you must also set a `ca_name` or set `skip_verify` to true."
                                 type: boolean
                                 default: false
+                          sampling_rate:
+                            description: "Sampling rate for Kiali server traces. >= 1.0 always samples and <= 0 never samples."
+                            type: number
+                            default: 0.5
                   port:
                     description: "The port that the server will bind to in order to receive console and API requests."
                     type: integer
@@ -1910,6 +1996,8 @@ spec:
                   web_history_mode:
                     description: "Define the history mode of kiali UI. Value must be one of: `browser` or `hash`."
                     type: string
+                    enum: ["browser", "hash"]
+                    default: "browser"
                   web_port:
                     description: "Defines the ingress port where the connections come from. This is usually necessary when the application responds through a proxy/ingress, and it does not forward the correct headers (when this happens, Kiali cannot guess the port). When empty, Kiali will try to guess this value from HTTP headers."
                     type: string

--- a/manifests/kiali-upstream/2.15.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.15.0/manifests/kiali.crd.yaml
@@ -1986,10 +1986,11 @@ spec:
                     enum: ["", "http", "https"]
                   write_timeout:
                     description: |
-                      The maximum duration, in seconds, before timing out writes of the HTTP response back to the client.
+                      The maximum duration before timing out writes of the HTTP response back to the client.
+                      Can be specified as a number (seconds) or duration string (e.g., "30s", "1h", "2m30s").
 
                       In OpenShift clusters, the route request time out should be also increased.
                       This can be done by annotating the specific route with `haproxy.router.openshift.io/timeout`.
                       See https://docs.openshift.com/container-platform/4.16/networking/routes/route-configuration.html#nw-configuring-route-timeouts_route-configuration for further details.
-                    type: integer
-                    default: 30
+                    x-kubernetes-int-or-string: true
+                    default: "60s"

--- a/manifests/kiali-upstream/2.15.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.15.0/manifests/kiali.crd.yaml
@@ -1485,30 +1485,6 @@ spec:
                 description: "Defines specific labels used by Istio that Kiali needs to know about."
                 type: object
                 properties:
-                  ambient_namespace_label:
-                    description: "The label used to identify ambient namespaces."
-                    type: string
-                    default: "istio.io/dataplane-mode"
-                  ambient_namespace_label_value:
-                    description: "The value of the ambient namespace label."
-                    type: string
-                    default: "ambient"
-                  ambient_waypoint_gateway_label:
-                    description: "The label used to identify ambient waypoint gateways."
-                    type: string
-                    default: "gateway.networking.k8s.io/gateway-name"
-                  ambient_waypoint_label:
-                    description: "The label used to identify ambient waypoint."
-                    type: string
-                    default: "gateway.istio.io/managed"
-                  ambient_waypoint_label_value:
-                    description: "The value of the ambient waypoint label."
-                    type: string
-                    default: "istio.io-mesh-controller"
-                  ambient_waypoint_use_label:
-                    description: "The label used to specify waypoint usage."
-                    type: string
-                    default: "istio.io/use-waypoint"
                   app_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string

--- a/manifests/kiali-upstream/2.15.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.15.0/manifests/kiali.crd.yaml
@@ -153,6 +153,7 @@ spec:
                         type: string
                       api_token:
                         type: string
+                        default: "id_token"
                       authentication_timeout:
                         type: integer
                         default: 300
@@ -189,16 +190,20 @@ spec:
                       client_id_prefix:
                         description: "DEPRECATED AFTER v1.73: A prefix that will be applied to the OpenShift OAuth client identifier."
                         type: string
+                      insecure_skip_verify_tls:
+                        description: "Set true to skip verifying certificate validity when Kiali contacts OpenShift over https."
+                        type: boolean
+                        default: false
                       redirect_uris:
-                        description: "The OAuthClient redirect URIs. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `auth.strategy` set to `openshift`."
+                        description: "Custom redirect URIs for the OpenShift OAuth client. These URIs specify where users will be redirected after successful authentication. If not specified, Kiali will automatically generate appropriate redirect URIs based on the Kiali server's route. You normally do not have to set this unless you are creating remote cluster resources (see `deployment.remote_cluster_resources_only`) with `auth.strategy` set to `openshift`."
                         type: array
                         items:
                           type: string
                       token_inactivity_timeout:
-                        description: "Timeout that overrides the default OpenShift token inactivity timeout. This value represents the maximum amount of time in seconds that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. If 0, the Kiali tokens never timeout. OpenShift may have a minimum allowed value - see the OpenShift documentation specific for the version of OpenShift you are using. WARNING: existing tokens will not be affected by changing this setting."
+                        description: "Sets the maximum time in seconds that can elapse between consecutive uses of an OAuth access token before it expires due to inactivity. This helps improve security by automatically expiring unused tokens. If set to 0, tokens will not expire due to inactivity. Note that OpenShift may enforce minimum values for this setting, and existing tokens are not affected by changes to this configuration."
                         type: integer
                       token_max_age:
-                        description: "A time duration in seconds that overrides the default OpenShift access token max age. If 0 then there will be no expiration of tokens."
+                        description: "Sets the absolute maximum lifetime in seconds for OAuth access tokens, regardless of activity. After this time period, tokens will expire and users must re-authenticate. If set to 0, tokens will not have an absolute expiration time and will only expire due to inactivity (if token_inactivity_timeout is configured)."
                         type: integer
 
               clustering:
@@ -538,6 +543,7 @@ spec:
                   image_digest:
                     description: "If `deployment.image_version` is a digest hash, this value indicates what type of digest it is. A typical value would be 'sha256'. Note: do NOT prefix this value with a '@'."
                     type: string
+                    default: ""
                   image_name:
                     description: "Determines which Kiali image to download and install. If you set this to a specific name (i.e. you do not leave it as the default empty string), you must make sure that image is supported by the operator. If empty, the operator will use a known supported image name based on which `version` was defined. Note that, as a security measure, a cluster admin may have configured the Kiali operator to ignore this setting. A cluster admin may do this to ensure the Kiali operator only installs a single, specific Kiali version, thus this setting may have no effect depending on how the operator itself was configured."
                     type: string
@@ -1000,6 +1006,9 @@ spec:
                                 service:
                                   description: "The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)."
                                   type: string
+                                version:
+                                  description: "The name of a variable that holds the version, if used in that dashboard (else it must be omitted)."
+                                  type: string
                                 workload:
                                   description: "The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)."
                                   type: string
@@ -1022,6 +1031,7 @@ spec:
                       internal_url:
                         description: "The URL used by Kiali to perform requests and queries to Grafana. An example would be `http://grafana.istio-system:3000`. This URL can contain query parameters if needed, such as '?orgId=1'. If not defined, it will default to `http://grafana.<istio namespace>:3000`."
                         type: string
+                        default: "http://grafana.istio-system:3000"
                       url:
                         description: "DEPRECATED AFTER v1.73: The URL used to access Grafana from external sources."
                         type: string
@@ -1110,6 +1120,10 @@ spec:
                         description: "The annotation used by Istio to identify domains."
                         type: string
                         default: "svc.cluster.local"
+                      istiod_polling_interval_seconds:
+                        description: "How often in seconds Kiali will poll istiod(s) for proxy status and registry services. Polling is not performed if istio_api_enabled is false."
+                        type: integer
+                        default: 20
                       istio_injection_annotation:
                         description: "DEPRECATED AFTER v2.11: This setting is deprecated and will be ignored. The name of the field that annotates a workload to indicate a sidecar should be automatically injected by Istio is now hardcoded to the standard value."
                         type: string
@@ -1131,6 +1145,10 @@ spec:
                       url_service_version:
                         description: "DEPRECATED AFTER v2.11: This setting is deprecated and will be ignored. The Istio service used to determine the Istio version is now autodetected from services."
                         type: string
+                      validation_change_detection_enabled:
+                        description: "When true, Kiali will detect changes in Istio configuration and trigger validation reconciliation."
+                        type: boolean
+                        default: true
                       validation_reconcile_interval:
                         description: "Configures how often Kiali will validate Istio configuration. Validations cannot be disabled at the moment but you can set this to a long period of time. Accepts a golang duration string e.g. '1h' or '30m'."
                         type: string
@@ -1184,6 +1202,9 @@ spec:
                                 service:
                                   description: "The name of a variable that holds the service name, if used in that dashboard (else it must be omitted)."
                                   type: string
+                                version:
+                                  description: "The name of a variable that holds the version, if used in that dashboard (else it must be omitted)."
+                                  type: string
                                 workload:
                                   description: "The name of a variable that holds the workload name, if used in that dashboard (else it must be omitted)."
                                   type: string
@@ -1200,6 +1221,7 @@ spec:
                       internal_url:
                         description: "The URL used by Kiali to perform requests and queries to Perses. An example would be `http://perses.istio-system:4000`. This URL can contain query parameters if needed, such as '?orgId=1'. If not defined, it will default to `http://perses.<istio_namespace>:4000`."
                         type: string
+                        default: "http://perses.istio-system:4000"
                       is_core:
                         description: "Used in the Components health feature. When true, the unhealthy scenarios will be raised as errors. Otherwise, they will be raised as a warning."
                         type: boolean
@@ -1463,6 +1485,30 @@ spec:
                 description: "Defines specific labels used by Istio that Kiali needs to know about."
                 type: object
                 properties:
+                  ambient_namespace_label:
+                    description: "The label used to identify ambient namespaces."
+                    type: string
+                    default: "istio.io/dataplane-mode"
+                  ambient_namespace_label_value:
+                    description: "The value of the ambient namespace label."
+                    type: string
+                    default: "ambient"
+                  ambient_waypoint_gateway_label:
+                    description: "The label used to identify ambient waypoint gateways."
+                    type: string
+                    default: "gateway.networking.k8s.io/gateway-name"
+                  ambient_waypoint_label:
+                    description: "The label used to identify ambient waypoint."
+                    type: string
+                    default: "gateway.istio.io/managed"
+                  ambient_waypoint_label_value:
+                    description: "The value of the ambient waypoint label."
+                    type: string
+                    default: "istio.io-mesh-controller"
+                  ambient_waypoint_use_label:
+                    description: "The label used to specify waypoint usage."
+                    type: string
+                    default: "istio.io/use-waypoint"
                   app_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string
@@ -1668,6 +1714,42 @@ spec:
                             description: "If true list pages display checkbox toggles for the include options, Otherwise the configured settings are applied but can not be changed by the user."
                             type: boolean
                             default: false
+                      mesh:
+                        description: "Default settings for the Mesh UI."
+                        type: object
+                        properties:
+                          find_options:
+                            description: "A list of commonly used and useful find expressions that will be provided to the user out-of-box."
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                auto_select:
+                                  description: "If true this option will be selected and take effect automatically. Note that only one option in the list can have this value be set to true."
+                                  type: boolean
+                                  default: false
+                                description:
+                                  description: "Human-readable text to let the user know what the expression does."
+                                  type: string
+                                expression:
+                                  description: "The find expression."
+                                  type: string
+                          hide_options:
+                            description: "A list of commonly used and useful hide expressions that will be provided to the user out-of-box."
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                auto_select:
+                                  description: "If true this option will be selected and take effect automatically. Note that only one option in the list can have this value be set to true."
+                                  type: boolean
+                                  default: false
+                                description:
+                                  description: "Human-readable text to let the user know what the expression does."
+                                  type: string
+                                expression:
+                                  description: "The hide expression."
+                                  type: string
                       metrics_inbound:
                         description: |
                           Additional label aggregation for inbound metric pages in detail pages.
@@ -1886,6 +1968,10 @@ spec:
                                 description: "Enable TLS for the collector. This must be specified when `protocol` is `https` or `grpc`. When you set this to `true`, you must also set a `ca_name` or set `skip_verify` to true."
                                 type: boolean
                                 default: false
+                          sampling_rate:
+                            description: "Sampling rate for Kiali server traces. >= 1.0 always samples and <= 0 never samples."
+                            type: number
+                            default: 0.5
                   port:
                     description: "The port that the server will bind to in order to receive console and API requests."
                     type: integer
@@ -1910,6 +1996,8 @@ spec:
                   web_history_mode:
                     description: "Define the history mode of kiali UI. Value must be one of: `browser` or `hash`."
                     type: string
+                    enum: ["browser", "hash"]
+                    default: "browser"
                   web_port:
                     description: "Defines the ingress port where the connections come from. This is usually necessary when the application responds through a proxy/ingress, and it does not forward the correct headers (when this happens, Kiali cannot guess the port). When empty, Kiali will try to guess this value from HTTP headers."
                     type: string

--- a/molecule/config-values-test/converge.yml
+++ b/molecule/config-values-test/converge.yml
@@ -501,3 +501,36 @@
       - kiali_configmap.kiali_internal | length == 2
       - kiali_configmap.kiali_internal['first_internal_setting'] == 111
       - kiali_configmap.kiali_internal['second_internal_setting'].foo == 'bar'
+
+  # Test the comprehensive Kiali CR from kiali-cr-all.yaml
+  # First delete the existing CR, then create the new one and verify it works
+
+  - name: Delete the existing Kiali CR
+    k8s:
+      state: absent
+      api_version: kiali.io/v1alpha1
+      kind: Kiali
+      namespace: "{{ cr_namespace }}"
+      name: "{{ custom_resource.metadata.name }}"
+
+  - name: Wait for Kiali CR to be completely removed
+    k8s_info:
+      api_version: kiali.io/v1alpha1
+      kind: Kiali
+      namespace: "{{ cr_namespace }}"
+      name: "{{ custom_resource.metadata.name }}"
+    register: kiali_cr_check
+    until: kiali_cr_check.resources | length == 0
+    retries: "{{ wait_retries|int }}"
+    delay: 5
+
+  - name: Create the comprehensive Kiali CR from kiali-cr-all-yaml
+    vars:
+      kiali_cr_all_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/config-values-test/kiali-cr-all-yaml"
+      kiali_cr_all: "{{ lookup('template', kiali_cr_all_file_path) | from_yaml }}"
+    k8s:
+      namespace: "{{ cr_namespace }}"
+      definition: "{{ kiali_cr_all }}"
+
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -271,4 +271,4 @@ spec:
     web_port: ""
     web_root: ""
     web_schema: ""
-    write_timeout: 30
+    write_timeout: "60s"

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -1,0 +1,280 @@
+# This is a Kiali CR that contains almost all the possible settings
+# as defined in the Kiali CRD schema. Some are not defined here; they are tested in
+# other places and molecule tests (e.g. deployment.affinity).
+#
+# All values are set to their default values except where otherwise noted.
+#
+# The purpose of this is to make sure we can create a CR that contains all the possible settings
+# and that it installs with no Kiali CRD validation errors and Kiali deploys with no issues.
+
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+spec:
+  version: {{ kiali.spec_version }}
+
+  additional_display_details:
+  - title: "API Documentation"
+    annotation: "kiali.io/api-spec"
+    icon_annotation: "kiali.io/api-type"
+
+  auth:
+    strategy: "anonymous"
+
+  installation_tag: "config-values-test-installation"
+
+  clustering:
+    autodetect_secrets:
+      enabled: false
+      label: "kiali.io/multiCluster=true"
+    clusters:
+    - name: "remote-cluster-1"
+      #secret_name: "remote-cluster-secret" # we can't set this otherwise Kiali won't start because this secret doesn't exist
+    ignore_home_cluster: false
+    kiali_urls:
+    - cluster_name: "east"
+      instance_name: "kiali"
+      namespace: "istio-system"
+      url: "https://kiali.east.example.com"
+
+  custom_dashboards:
+  - name: "custom-app-dashboard"
+    title: "Custom Application Metrics"
+    items:
+    - chart:
+        name: "Request Rate"
+        spans: 6
+        metricName: "request_rate"
+        dataType: "raw"
+
+  deployment:
+    cluster_wide_access: {{ kiali.cluster_wide_access|bool }}
+    image_digest: ""
+    image_name: "{{ kiali.image_name }}"
+    image_pull_policy: {{ kiali.image_pull_policy }}
+    image_version: "{{ kiali.image_version }}"
+    ingress:
+      enabled: true
+    logger:
+      log_level: info
+    namespace: {{ kiali.install_namespace }}
+    remote_cluster_resources_only: false
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
+
+  extensions:
+  - enabled: false
+    name: "custom-extension"
+
+  external_services:
+    custom_dashboards:
+      discovery_auto_threshold: 10
+      discovery_enabled: "auto"
+      enabled: false
+      is_core: false
+      namespace_label: "namespace"
+    grafana:
+      dashboards:
+      - name: "Istio Service Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          service: "var-service"
+          version: "var-version"
+      - name: "Istio Workload Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          workload: "var-workload"
+          version: "var-version"
+      - name: "Istio Mesh Dashboard"
+      - name: "Istio Control Plane Dashboard"
+      - name: "Istio Performance Dashboard"
+      - name: "Istio Wasm Extension Dashboard"
+    istio:
+      component_status:
+        components:
+        - app_label: "istiod"
+          is_core: true
+          is_proxy: false
+          namespace: "istio-system"
+        enabled: true
+      egress_gateway_namespace: "istio-egress"
+      gateway_api_classes:
+      - name: "istio"
+        class_name: "istio"
+      gateway_api_classes_label_selector: "app=istio-gateway"
+      istio_api_enabled: true
+      istio_identity_domain: "svc.cluster.local"
+      istiod_polling_interval_seconds: 20
+      validation_change_detection_enabled: true
+      validation_reconcile_interval: "1m"
+    perses:
+      dashboards:
+      - name: "Istio Service Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          service: "var-service"
+          version: "var-version"
+      - name: "Istio Workload Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          workload: "var-workload"
+          version: "var-version"
+      - name: "Istio Mesh Dashboard"
+      - name: "Istio Control Plane Dashboard"
+      - name: "Istio Performance Dashboard"
+      - name: "Istio Wasm Extension Dashboard"
+      enabled: false
+      external_url: "https://perses.example.com"
+      internal_url: "http://perses.istio-system:4000"
+      project: "istio-monitoring"
+    prometheus:
+      custom_headers:
+        X-Prometheus-Header: "prometheus-value"
+      query_scope:
+        mesh_id: "mesh-1"
+        cluster: "primary"
+      thanos_proxy:
+        enabled: false
+        retention_period: "30d"
+        scrape_interval: "15s"
+    tracing:
+      custom_headers:
+        X-Jaeger-Header: "jaeger-value"
+      disable_version_check: false
+      enabled: false
+      grpc_port: 9095
+      namespace_selector: true
+      provider: "jaeger"
+      query_timeout: 5
+      tempo_config:
+        cache_capacity: 200
+        cache_enabled: true
+        datasource_uid: "tempo-uid"
+        org_id: "1"
+        url_format: "grafana"
+      use_grpc: false
+      whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
+
+  health_config:
+    rate:
+    - namespace: ".*"
+      kind: ".*"
+      name: ".*"
+      tolerance:
+      - protocol: "http"
+        direction: ".*"
+        code: "[45]xx"
+        degraded: 10
+        failure: 20
+      - protocol: "grpc"
+        direction: "inbound"
+        code: "[1-9]|1[0-6]"
+        degraded: 5
+        failure: 15
+
+  istio_labels:
+    ambient_namespace_label: "istio.io/dataplane-mode"
+    ambient_namespace_label_value: "ambient"
+    ambient_waypoint_gateway_label: "gateway.networking.k8s.io/gateway-name"
+    ambient_waypoint_label: "gateway.istio.io/managed"
+    ambient_waypoint_label_value: "istio.io-mesh-controller"
+    ambient_waypoint_use_label: "istio.io/use-waypoint"
+    app_label_name: "app.kubernetes.io/name"
+    egress_gateway_label: "istio=egressgateway"
+    ingress_gateway_label: "istio=ingressgateway"
+    injection_label_name: "istio-injection"
+    injection_label_rev: "istio.io/rev"
+    version_label_name: "app.kubernetes.io/version"
+
+  kiali_feature_flags:
+    disabled_features: []
+    istio_annotation_action: true
+    istio_injection_action: true
+    istio_upgrade_action: true
+    ui_defaults:
+      graph:
+        find_options:
+        - description: "Find: slow edges (> 1s)"
+          expression: "rt > 1000"
+          auto_select: false
+        settings:
+          animation: "point"
+        traffic:
+          ambient: "total"
+          grpc: "requests"
+          http: "requests"
+          tcp: "sent"
+      i18n:
+        language: "en"
+        show_selector: true
+      list:
+        include_health: false
+        include_istio_resources: false
+        include_validations: false
+        show_include_toggles: true
+      mesh:
+        find_options:
+        - description: "Find: unhealthy nodes"
+          expression: "! healthy"
+        hide_options:
+        - description: "Hide: healthy nodes"
+          expression: "healthy"
+      metrics_inbound:
+        aggregations:
+        - display_name: "Istio Network"
+          label: "topology_istio_io_network"
+      metrics_outbound:
+        aggregations:
+        - display_name: "Source Workload"
+          label: "source_workload"
+      metrics_per_refresh: "1m"
+      namespaces: []
+      refresh_interval: "1m"
+      tracing:
+        limit: 100
+    validations:
+      ignore: ["KIA0101", "KIA0201"]
+      skip_wildcard_gateway_hosts: true
+
+  kubernetes_config:
+    burst: 200
+    cache_duration: 300
+    cache_token_namespace_duration: 10
+    cluster_name: "Kubernetes"
+    excluded_workloads: ["CronJob", "DeploymentConfig", "Job", "ReplicationController"]
+    qps: 175
+
+  server:
+    address: "0.0.0.0"
+    audit_log: true
+    cors_allow_all: false
+    gzip_enabled: true
+    node_port: 32444
+    observability:
+      metrics:
+        enabled: true
+        port: 9090
+      tracing:
+        collector_type: "otel"
+        collector_url: "jaeger-collector.istio-system:4318"
+        enabled: false
+        otel:
+          ca_name: "jaeger-ca"
+          protocol: "http"
+          skip_verify: false
+          tls_enabled: false
+        sampling_rate: 0.5
+    port: 20001
+    profiler:
+      enabled: false
+    require_auth: true
+    web_fqdn: ""
+    web_history_mode: "browser"
+    web_port: ""
+    web_root: ""
+    web_schema: ""
+    write_timeout: 30

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -177,12 +177,6 @@ spec:
         failure: 15
 
   istio_labels:
-    ambient_namespace_label: "istio.io/dataplane-mode"
-    ambient_namespace_label_value: "ambient"
-    ambient_waypoint_gateway_label: "gateway.networking.k8s.io/gateway-name"
-    ambient_waypoint_label: "gateway.istio.io/managed"
-    ambient_waypoint_label_value: "istio.io-mesh-controller"
-    ambient_waypoint_use_label: "istio.io/use-waypoint"
     app_label_name: "app.kubernetes.io/name"
     egress_gateway_label: "istio=egressgateway"
     ingress_gateway_label: "istio=ingressgateway"

--- a/molecule/config-values-test/kiali-cr.yaml
+++ b/molecule/config-values-test/kiali-cr.yaml
@@ -17,3 +17,4 @@ spec:
     service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
   server:
     node_port: 32444
+    write_timeout: 60 # using integer format; string format ("60s") also works (this is tested in converge.yaml)

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -158,11 +158,13 @@ kiali_defaults:
           datasource: "var-datasource"
           namespace: "var-namespace"
           service: "var-service"
+          version: "var-version"
       - name: "Istio Workload Dashboard"
         variables:
           datasource: "var-datasource"
           namespace: "var-namespace"
           workload: "var-workload"
+          version: "var-version"
       - name: "Istio Mesh Dashboard"
       - name: "Istio Control Plane Dashboard"
       - name: "Istio Performance Dashboard"
@@ -171,7 +173,7 @@ kiali_defaults:
       enabled: true
       external_url: ""
       health_check_url: ""
-      #internal_url
+      internal_url: "http://grafana.istio-system:3000"
       is_core: false
     istio:
       component_status:
@@ -195,11 +197,13 @@ kiali_defaults:
             datasource: "var-datasource"
             namespace: "var-namespace"
             service: "var-service"
+            version: "var-version"
         - name: "Istio Workload Dashboard"
           variables:
             datasource: "var-datasource"
             namespace: "var-namespace"
             workload: "var-workload"
+            version: "var-version"
         - name: "Istio Mesh Dashboard"
         - name: "Istio Control Plane Dashboard"
         - name: "Istio Performance Dashboard"
@@ -207,7 +211,7 @@ kiali_defaults:
       enabled: false
       external_url: ""
       health_check_url: ""
-      #internal_url
+      internal_url: "http://perses.istio-system:4000"
       is_core: false
       project: "istio"
     prometheus:
@@ -320,6 +324,13 @@ kiali_defaults:
         show_include_toggles: false
       i18n:
         show_selector: false
+      mesh:
+        find_options:
+        - description: "Find: unhealthy nodes"
+          expression: "! healthy"
+        hide_options:
+        - description: "Hide: healthy nodes"
+          expression: "healthy"
       metrics_inbound:
         aggregations: []
       metrics_outbound:
@@ -370,12 +381,13 @@ kiali_defaults:
           protocol: "http"
           skip_verify: false
           tls_enabled: false
+        sampling_rate: 0.5
     port: 20001
     profiler:
       enabled: false
     require_auth: false
     web_fqdn: ""
-    web_history_mode: ""
+    web_history_mode: "browser"
     web_port: ""
     web_root: ""
     web_schema: ""

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -34,6 +34,7 @@ kiali_defaults:
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
     openshift:
+      insecure_skip_verify_tls: false
       #redirect_uris:
       #token_inactivity_timeout:
       #token_max_age:
@@ -182,7 +183,9 @@ kiali_defaults:
       gateway_api_classes_label_selector: ""
       istio_api_enabled: true
       istio_identity_domain: "svc.cluster.local"
+      istiod_polling_interval_seconds: 20
       root_namespace: ""
+      validation_change_detection_enabled: true
       validation_reconcile_interval: "1m"
     perses:
       auth:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -391,7 +391,7 @@ kiali_defaults:
     web_port: ""
     web_root: ""
     web_schema: ""
-    write_timeout: 30
+    write_timeout: "60s"
 
 # These variables are outside of the kiali_defaults. Their values will be
 # auto-detected by the role and are not meant to be set by the user.


### PR DESCRIPTION
fixes: https://github.com/kiali/kiali/issues/8685

Compare the config structure defined in [config.go](https://github.com/kiali/kiali/blob/master/config/config.go) with the [CRD Schema golden copy](https://github.com/kiali/kiali-operator/blob/master/crd-docs/crd/kiali.io_kialis.yaml).

Settings are missing in the schema and some defaults were wrong.

I added to config-values-test molecule test to check for problems like this.

* server PR: https://github.com/kiali/kiali/pull/8686
* operator PR: https://github.com/kiali/kiali-operator/pull/953
* helm PR: https://github.com/kiali/helm-charts/pull/345