### PR TITLE
Add kiali_feature_flags.authz.require_namespace_get config option

### DIFF
--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -170,6 +170,9 @@ jobs:
       with:
         node-version: '24'
 
+    - name: Enable corepack for Yarn 4
+      run: corepack enable
+
     - name: Free Disk Space
       run: |
         echo "=== Disk space before cleanup ==="

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -481,7 +481,6 @@ spec:
 
   kiali_feature_flags:
     authz:
-      # default: require_namespace_get is false
       require_namespace_get: false
     clustering:
       enable_exec_provider: false

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -480,6 +480,9 @@ spec:
     version_label_name: ""
 
   kiali_feature_flags:
+    authz:
+      # default: require_namespace_get is false
+      require_namespace_get: false
     clustering:
       enable_exec_provider: false
     # default: custom_workload_types is an empty list

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1730,6 +1730,17 @@ spec:
                 description: "Kiali features that can be enabled or disabled."
                 type: object
                 properties:
+                  authz:
+                    description: "Authorization-related feature flags."
+                    type: object
+                    properties:
+                      require_namespace_get:
+                        description: |
+                          When true, a user must have GET permission on a namespace for it to be visible,
+                          even if the user has LIST permission. When false (the default), a successful LIST
+                          is trusted without per-namespace GET checks. Enable this in multi-tenant environments
+                          where LIST permission is granted broadly but GET is restricted per namespace.
+                        type: boolean
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1741,6 +1741,7 @@ spec:
                           is trusted without per-namespace GET checks. Enable this in multi-tenant environments
                           where LIST permission is granted broadly but GET is restricted per namespace.
                         type: boolean
+                        default: false
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1730,6 +1730,17 @@ spec:
                 description: "Kiali features that can be enabled or disabled."
                 type: object
                 properties:
+                  authz:
+                    description: "Authorization-related feature flags."
+                    type: object
+                    properties:
+                      require_namespace_get:
+                        description: |
+                          When true, a user must have GET permission on a namespace for it to be visible,
+                          even if the user has LIST permission. When false (the default), a successful LIST
+                          is trusted without per-namespace GET checks. Enable this in multi-tenant environments
+                          where LIST permission is granted broadly but GET is restricted per namespace.
+                        type: boolean
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1741,6 +1741,7 @@ spec:
                           is trusted without per-namespace GET checks. Enable this in multi-tenant environments
                           where LIST permission is granted broadly but GET is restricted per namespace.
                         type: boolean
+                        default: false
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/manifests/kiali-upstream/2.25.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.25.0/manifests/kiali.crd.yaml
@@ -1730,6 +1730,17 @@ spec:
                 description: "Kiali features that can be enabled or disabled."
                 type: object
                 properties:
+                  authz:
+                    description: "Authorization-related feature flags."
+                    type: object
+                    properties:
+                      require_namespace_get:
+                        description: |
+                          When true, a user must have GET permission on a namespace for it to be visible,
+                          even if the user has LIST permission. When false (the default), a successful LIST
+                          is trusted without per-namespace GET checks. Enable this in multi-tenant environments
+                          where LIST permission is granted broadly but GET is restricted per namespace.
+                        type: boolean
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/manifests/kiali-upstream/2.25.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.25.0/manifests/kiali.crd.yaml
@@ -1741,6 +1741,7 @@ spec:
                           is trusted without per-namespace GET checks. Enable this in multi-tenant environments
                           where LIST permission is granted broadly but GET is restricted per namespace.
                         type: boolean
+                        default: false
                   certificates_information_indicators:
                     description: "DEPRECATED AFTER v1.73: Settings for certificate information indicators."
                     type: object

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -315,6 +315,8 @@ kiali_defaults:
     version_label_name: ""
 
   kiali_feature_flags:
+    authz:
+      require_namespace_get: false
     clustering:
       enable_exec_provider: false
     custom_workload_types: []


### PR DESCRIPTION
Part-of: https://github.com/kiali/kiali/issues/7125

## Summary
- Adds a new `kiali_feature_flags.authz.require_namespace_get` configuration option
- When enabled, Kiali requires GET permission on each namespace for it to be visible, even if the user has LIST permission
- Supports multi-tenant environments where LIST is granted broadly but GET is restricted per namespace
- Defaults to `false` to preserve backward compatibility
- Updates CRD golden copy, synced CRD copies, example CR, and operator defaults

Made with [Cursor](https://cursor.com)