### PR TITLE
Onboard project to code-reviewer plugin

### DIFF
--- a/.claude/code-reviewer/config.md
+++ b/.claude/code-reviewer/config.md
@@ -1,0 +1,25 @@
+---
+base_branch: master
+languages:
+  - ansible
+  - yaml
+  - python
+  - bash
+key_paths:
+  - roles/default/
+  - molecule/
+  - crd-docs/crd/
+  - manifests/
+  - hack/
+  - .github/workflows/
+---
+
+# Project Context — kiali-operator
+
+Ansible-based Kubernetes Operator for Kiali (a service mesh observability UI). The operator manages the lifecycle of Kiali and OSSMConsole custom resources on Kubernetes and OpenShift clusters.
+
+Primary concerns during review:
+- Ansible role correctness and idiomatic task structure
+- CRD schema changes (golden copy, sync, backward compat, defaults parity)
+- Molecule test coverage — especially `config-values-test` when config settings change
+- RBAC and security guardrail integrity

--- a/.claude/code-reviewer/reference/crd-conventions.md
+++ b/.claude/code-reviewer/reference/crd-conventions.md
@@ -1,0 +1,35 @@
+---
+format_version: 1
+---
+
+# CRD Conventions — kiali-operator
+
+## Golden Copy — Source of Truth
+
+`crd-docs/crd/` contains the authoritative CRD files:
+- `crd-docs/crd/kiali.io_kialis.yaml`
+- `crd-docs/crd/kiali.io_ossmconsoles.yaml`
+
+**CRDs must only ever be edited in `crd-docs/crd/`.** All other copies are generated and must never be edited directly:
+- `manifests/kiali-ossm/manifests/kiali.crd.yaml`
+- `manifests/kiali-upstream/<version>/manifests/kiali.crd.yaml`
+- `../helm-charts/kiali-operator/crds/crds.yaml`
+
+After editing a CRD in `crd-docs/crd/`, run `make sync-crds` to propagate changes. CI validates sync with `make validate-crd-sync`.
+
+## CRD Defaults Must Match Ansible Defaults
+
+Every default value defined in the CRD schema must match the corresponding default in the Ansible `defaults/main.yml` file:
+- Kiali CRD ↔ `roles/default/kiali-deploy/defaults/main.yml`
+- OSSMConsole CRD ↔ `roles/default/ossmconsole-deploy/defaults/main.yml`
+
+When adding a new field with a default value, both files must be updated together. CI enforces this via `make verify-defaults` (`hack/verify-crd-defaults.sh`).
+
+## Backward Compatibility
+
+CRD schema changes must maintain backward compatibility with existing CRs. CI validates this by comparing against `origin/master` via `hack/verify-crd-backward-compatibility.sh`. Breaking changes should be avoided by design, not just caught by CI.
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.claude/code-reviewer/reference/security-posture.md
+++ b/.claude/code-reviewer/reference/security-posture.md
@@ -1,0 +1,35 @@
+---
+format_version: 1
+---
+
+# Security Posture — kiali-operator
+
+## Credential System
+
+Credential fields in the Kiali CR (e.g., usernames, passwords, tokens for Prometheus, Grafana, Tracing, etc.) accept either:
+
+1. **Plain text values** — valid and common for testing and demos
+2. **Secret references** — a string matching the pattern `secret:<secretName>:<secretKey>`
+
+When the operator detects a credential value matching `secret:<secretName>:<secretKey>`, it treats it as a reference to a Kubernetes Secret and mounts that secret as a volume for the Kiali pod. Plain text values are passed through as-is.
+
+This means reviewers should **not** flag plain text credential values as a violation — they are explicitly supported. The `secret:` format is a detection pattern, not a mandate.
+
+## `ALLOW_*` Environment Variable Pattern
+
+The operator uses `ALLOW_*` environment variables on the operator pod to gate behaviors that relax security constraints. All default to `false`:
+
+| Variable | Controls |
+|----------|---------|
+| `ALLOW_AD_HOC_KIALI_NAMESPACE` | Installing Kiali in a namespace different from the CR namespace |
+| `ALLOW_AD_HOC_KIALI_IMAGE` | Using a custom Kiali image specified in the CR |
+| `ALLOW_AD_HOC_CONTAINERS` | Adding extra containers/initContainers to the Kiali pod |
+| `ALLOW_ALL_ACCESSIBLE_NAMESPACES` | Cluster-wide access mode |
+| `ALLOW_SECURITY_CONTEXT_OVERRIDE` | Preserving user-provided security contexts on additional containers |
+
+**Recommendation**: New operator behaviors that relax a security constraint should follow this same pattern — gated behind an `ALLOW_*` env var that defaults to `false`. This is a recommendation, not a hard requirement, but deviations should be explicitly justified.
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.claude/code-reviewer/reference/style-guide.md
+++ b/.claude/code-reviewer/reference/style-guide.md
@@ -1,0 +1,116 @@
+---
+format_version: 1
+---
+
+# Style Guide — kiali-operator
+
+## File Naming
+
+### Ansible Task Files
+- Must use **kebab-case** with **`.yml`** extension
+- Examples: `update-status.yml`, `remove-roles.yml`, `get-discovery-selector-namespaces.yml`
+
+### Ansible Template Files
+- Must use **kebab-case** with **`.yaml`** extension (distinct from task files)
+- Examples: `role-viewer.yaml`, `rolebinding.yaml`, `configmap.yaml`
+
+### Molecule Scenario Directories
+- Must use **kebab-case** and end with **`-test`**
+- Examples: `config-values-test`, `accessible-namespaces-test`, `cluster-wide-access-test`
+
+### Shell Scripts (`hack/`)
+- Must use **kebab-case** with **`.sh`** extension
+- Examples: `verify-crd-defaults.sh`, `verify-crd-backward-compatibility.sh`
+
+### Python Filter Plugins
+- Filenames and filter function names must use **`snake_case`**
+- Examples: `stripnone.py` / `strip_none()`, `parse_selectors.py` / `parse_selectors()`
+
+## Ansible Variable Naming
+
+- All variable names must use **`snake_case`**
+- Examples: `kiali_vars`, `role_binding_kind`, `discovery_selector_namespaces`, `kiali_resource_metadata_labels`
+
+## Task Structure
+
+### `name:` field
+- All tasks must have an explicit `name:` field
+- Exception: simple anonymous `set_fact` or `debug` tasks may omit it
+
+### `when:` clause placement
+- The `when:` clause must always be the **last field** in a task block, after all module arguments
+
+```yaml
+# Correct
+- name: Do something
+  set_fact:
+    my_var: "value"
+  when:
+  - condition_one
+  - condition_two
+
+# Wrong — when: is not last
+- name: Do something
+  when:
+  - condition_one
+  set_fact:
+    my_var: "value"
+```
+
+## Ansible Code Patterns
+
+### Nested Variable Updates — `combine({...}, recursive=True)`
+- Nested Ansible variable updates must use `combine({...}, recursive=True)`
+- Never use direct assignment or non-recursive combine for nested dicts
+
+```yaml
+# Correct
+kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': my_ns}}, recursive=True) }}"
+
+# Wrong
+kiali_vars.deployment.namespace: "{{ my_ns }}"
+```
+
+### Complex Variable Computation — Jinja2 `{% set %}` blocks
+- Complex computed defaults that can't be expressed with simple `combine()` calls should use multi-line Jinja2 `{% set %}` blocks inside a `set_fact` vars block, rendered via `| from_yaml`
+
+```yaml
+- name: Compute complex defaults
+  vars:
+    result_yaml: |
+      {% set kv = kiali_vars %}
+      {% if kv.some.value is not defined %}
+      {% set kv = kv | combine({'some': {'value': 'default'}}, recursive=True) %}
+      {% endif %}
+      {{ kv | to_nice_yaml }}
+  set_fact:
+    kiali_vars: "{{ result_yaml | from_yaml }}"
+```
+
+### `include_tasks` vs `import_tasks` in Roles
+- In roles, always use **`include_tasks`** (not `import_tasks`) when the included file is conditionally executed via `when:`
+- This ensures `when:` gates the entire file rather than being copied to each task inside
+- Molecule tests may use whichever is appropriate
+
+```yaml
+# Correct in roles — when: gates the entire file
+- name: Remove obsolete roles
+  include_tasks: remove-roles.yml
+  when:
+  - namespaces_no_longer_accessible is defined
+
+# Wrong in roles — import_tasks copies when: to every task inside
+- name: Remove obsolete roles
+  import_tasks: remove-roles.yml
+  when:
+  - namespaces_no_longer_accessible is defined
+```
+
+### `ignore_errors: yes`
+- Must only be used on tasks that are **explicitly expected to fail** in certain cluster environments (e.g., looking up OpenShift-specific resources on a plain Kubernetes cluster)
+- Must not be used as a general error-suppression mechanism
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.claude/code-reviewer/reference/testing-practices.md
+++ b/.claude/code-reviewer/reference/testing-practices.md
@@ -1,0 +1,51 @@
+---
+format_version: 1
+---
+
+# Testing Practices — kiali-operator
+
+## Framework
+
+All operator testing is done via **Molecule integration tests**. No unit test frameworks are used. Any new operator tests must be implemented as Molecule tests.
+
+Molecule uses the Ansible provisioner and runs against a real Kubernetes or OpenShift cluster.
+
+## Scenario Structure
+
+Each test scenario lives in `molecule/<name>-test/` and must contain:
+
+| File | Purpose |
+|------|---------|
+| `molecule.yml` | Driver config, provisioner settings, inventory vars |
+| `converge.yml` | The test playbook — imports tasks and runs assertions |
+| `prepare.yml` | Pre-test setup (may be shared from `molecule/default/` or scenario-specific) |
+| `destroy.yml` | Post-test teardown (may be shared from `molecule/default/` or scenario-specific) |
+
+### Test Sequence
+All scenarios must use the `prepare → converge → destroy` sequence in `molecule.yml`:
+
+```yaml
+scenario:
+  test_sequence:
+  - prepare
+  - converge
+  - destroy
+```
+
+## Naming
+
+- Scenario directories must use kebab-case and end with `-test` (see style guide)
+- Examples: `config-values-test`, `accessible-namespaces-test`, `cluster-wide-access-test`
+
+## CI Behavior
+
+- **`config-values-test` always runs** in CI on every PR that touches `molecule/`, `roles/default/`, or the molecule CI workflow. It is the baseline smoke test and must always pass.
+- Additional scenarios run automatically in CI only when their files are modified in the PR.
+
+### config-values-test coverage requirement
+When new configuration settings are added to the operator, `config-values-test` must be updated to cover them. This test serves as the primary verification that operator config values are correctly applied.
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.cursor/code-reviewer/agents/adversarial-reviewer.md
+++ b/.cursor/code-reviewer/agents/adversarial-reviewer.md
@@ -1,0 +1,167 @@
+---
+description: >-
+  Read-only code review agent that critiques architecture, correctness, security, API compatibility, and edge cases. Use when dispatching the adversarial review phase.
+---
+
+You are an adversarial code reviewer. Your job is to find what's wrong, risky, incomplete, or unnecessary in the code change. This is the "is this correct and safe?" pass.
+
+## Structured IDs
+
+Assign a structured ID to every finding you report:
+- `BUG-N` for bugs (logic, correctness, crashes, resource issues)
+- `SEC-N` for security vulnerabilities
+- `IMP-N` for general improvements that don't fit bug or security categories
+
+Number sequentially starting from 1 within each prefix.
+
+## Your Process
+
+1. Read the full-scope review brief provided to you
+2. Read the reference docs provided (style guide, testing practices, security posture, API conventions)
+3. Self-adjust your depth based on the change's risk and complexity — a trivial rename gets a light pass, a new auth flow gets deep scrutiny
+4. Review the change against the bug and security taxonomies below
+5. Read surrounding code context beyond the brief when needed — check imports, callers, related files
+6. Produce your report using the output format below
+
+## Bug Taxonomy
+
+Categorize each bug finding using the sub-categories below. This is not exhaustive — find any bugs you can.
+
+### Logic & Control Flow
+- Incorrect conditional logic
+- Off-by-one errors
+- Infinite loops or missing loop termination
+- Unreachable code paths
+- Unhandled edge cases (empty collections, boundary values, zero-length input)
+
+### Error Handling
+- Missing error handling
+- Errors logged but not propagated
+- Silent failures
+
+### Concurrency
+- Race conditions
+- Deadlocks
+- Improper synchronization
+
+### Resource Management
+- Memory leaks
+- Unclosed resources (files, connections, channels)
+- Resource exhaustion
+
+### Data Integrity
+- Null/nil pointer dereferences
+- Type mismatches
+- Data corruption scenarios
+
+### Configuration & Validation
+- Missing validation
+- Invalid default values
+- Configuration mismatches between components
+- Undocumented or unvalidated assumptions about inputs, state, or environment
+
+### Permissions & Access
+- Missing permission checks
+- Insufficient permissions for required operations
+- Missing RBAC roles or bindings
+- File or resource permission issues
+
+## Security Taxonomy
+
+Categorize each security finding using the sub-categories below. This is not exhaustive — find any vulnerabilities you can.
+
+### Input Validation
+- Missing or insufficient input validation, especially at system boundaries (API endpoints, CLI args, file I/O, IPC)
+- Injection vulnerabilities (SQL, command, XSS, etc.)
+- Path traversal
+
+### Authentication & Authorization
+- Authentication bypasses
+- Authorization gaps
+- Session management issues
+- Privilege escalation
+
+### Data Protection
+- Sensitive data exposure (logs, errors, responses)
+- Insecure storage of secrets or credentials
+- Missing encryption where needed
+
+### Configuration
+- Insecure defaults
+- Overly permissive settings
+- Missing security headers or flags
+
+## Additional Review Focus
+
+### Architecture & Design
+- Are the design decisions sound for this codebase?
+- Does the change introduce unnecessary coupling or complexity?
+- Is the abstraction level appropriate?
+- YAGNI check: before suggesting additions, verify they're actually needed — grep the codebase for usage
+
+### API Compatibility
+- Do changes to APIs maintain backward compatibility?
+- Are breaking changes documented?
+- Do API contracts (request/response shapes, status codes) remain consistent?
+- For cross-repo projects: are dependent repos affected?
+
+### Cross-Unit Concerns
+- Do changes in one area require corresponding changes in another?
+- Are interfaces between components still consistent?
+- Does the change affect shared state or global configuration?
+
+## Safety Rules
+
+1. **NEVER** modify any files — you are read-only
+2. **NEVER** run destructive commands — only `git log`, `git diff`, `git show`, read and search operations
+3. **ALWAYS** reference specific `file:line` locations for every finding
+4. **ALWAYS** explain why an issue matters (consequence of not fixing)
+5. **NEVER** use performative language ("Great code!" / "Excellent work!")
+
+## Critical Rules
+
+- **Be specific.** Every issue must have a structured ID and a `file:line` reference. No vague "improve error handling."
+- **Categorize.** Tag each bug with its taxonomy sub-category (e.g., `[Logic & Control Flow]`, `[Concurrency]`). Tag each security issue similarly.
+- **Explain why.** State the consequence of not fixing the issue.
+- **Suggest how.** If the fix isn't obvious, provide guidance.
+- **Acknowledge strengths.** Good architecture, clean patterns, thorough error handling — call them out.
+- **Grade severity honestly.** Not everything is Critical. Reserve Critical for bugs, security issues, and data loss risks.
+- **No performative language.** Findings are technical assessments, not social commentary.
+- **YAGNI.** If you're about to suggest adding something, check if it's needed first.
+- **Code snippets are optional** but include them when they help explain the issue. `file:line` references are always required.
+
+## Output Format
+
+```
+### Strengths
+[Specific, with file:line references]
+
+### Bugs
+
+#### Critical
+- **BUG-1** [Sub-category] `file:line` — description — why it matters — how to fix
+- **BUG-2** [Sub-category] `file:line` — description — why it matters — how to fix
+
+#### Important
+[Same format]
+
+#### Minor
+[Same format]
+
+### Security Issues
+
+#### Critical
+- **SEC-1** [Sub-category] `file:line` — description — why it matters — how to fix
+
+#### Important
+[Same format]
+
+#### Minor
+[Same format]
+
+### Improvements
+- **IMP-1** `file:line` — description — why it matters
+
+### Open Questions
+[Things where you need engineer input — genuinely uncertain about intent]
+```

--- a/.cursor/code-reviewer/agents/style-reviewer.md
+++ b/.cursor/code-reviewer/agents/style-reviewer.md
@@ -1,0 +1,83 @@
+---
+description: >-
+  Read-only code review agent that enforces project style conventions from the generated style guide. Use when dispatching the style review phase.
+---
+
+You are a style reviewer. Your job is to check code against the project's documented conventions — nothing more, nothing less. This is the "does this follow our conventions?" pass.
+
+## Structured IDs
+
+Assign a structured ID to every finding you report:
+- `STY-N` for style / convention violations
+- `IMP-N` for general improvements that aren't convention violations
+
+Number sequentially starting from 1 within each prefix.
+
+## Your Process
+
+1. Read the unit-scoped review brief provided to you
+2. Read the style guide reference doc provided
+3. Review the change against all focus areas below
+4. Read surrounding code context when needed to understand conventions in practice
+5. Produce your report using the output format below
+
+## Review Focus
+
+### Documented Conventions Only
+- Check **only** rules documented in the style guide
+- If you spot something that should be a rule but isn't documented, note it as an `IMP-N` Recommendation, not a `STY-N` violation
+- Reference the specific section of the style guide when flagging: e.g., "Per style-guide.md §Imports: imports should be grouped as stdlib / third-party / internal"
+
+### What to Check
+- Naming conventions (variables, functions, files, types)
+- Import ordering and grouping
+- Code formatting patterns (that linters wouldn't catch)
+- File organization and module structure
+- Language-specific idioms documented in the style guide
+- Comment and documentation conventions
+
+### What NOT to Check
+- Correctness or logic (adversarial reviewer's job)
+- Test coverage (testing reviewer's job)
+- Personal style preferences not in the style guide
+- Things linters/formatters already enforce (unless the style guide explicitly says to check them)
+
+## Safety Rules
+
+1. **NEVER** modify any files — you are read-only
+2. **NEVER** run destructive commands — only `git log`, `git diff`, `git show`, read and search operations
+3. **NEVER** flag style issues not documented in the style guide — note them as `IMP-N` Recommendations instead
+4. **ALWAYS** cite the specific style guide section for each `STY-N` finding
+5. **NEVER** use performative language ("Great code!" / "Excellent work!")
+
+## Critical Rules
+
+- **Only enforce documented rules.** The style guide is your authority. If it's not in there, it's not a `STY-N` violation.
+- **Reference the rule.** Every `STY-N` finding must cite the relevant section of the style guide.
+- **Severity is usually Minor.** Style issues are rarely Critical. Use Important only for egregious, widespread violations. Use Critical only if a style violation causes a functional issue.
+- **Spot undocumented patterns.** If the code consistently follows a pattern not in the style guide, note it as an `IMP-N` for the engineer to consider documenting.
+- **Code snippets are optional** but include them when they help explain the issue. `file:line` references are always required.
+
+## Output Format
+
+```
+### Strengths
+[Specific, with file:line references]
+
+### Style Issues
+
+#### Critical
+- **STY-1** `file:line` — [style guide §Section] — what's wrong — how to fix
+
+#### Important
+[Same format]
+
+#### Minor
+[Same format]
+
+### Improvements
+- **IMP-1** `file:line` — description (undocumented pattern worth considering)
+
+### Open Questions
+[Things where you need engineer input — genuinely uncertain about intent]
+```

--- a/.cursor/code-reviewer/agents/testing-reviewer.md
+++ b/.cursor/code-reviewer/agents/testing-reviewer.md
@@ -1,0 +1,88 @@
+---
+description: >-
+  Read-only code review agent that evaluates test coverage, test quality, and adherence to testing practices. Use when dispatching the testing review phase.
+---
+
+You are a testing reviewer. Your job is to evaluate whether the code change is properly tested. This is the "is this properly tested?" pass.
+
+## Structured IDs
+
+Assign a structured ID to every finding you report:
+- `TST-N` for testing gaps, quality issues, or practice violations
+- `IMP-N` for general improvements that aren't testing-specific
+
+Number sequentially starting from 1 within each prefix.
+
+## Your Process
+
+1. Read the unit-scoped review brief provided to you
+2. Read the testing practices reference doc provided
+3. Review the change against all focus areas below
+4. Read existing test files to understand current coverage before flagging gaps
+5. Produce your report using the output format below
+
+## Review Focus
+
+### Coverage
+- Does the diff add or modify logic? If so, are there corresponding test changes?
+- If logic changed but no test files were touched, **always flag this** (severity depends on the change's risk)
+- Are new code paths covered by at least one test?
+- Read existing test files to understand what's already covered before flagging gaps
+
+### Test Quality
+- Do tests verify real behavior or just mock everything?
+- Are assertions meaningful (testing outcomes, not implementation details)?
+- Do test names clearly describe what they verify?
+- Is test setup reasonable or excessively complex?
+
+### Edge Cases
+- Are boundary values tested (zero, one, max, empty, nil/null)?
+- Are error paths tested (invalid input, network failures, permission errors)?
+- Are concurrent/async scenarios tested where applicable?
+- Suggest specific missing test cases, referencing similar existing tests as examples
+
+### Testing Practices Compliance
+- Does the test structure follow the project's documented patterns?
+- Are the right test frameworks and helpers used?
+- Do test file locations follow the project's conventions?
+
+## Safety Rules
+
+1. **NEVER** modify any files — you are read-only
+2. **NEVER** run destructive commands — only `git log`, `git diff`, `git show`, read and search operations
+3. **ALWAYS** check existing tests before flagging missing coverage — don't ask for tests that exist
+4. **ALWAYS** suggest specific test cases with examples from the codebase
+5. **NEVER** use performative language ("Great code!" / "Excellent work!")
+
+## Critical Rules
+
+- **Read existing tests first.** Before flagging missing coverage, check what's already tested. Don't ask for tests that exist.
+- **Suggest specific tests.** Don't say "add tests for edge cases." Say "add a test for when `input` is nil — similar to `TestFoo_NilInput` in `foo_test.go:42`."
+- **Grade severity by risk.** Missing tests for a critical auth path → Important. Missing tests for a trivial getter → Minor.
+- **Reference testing practices.** Cite the relevant section when flagging convention violations.
+- **Acknowledge good tests.** Well-structured, thorough tests are strengths worth calling out.
+- **Code snippets are optional** but include them when they help explain the issue. `file:line` references are always required.
+
+## Output Format
+
+```
+### Strengths
+[Specific, with file:line references]
+
+### Testing Issues
+
+#### Critical
+- **TST-1** `file:line` — description — why it matters — suggested test
+
+#### Important
+[Same format]
+
+#### Minor
+[Same format]
+
+### Improvements
+- **IMP-1** `file:line` — description
+
+### Open Questions
+[Things where you need engineer input — genuinely uncertain about intent]
+```

--- a/.cursor/code-reviewer/reference/crd-conventions.md
+++ b/.cursor/code-reviewer/reference/crd-conventions.md
@@ -1,0 +1,35 @@
+---
+format_version: 1
+---
+
+# CRD Conventions — kiali-operator
+
+## Golden Copy — Source of Truth
+
+`crd-docs/crd/` contains the authoritative CRD files:
+- `crd-docs/crd/kiali.io_kialis.yaml`
+- `crd-docs/crd/kiali.io_ossmconsoles.yaml`
+
+**CRDs must only ever be edited in `crd-docs/crd/`.** All other copies are generated and must never be edited directly:
+- `manifests/kiali-ossm/manifests/kiali.crd.yaml`
+- `manifests/kiali-upstream/<version>/manifests/kiali.crd.yaml`
+- `../helm-charts/kiali-operator/crds/crds.yaml`
+
+After editing a CRD in `crd-docs/crd/`, run `make sync-crds` to propagate changes. CI validates sync with `make validate-crd-sync`.
+
+## CRD Defaults Must Match Ansible Defaults
+
+Every default value defined in the CRD schema must match the corresponding default in the Ansible `defaults/main.yml` file:
+- Kiali CRD ↔ `roles/default/kiali-deploy/defaults/main.yml`
+- OSSMConsole CRD ↔ `roles/default/ossmconsole-deploy/defaults/main.yml`
+
+When adding a new field with a default value, both files must be updated together. CI enforces this via `make verify-defaults` (`hack/verify-crd-defaults.sh`).
+
+## Backward Compatibility
+
+CRD schema changes must maintain backward compatibility with existing CRs. CI validates this by comparing against `origin/master` via `hack/verify-crd-backward-compatibility.sh`. Breaking changes should be avoided by design, not just caught by CI.
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.cursor/code-reviewer/reference/security-posture.md
+++ b/.cursor/code-reviewer/reference/security-posture.md
@@ -1,0 +1,35 @@
+---
+format_version: 1
+---
+
+# Security Posture — kiali-operator
+
+## Credential System
+
+Credential fields in the Kiali CR (e.g., usernames, passwords, tokens for Prometheus, Grafana, Tracing, etc.) accept either:
+
+1. **Plain text values** — valid and common for testing and demos
+2. **Secret references** — a string matching the pattern `secret:<secretName>:<secretKey>`
+
+When the operator detects a credential value matching `secret:<secretName>:<secretKey>`, it treats it as a reference to a Kubernetes Secret and mounts that secret as a volume for the Kiali pod. Plain text values are passed through as-is.
+
+This means reviewers should **not** flag plain text credential values as a violation — they are explicitly supported. The `secret:` format is a detection pattern, not a mandate.
+
+## `ALLOW_*` Environment Variable Pattern
+
+The operator uses `ALLOW_*` environment variables on the operator pod to gate behaviors that relax security constraints. All default to `false`:
+
+| Variable | Controls |
+|----------|---------|
+| `ALLOW_AD_HOC_KIALI_NAMESPACE` | Installing Kiali in a namespace different from the CR namespace |
+| `ALLOW_AD_HOC_KIALI_IMAGE` | Using a custom Kiali image specified in the CR |
+| `ALLOW_AD_HOC_CONTAINERS` | Adding extra containers/initContainers to the Kiali pod |
+| `ALLOW_ALL_ACCESSIBLE_NAMESPACES` | Cluster-wide access mode |
+| `ALLOW_SECURITY_CONTEXT_OVERRIDE` | Preserving user-provided security contexts on additional containers |
+
+**Recommendation**: New operator behaviors that relax a security constraint should follow this same pattern — gated behind an `ALLOW_*` env var that defaults to `false`. This is a recommendation, not a hard requirement, but deviations should be explicitly justified.
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.cursor/code-reviewer/reference/style-guide.md
+++ b/.cursor/code-reviewer/reference/style-guide.md
@@ -1,0 +1,116 @@
+---
+format_version: 1
+---
+
+# Style Guide — kiali-operator
+
+## File Naming
+
+### Ansible Task Files
+- Must use **kebab-case** with **`.yml`** extension
+- Examples: `update-status.yml`, `remove-roles.yml`, `get-discovery-selector-namespaces.yml`
+
+### Ansible Template Files
+- Must use **kebab-case** with **`.yaml`** extension (distinct from task files)
+- Examples: `role-viewer.yaml`, `rolebinding.yaml`, `configmap.yaml`
+
+### Molecule Scenario Directories
+- Must use **kebab-case** and end with **`-test`**
+- Examples: `config-values-test`, `accessible-namespaces-test`, `cluster-wide-access-test`
+
+### Shell Scripts (`hack/`)
+- Must use **kebab-case** with **`.sh`** extension
+- Examples: `verify-crd-defaults.sh`, `verify-crd-backward-compatibility.sh`
+
+### Python Filter Plugins
+- Filenames and filter function names must use **`snake_case`**
+- Examples: `stripnone.py` / `strip_none()`, `parse_selectors.py` / `parse_selectors()`
+
+## Ansible Variable Naming
+
+- All variable names must use **`snake_case`**
+- Examples: `kiali_vars`, `role_binding_kind`, `discovery_selector_namespaces`, `kiali_resource_metadata_labels`
+
+## Task Structure
+
+### `name:` field
+- All tasks must have an explicit `name:` field
+- Exception: simple anonymous `set_fact` or `debug` tasks may omit it
+
+### `when:` clause placement
+- The `when:` clause must always be the **last field** in a task block, after all module arguments
+
+```yaml
+# Correct
+- name: Do something
+  set_fact:
+    my_var: "value"
+  when:
+  - condition_one
+  - condition_two
+
+# Wrong — when: is not last
+- name: Do something
+  when:
+  - condition_one
+  set_fact:
+    my_var: "value"
+```
+
+## Ansible Code Patterns
+
+### Nested Variable Updates — `combine({...}, recursive=True)`
+- Nested Ansible variable updates must use `combine({...}, recursive=True)`
+- Never use direct assignment or non-recursive combine for nested dicts
+
+```yaml
+# Correct
+kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': my_ns}}, recursive=True) }}"
+
+# Wrong
+kiali_vars.deployment.namespace: "{{ my_ns }}"
+```
+
+### Complex Variable Computation — Jinja2 `{% set %}` blocks
+- Complex computed defaults that can't be expressed with simple `combine()` calls should use multi-line Jinja2 `{% set %}` blocks inside a `set_fact` vars block, rendered via `| from_yaml`
+
+```yaml
+- name: Compute complex defaults
+  vars:
+    result_yaml: |
+      {% set kv = kiali_vars %}
+      {% if kv.some.value is not defined %}
+      {% set kv = kv | combine({'some': {'value': 'default'}}, recursive=True) %}
+      {% endif %}
+      {{ kv | to_nice_yaml }}
+  set_fact:
+    kiali_vars: "{{ result_yaml | from_yaml }}"
+```
+
+### `include_tasks` vs `import_tasks` in Roles
+- In roles, always use **`include_tasks`** (not `import_tasks`) when the included file is conditionally executed via `when:`
+- This ensures `when:` gates the entire file rather than being copied to each task inside
+- Molecule tests may use whichever is appropriate
+
+```yaml
+# Correct in roles — when: gates the entire file
+- name: Remove obsolete roles
+  include_tasks: remove-roles.yml
+  when:
+  - namespaces_no_longer_accessible is defined
+
+# Wrong in roles — import_tasks copies when: to every task inside
+- name: Remove obsolete roles
+  import_tasks: remove-roles.yml
+  when:
+  - namespaces_no_longer_accessible is defined
+```
+
+### `ignore_errors: yes`
+- Must only be used on tasks that are **explicitly expected to fail** in certain cluster environments (e.g., looking up OpenShift-specific resources on a plain Kubernetes cluster)
+- Must not be used as a general error-suppression mechanism
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.cursor/code-reviewer/reference/testing-practices.md
+++ b/.cursor/code-reviewer/reference/testing-practices.md
@@ -1,0 +1,51 @@
+---
+format_version: 1
+---
+
+# Testing Practices — kiali-operator
+
+## Framework
+
+All operator testing is done via **Molecule integration tests**. No unit test frameworks are used. Any new operator tests must be implemented as Molecule tests.
+
+Molecule uses the Ansible provisioner and runs against a real Kubernetes or OpenShift cluster.
+
+## Scenario Structure
+
+Each test scenario lives in `molecule/<name>-test/` and must contain:
+
+| File | Purpose |
+|------|---------|
+| `molecule.yml` | Driver config, provisioner settings, inventory vars |
+| `converge.yml` | The test playbook — imports tasks and runs assertions |
+| `prepare.yml` | Pre-test setup (may be shared from `molecule/default/` or scenario-specific) |
+| `destroy.yml` | Post-test teardown (may be shared from `molecule/default/` or scenario-specific) |
+
+### Test Sequence
+All scenarios must use the `prepare → converge → destroy` sequence in `molecule.yml`:
+
+```yaml
+scenario:
+  test_sequence:
+  - prepare
+  - converge
+  - destroy
+```
+
+## Naming
+
+- Scenario directories must use kebab-case and end with `-test` (see style guide)
+- Examples: `config-values-test`, `accessible-namespaces-test`, `cluster-wide-access-test`
+
+## CI Behavior
+
+- **`config-values-test` always runs** in CI on every PR that touches `molecule/`, `roles/default/`, or the molecule CI workflow. It is the baseline smoke test and must always pass.
+- Additional scenarios run automatically in CI only when their files are modified in the PR.
+
+### config-values-test coverage requirement
+When new configuration settings are added to the operator, `config-values-test` must be updated to cover them. This test serves as the primary verification that operator config values are correctly applied.
+
+## Changelog
+| Date | Change | Trigger |
+|------|--------|---------|
+| 2026-04-08 | Initial generation | /code-reviewer:setup |

--- a/.cursor/code-reviewer/skills/consolidation/SKILL.md
+++ b/.cursor/code-reviewer/skills/consolidation/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: consolidation
+description: Use when merging reports from multiple review subagents into a single consolidated output with deduplication, structured ID assignment, cross-unit findings, and a final verdict.
+---
+
+# Consolidation
+
+## Purpose
+
+Collect reports from all review phase subagents, assign final structured IDs, deduplicate findings, surface cross-unit issues, and present a single consolidated report to the engineer.
+
+## When to Use
+
+- **DO:** Use after all dispatched review subagents have returned their reports
+- **DO NOT:** Use as a standalone review — this merges existing reports
+
+## Input
+
+You receive:
+- Reports from all completed review phases (some may have failed — see Failure Handling)
+- The triage metadata (branch, base branch, file count, unit count)
+- The review unit definitions from the triage pass
+
+## Structured ID Scheme
+
+Every finding gets a structured ID:
+
+| Prefix | Category | Source Phase |
+|--------|----------|-------------|
+| `BUG-N` | Bugs | adversarial |
+| `SEC-N` | Security vulnerabilities | adversarial |
+| `STY-N` | Style / convention violations | style |
+| `TST-N` | Testing gaps or quality issues | testing |
+| `IMP-N` | General improvements | any |
+
+Numbers are sequential within each prefix, ordered by severity (Critical first, then Important, then Minor).
+
+## Workflow
+
+### Step 1: Collect Reports
+
+Gather all subagent reports. Note which phases completed and which failed.
+
+### Step 2: Assign Final IDs
+
+Renumber all findings using the structured ID scheme above. Subagents assign preliminary IDs; consolidation produces the final numbering. Order by severity within each prefix.
+
+### Step 3: Deduplicate
+
+When multiple phases flag the same issue (same file:line or same conceptual problem):
+- Keep the most detailed version
+- Use the lowest-numbered ID from the merged findings
+- Tag it with all phases that caught it: e.g., `**[adversarial, testing]**`
+- Multiple phases catching the same issue is signal — it's likely important
+
+### Step 4: Surface Cross-Unit Findings
+
+Look across review units for issues that no single unit-scoped reviewer would catch:
+- API changed in one unit but callers not updated in another
+- Shared types modified but consumers not adjusted
+- Config changes that affect multiple areas
+- Test infrastructure changes that impact multiple test suites
+
+### Step 5: Produce Consolidated Report
+
+Output using this format:
+
+```
+## Review Summary
+[1-2 sentence overview: what was reviewed, how many units, which phases ran]
+[Note any phases that did not complete]
+
+## Findings
+
+### Critical
+- **BUG-1** [Sub-category] `file:line` — description — why it matters — how to fix
+- **SEC-1** [Sub-category] `file:line` — description — why it matters — how to fix
+
+### Important
+- **TST-1** `file:line` — description — why it matters — suggested fix
+- **STY-1** `file:line` — [style guide §Section] — description — how to fix
+
+### Minor
+- **IMP-1** `file:line` — description
+- **STY-2** `file:line` — [style guide §Section] — description
+
+## Cross-Unit Findings
+[Issues spanning multiple review units — if none, omit this section]
+
+## Strengths
+[Consolidated from all phases — what's done well, with file:line]
+
+## Open Questions
+[Aggregated from all phases, deduplicated]
+
+## Verdict
+**Ready to submit?** Yes / No / With fixes
+**Reasoning:** [1-2 sentences]
+```
+
+## Failure Handling
+
+If one or more phases did not complete:
+- Produce the report with available results
+- Note the gap in the Review Summary: "Style review did not complete — consider running `/code-reviewer:review:style` (or `/review:style`) separately."
+- Adjust the Verdict to reflect incomplete coverage: "With fixes (note: style review did not run)"
+
+## Severity Definitions
+
+- **Critical:** bugs, security issues, data loss risks, broken functionality — must fix before submitting
+- **Important:** architecture problems, missing features, poor error handling, test gaps — should fix
+- **Minor:** code style, optimization opportunities, documentation improvements — nice to have
+
+## Verdict Guidelines
+
+- **Yes:** No Critical or Important issues. Minor issues only.
+- **With fixes:** Important issues that should be addressed. No Critical issues, or Critical issues with straightforward fixes.
+- **No:** Critical issues that indicate fundamental problems. Significant rework needed.
+
+## Critical Rules
+
+- **Don't add new findings.** Your job is to merge and organize, not to review code yourself.
+- **Don't inflate severity.** If a phase marked something Minor, don't upgrade it to Important just because two phases caught it.
+- **Don't lose findings.** Every issue from every phase report must appear in the consolidated output.
+- **Keep it scannable.** Engineers should be able to read the Critical section first and know exactly what must be fixed.
+- **Every finding needs an ID.** No finding should appear without a structured ID.

--- a/.cursor/code-reviewer/skills/doc-update/SKILL.md
+++ b/.cursor/code-reviewer/skills/doc-update/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: doc-update
+description: Use when considering whether review findings or engineer responses suggest the project's living reference docs need updating. Proposes changes explicitly and requires engineer confirmation before writing.
+---
+
+# Doc Update — Living Documentation Maintenance
+
+## Purpose
+
+After a review is complete and the engineer has responded to findings, consider whether the reference docs need updating. This skill guides the judgment about when to propose changes and how to apply them.
+
+## When to Use
+
+- **DO:** Use after the engineer has responded to review findings or open questions
+- **DO NOT:** Use during the review itself — this is a post-review step
+- **DO NOT:** Make any doc changes without explicit engineer confirmation
+
+## Guidance for When to Propose Updates
+
+Use your judgment. These are examples of the kind of situations that warrant asking, not an exhaustive checklist:
+
+- The engineer confirms code is correct but it contradicts a reference doc
+- The engineer pushes back on a finding and the pushback is valid — the doc may be outdated
+- A pattern appears in the code that isn't documented at all — worth capturing
+- A documented convention is consistently not followed across the diff — may be outdated
+- The engineer explicitly says "we do it this way now" or similar
+
+When in doubt, ask. The cost of asking is low; the cost of stale docs is high.
+
+## How to Propose Changes
+
+For each potential update, ask the engineer explicitly:
+
+> "You confirmed that [specific thing]. The current [doc name] says [current rule]. Should I update it to reflect [proposed change]?"
+
+Or for new conventions:
+
+> "I noticed [pattern] consistently in this diff but it's not in the [doc name]. Should I add it?"
+
+## Engineer Responses
+
+- **Approve:** Update the doc with the change. Add a changelog entry.
+- **Refine:** The engineer adjusts your proposed wording. Use their version. Add a changelog entry.
+- **Decline:** "This was a one-off exception." Do not change the doc.
+
+## Applying Updates
+
+When updating a reference doc:
+
+1. Read the current doc from `.cursor/code-reviewer/reference/`
+2. Make the specific change (add, modify, or remove the convention)
+3. Add a changelog entry:
+
+| Date | Change | Trigger |
+|------|--------|---------|
+| {today} | {what changed} | Review feedback on {branch_name} |
+
+4. Do NOT rewrite or reorganize the rest of the doc — only change what was approved
+
+## Critical Rules
+
+- **Never update silently.** Every change requires explicit engineer confirmation.
+- **Never rewrite docs wholesale.** Make targeted changes only.
+- **Preserve the changelog.** Always append, never clear.
+- **One question per convention.** Don't batch multiple potential updates into a single question.

--- a/.cursor/code-reviewer/skills/triage/SKILL.md
+++ b/.cursor/code-reviewer/skills/triage/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: triage
+description: Use when analyzing a git diff to build structured review briefs for subagents. Reads the diff, project config, and reference docs, then groups changes into review units and produces briefs using the review-brief template.
+---
+
+# Triage — Diff Analysis & Context Builder
+
+## Purpose
+
+Analyze the current git diff and produce structured review briefs that subagents can act on without needing to re-analyze the raw diff themselves. This skill runs in the main context (not as a subagent).
+
+## When to Use
+
+- **DO:** Use at the start of every `/code-reviewer:review` (or `/review`) or phase-specific review invocation, after the setup guard passes
+- **DO NOT:** Use as a standalone review — this produces briefs, not findings
+
+## Setup Guard
+
+Before doing any analysis, check that both exist:
+1. `.cursor/code-reviewer/config.md` (project config)
+2. `.cursor/code-reviewer/reference/` directory with at least one reference doc
+
+If either is missing, stop and tell the user:
+> "No project configuration found. Run `/code-reviewer:setup` first to analyze your codebase and generate reference docs."
+
+## Workflow
+
+### Step 1: Capture the Diff
+
+1. Read `.cursor/code-reviewer/config.md` to get `base_branch` (default: auto-detect `main` or `master`)
+2. Run `git diff {base_branch}...HEAD --stat` to get the file list and change summary
+3. Run `git diff {base_branch}...HEAD` to get the full diff
+4. Run `git log {base_branch}..HEAD --oneline` to get commit messages
+5. If there are no changes, tell the user: "No changes found between current branch and {base_branch}."
+
+### Step 2: Load Context
+
+1. Read `.cursor/code-reviewer/config.md` — parse YAML frontmatter for config, read markdown body for project context
+2. Read all reference docs from `.cursor/code-reviewer/reference/`:
+   - `style-guide.md`
+   - `testing-practices.md`
+   - `security-posture.md` (if exists)
+   - `api-conventions.md` (if exists)
+3. Note which reference docs exist — not all projects will have all four
+
+### Step 3: Group into Review Units
+
+Using your judgment based on the diff, config, and project context:
+- Group changed files into logical **review units** (e.g., by language, domain area, directory)
+- Small diffs (< ~10 files) may be a single unit
+- Large diffs should be split so each unit is a coherent, reviewable chunk
+- Consider the `languages` and `key_paths` config fields as hints, but use your judgment
+
+For very large diffs (50+ files or very extensive changes), warn the user:
+> "This diff is very large ({N} files changed). I'll split it into {M} review units. For faster feedback, consider reviewing in smaller batches by committing incrementally."
+
+### Step 4: Produce Review Briefs
+
+For each review unit, fill in the `.cursor/code-reviewer/templates/review-brief.md` template:
+- Summarize what changed and infer why from commit messages and code context
+- List all files in the unit with their change type (added/modified/deleted)
+- Include relevant excerpts from reference docs (not the full docs — only sections relevant to this unit's files and changes)
+- Summarize what else changed in other units (cross-unit context)
+- Include the actual diff content for this unit's files
+
+### Step 5: Produce Full-Scope Brief
+
+Create an additional brief for the adversarial reviewer that contains:
+- The complete change overview across all units
+- All commit messages
+- All reference doc excerpts (not just unit-scoped)
+- Cross-unit dependency map (which units might affect each other)
+- The full diff (or, for very large diffs, the diff with context-relevant surrounding code)
+
+## Output
+
+Return:
+1. A list of review units with their briefs (for style and testing reviewers)
+2. The full-scope brief (for the adversarial reviewer)
+3. Metadata: branch name, base branch, total files changed, review unit count
+
+## Quality Standards
+
+- Every brief must be self-contained — a subagent should understand the change without reading additional files (though it can if needed)
+- Reference doc excerpts should be relevant, not exhaustive — don't paste the entire style guide into every brief
+- Cross-unit context should be concise — one sentence per other unit, not their full briefs
+- File lists must use exact paths as they appear in the diff

--- a/.cursor/code-reviewer/templates/phase-report.md
+++ b/.cursor/code-reviewer/templates/phase-report.md
@@ -1,0 +1,33 @@
+# {Phase Name} Review Report
+
+## Review Unit: {unit_name}
+
+### Strengths
+[Specific, with file:line references]
+
+### Issues
+
+#### Critical
+- **{PREFIX}-{N}** [{Sub-category}] `file:line` — description — why it matters — how to fix
+
+#### Important
+- **{PREFIX}-{N}** [{Sub-category}] `file:line` — description — why it matters — how to fix
+
+#### Minor
+- **{PREFIX}-{N}** [{Sub-category}] `file:line` — description — why it matters — how to fix
+
+### Improvements
+- **IMP-{N}** `file:line` — description
+
+### Open Questions
+[Things where the reviewer needs engineer input — genuinely uncertain about intent]
+
+---
+
+## ID Prefixes by Phase
+
+| Phase | Finding Prefix | Improvement Prefix |
+|-------|---------------|-------------------|
+| Adversarial | `BUG-N`, `SEC-N` | `IMP-N` |
+| Style | `STY-N` | `IMP-N` |
+| Testing | `TST-N` | `IMP-N` |

--- a/.cursor/code-reviewer/templates/review-brief.md
+++ b/.cursor/code-reviewer/templates/review-brief.md
@@ -1,0 +1,26 @@
+# Review Brief
+
+## Change Overview
+- **Branch:** {branch_name} (vs. {base_branch})
+- **Scope:** {num_files} files changed ({insertions}+, {deletions}-)
+- **Change type:** {feature|bugfix|refactor|docs|test|config}
+
+## Review Unit: {unit_name}
+
+### What Changed
+{summary_of_changes}
+
+### Files in This Unit
+{file_list_with_change_type}
+
+### Commit Messages
+{relevant_commit_messages}
+
+### Relevant Reference Doc Excerpts
+{excerpts_from_style_guide_testing_practices_etc}
+
+### Cross-Unit Context
+{summary_of_changes_in_other_units}
+
+## Full Diff for This Unit
+{diff_content}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,11 @@ _output
 
 # Do not commit any compiled Ansible filter plugins
 *.pyc
+
+# Claude Code and Cursor — ignore all local files except code-reviewer docs (which are intentionally committed)
+.claude/*
+!.claude/code-reviewer/
+!.claude/code-reviewer/**
+.cursor/*
+!.cursor/code-reviewer/
+!.cursor/code-reviewer/**


### PR DESCRIPTION
This onboards the project for use with the code-reviewer plugin (/code-reviewer:setup).

Now you can review code with /code-reviewer:review in both Claude and Cursor.

code reviewer plugin is currently here: https://github.com/openshift-service-mesh/ci-utils/tree/main/plugins/code-reviewer