### PR TITLE
[GH Action] Option to bump to the next version after the tag release creation

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -1,7 +1,14 @@
-name: Tag Bump Version
+name: Bump Release Version
 
 on:
   workflow_dispatch:
+    inputs:
+      tag_branch:
+        description: Branch to bump version
+        required: true
+        default: v2.11
+        type: string
+  workflow_call:
     inputs:
       tag_branch:
         description: Branch to bump version
@@ -14,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.event.inputs.tag_branch }}
 
@@ -45,21 +52,29 @@ jobs:
         git config user.email 'kiali-dev@googlegroups.com'
         git config user.name 'kiali-bot'
 
-    - name: Create Bump Version Tag in kiali/kiali-operator
+    - name: Bump to next version
       env:
         BRANCH: ${{ github.event.inputs.tag_branch }}
       run: |
         RAW_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
+        LATEST_TAG=$(git describe --tags --abbrev=0)
 
-        # Update the version in Kiali-operator repository
-        sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
+        # Check if the latest tag is the current release version tag
+        if [[ "$LATEST_TAG" == "$RAW_VERSION" ]]; then
+          RELEASE_VERSION=$(python bump.py patch $RAW_VERSION)
 
-        # Commit the changes
-        git add Makefile
-        git commit -m "Bump to version $RELEASE_VERSION"
-        git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
+          # Update the version in Kiali-operator repository
+          sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile
 
-        # Create the bump version tag
-        git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm
+          # Commit the changes
+          git add Makefile
+          git commit -m "Bump to version $RELEASE_VERSION"
+          git push origin $(git rev-parse HEAD):refs/heads/$BRANCH
+
+          # Create the ossm version tag
+          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION-ossm
+        else
+          echo "Error: Latest tag $LATEST_TAG does not match expected $RAW_VERSION tag"
+          exit 1
+        fi

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -1,4 +1,4 @@
-name: Tag Release Creator
+name: Release Tag Creator
 
 on:
   workflow_dispatch:
@@ -8,20 +8,21 @@ on:
         required: true
         default: v2.11
         type: string
-      target_commit:
-        description: Commit hash to tag (if empty, uses HEAD of the branch)
-        required: false
-        type: string
+      bump_next_version:
+        description: Bump to next version after creating release tag
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   release_tag:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.event.inputs.tag_branch }}
-        # We need to fetch the full history to check if the commit exists
+        # We need to fetch the full history to determine the latest tag
         fetch-depth: 0
 
     - name: Configure git
@@ -29,34 +30,30 @@ jobs:
         git config user.email 'kiali-dev@googlegroups.com'
         git config user.name 'kiali-bot'
 
-    - name: Validate target commit
-      run: |
-        # Set target commit to HEAD if empty
-        if [ -z "${{ inputs.target_commit }}" ]; then
-          TARGET_COMMIT=$(git rev-parse HEAD)
-          echo "No target commit specified, using HEAD: $TARGET_COMMIT"
-        else
-          TARGET_COMMIT="${{ inputs.target_commit }}"
-          echo "Using specified target commit: $TARGET_COMMIT"
-        fi
-
-        # Check if commit exists in the specified branch
-        if ! git merge-base --is-ancestor $TARGET_COMMIT HEAD 2>/dev/null; then
-          echo "Error: Commit $TARGET_COMMIT not found in branch ${{ github.event.inputs.tag_branch }}"
-          exit 1
-        fi
-
-        echo "Commit $TARGET_COMMIT is valid and exists in branch ${{ github.event.inputs.tag_branch }}"
-        echo "TARGET_COMMIT=$TARGET_COMMIT" >> $GITHUB_ENV
-
     - name: Create Release Tag in kiali/kiali-operator
       run: |
         RELEASE_VERSION=$(sed -rn 's/^VERSION \?= (.*)/\1/p' Makefile)
 
-        echo "Creating release tag $RELEASE_VERSION for commit $TARGET_COMMIT"
+        LATEST_TAG=$(git describe --tags --abbrev=0)
 
-        # Create the release tag
-        git push origin $TARGET_COMMIT:refs/tags/$RELEASE_VERSION
+        # Check if the latest tag is the current ossm version tag
+        if [[ "$LATEST_TAG" == "$RELEASE_VERSION-ossm" ]]; then
+          # Delete the ossm version tag
+          echo "Deleting existing ossm version tag: $RELEASE_VERSION-ossm"
+          git push origin --delete refs/tags/$RELEASE_VERSION-ossm
 
-        # Delete the bump version tag if it exists
-        git push origin --delete refs/tags/$RELEASE_VERSION-ossm || true
+          # Create the release tag
+          echo "Creating release tag $RELEASE_VERSION"
+          git push origin $(git rev-parse HEAD):refs/tags/$RELEASE_VERSION
+        else
+          echo "Error: Latest tag $LATEST_TAG does not match expected $RELEASE_VERSION-ossm tag"
+          exit 1
+        fi
+
+  bump_version:
+    name: Bump to Next Version
+    needs: [release_tag]
+    if: ${{ inputs.bump_next_version }}
+    uses: ./.github/workflows/bump-release-version.yml
+    with:
+      tag_branches: ${{ inputs.tag_branch }}

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -56,4 +56,4 @@ jobs:
     if: ${{ inputs.bump_next_version }}
     uses: ./.github/workflows/bump-release-version.yml
     with:
-      tag_branches: ${{ inputs.tag_branch }}
+      tag_branch: ${{ inputs.tag_branch }}


### PR DESCRIPTION
This PR enhances the tag release creation workflow by adding functionality to automatically bump to the next version after creating a release tag. Additionally, the latest tag of the branch is analyzed to verify if it is the expected one to avoid errors during the workflow.