### PR TITLE
Add PodDisruptionBudget support to the Kiali operator

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -234,6 +234,11 @@ spec:
     # default: pod_annotations is empty
     pod_annotations:
       proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+    pod_disruption_budget:
+      api_version: ""
+      # default: spec is empty
+      spec:
+        minAvailable: 1
     # default: pod_labels is empty
     pod_labels:
       sidecar.istio.io/inject: "true"

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -809,6 +809,27 @@ spec:
                     type: object
                     additionalProperties:
                       type: string
+                  pod_disruption_budget:
+                    description: |
+                      Determines what (if any) PodDisruptionBudget should be created for the Kiali pod.
+                      A typical way to configure PDB for Kiali is,
+                      ```
+                      spec:
+                        deployment:
+                          pod_disruption_budget:
+                            api_version: "policy/v1"
+                            spec:
+                              minAvailable: 1
+                      ```
+                    type: object
+                    properties:
+                      api_version:
+                        description: "A specific PDB API version that can be specified in case there is some PDB feature you want to use that is only supported in that specific version. If value is an empty string, the default version of 'policy/v1' will be used."
+                        type: string
+                      spec:
+                        description: "The `spec` specified here will be placed in the created PDB resource's 'spec' section. If `spec` is left empty, no PDB resource will be created. Note that you must not specify the 'selector' section in `spec`; the Kiali Operator will populate that for you."
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                   pod_labels:
                     description: |
                       Custom labels to be created on the Kiali pod.

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -477,6 +477,17 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["policy"]
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups: ["monitoring.coreos.com"]
           resources:
           - servicemonitors

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -809,6 +809,27 @@ spec:
                     type: object
                     additionalProperties:
                       type: string
+                  pod_disruption_budget:
+                    description: |
+                      Determines what (if any) PodDisruptionBudget should be created for the Kiali pod.
+                      A typical way to configure PDB for Kiali is,
+                      ```
+                      spec:
+                        deployment:
+                          pod_disruption_budget:
+                            api_version: "policy/v1"
+                            spec:
+                              minAvailable: 1
+                      ```
+                    type: object
+                    properties:
+                      api_version:
+                        description: "A specific PDB API version that can be specified in case there is some PDB feature you want to use that is only supported in that specific version. If value is an empty string, the default version of 'policy/v1' will be used."
+                        type: string
+                      spec:
+                        description: "The `spec` specified here will be placed in the created PDB resource's 'spec' section. If `spec` is left empty, no PDB resource will be created. Note that you must not specify the 'selector' section in `spec`; the Kiali Operator will populate that for you."
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                   pod_labels:
                     description: |
                       Custom labels to be created on the Kiali pod.

--- a/manifests/kiali-upstream/2.26.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.26.0/manifests/kiali.crd.yaml
@@ -809,6 +809,27 @@ spec:
                     type: object
                     additionalProperties:
                       type: string
+                  pod_disruption_budget:
+                    description: |
+                      Determines what (if any) PodDisruptionBudget should be created for the Kiali pod.
+                      A typical way to configure PDB for Kiali is,
+                      ```
+                      spec:
+                        deployment:
+                          pod_disruption_budget:
+                            api_version: "policy/v1"
+                            spec:
+                              minAvailable: 1
+                      ```
+                    type: object
+                    properties:
+                      api_version:
+                        description: "A specific PDB API version that can be specified in case there is some PDB feature you want to use that is only supported in that specific version. If value is an empty string, the default version of 'policy/v1' will be used."
+                        type: string
+                      spec:
+                        description: "The `spec` specified here will be placed in the created PDB resource's 'spec' section. If `spec` is left empty, no PDB resource will be created. Note that you must not specify the 'selector' section in `spec`; the Kiali Operator will populate that for you."
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
                   pod_labels:
                     description: |
                       Custom labels to be created on the Kiali pod.

--- a/manifests/kiali-upstream/2.26.0/manifests/kiali.v2.26.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.26.0/manifests/kiali.v2.26.0.clusterserviceversion.yaml
@@ -362,6 +362,17 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: ["policy"]
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups: ["monitoring.coreos.com"]
           resources:
           - servicemonitors

--- a/molecule/affinity-tolerations-resources-test/converge.yml
+++ b/molecule/affinity-tolerations-resources-test/converge.yml
@@ -73,6 +73,9 @@
         spec:
           minReplicas: 2
           maxReplicas: 2
+      new_pdb:
+        spec:
+          minAvailable: 1
       new_ingress_labels:
         aaa: bbb
         camelCaseName: camelCaseValue
@@ -176,6 +179,21 @@
       - hpa_resource_raw.resources | length == 1
       fail_msg: "HPA was not created successfully: {{ hpa_resource_raw }}"
 
+  - name: Get the PDB resource that should now exist
+    k8s_info:
+      api_version: policy/v1
+      kind: PodDisruptionBudget
+      namespace: "{{ kiali.install_namespace }}"
+      name: kiali
+    register: pdb_resource_raw
+  - name: Assert the PDB resource has been created
+    assert:
+      that:
+      - pdb_resource_raw.resources is defined
+      - pdb_resource_raw.resources | length == 1
+      - pdb_resource_raw.resources[0].spec.minAvailable == 1
+      fail_msg: "PDB was not created successfully: {{ pdb_resource_raw }}"
+
   - name: Wait until the Kiali deployment is up to date with the HPA replicas
     k8s_info:
       api_version: apps/v1
@@ -209,6 +227,7 @@
       new_service_annotations: null
       new_pod_labels: null
       new_hpa: null
+      new_pdb: null
       new_ingress_labels: null
       new_topology_spread_constraints: null
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
@@ -249,6 +268,20 @@
       - hpa_resource_raw.resources is defined
       - hpa_resource_raw.resources | length == 0
       fail_msg: "HPA was not deleted successfully: {{ hpa_resource_raw }} [kiali CR={{ kiali_cr }}]"
+
+  - name: Try to obtain the PDB which should have been removed
+    k8s_info:
+      api_version: policy/v1
+      kind: PodDisruptionBudget
+      namespace: "{{ kiali.install_namespace }}"
+      name: kiali
+    register: pdb_resource_raw
+  - name: Assert the PDB resource has been removed
+    assert:
+      that:
+      - pdb_resource_raw.resources is defined
+      - pdb_resource_raw.resources | length == 0
+      fail_msg: "PDB was not deleted successfully: {{ pdb_resource_raw }} [kiali CR={{ kiali_cr }}]"
 
   - name: Assert that replicas takes effect (there is no HPA defined anymore)
     assert:

--- a/molecule/affinity-tolerations-resources-test/set-affinity-tolerations-resources.yml
+++ b/molecule/affinity-tolerations-resources-test/set-affinity-tolerations-resources.yml
@@ -5,6 +5,6 @@
   vars:
     current_kiali_cr: "{{ kiali_cr_list.resources[0] }}"
   set_fact:
-    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'affinity': new_affinity, 'tolerations': new_tolerations, 'resources': new_resources, 'pod_annotations': new_pod_annotations, 'service_annotations': new_service_annotations, 'pod_labels': new_pod_labels, 'hpa': new_hpa, 'topology_spread_constraints': new_topology_spread_constraints, 'ingress': { 'additional_labels': new_ingress_labels }}}}, recursive=True) }}"
+    new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'deployment': {'affinity': new_affinity, 'tolerations': new_tolerations, 'resources': new_resources, 'pod_annotations': new_pod_annotations, 'service_annotations': new_service_annotations, 'pod_labels': new_pod_labels, 'hpa': new_hpa, 'pod_disruption_budget': new_pdb, 'topology_spread_constraints': new_topology_spread_constraints, 'ingress': { 'additional_labels': new_ingress_labels }}}}, recursive=True) }}"
 
 - import_tasks: ../common/set_kiali_cr.yml

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -109,6 +109,9 @@ kiali_defaults:
     node_selector: {}
     pod_annotations:
       proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+    pod_disruption_budget:
+      api_version: ""
+      spec: {}
     pod_labels: {}
     priority_class_name: ""
     probes:

--- a/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/default/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -15,6 +15,17 @@
   - is_k8s == True
   - kiali_vars.deployment.hpa.spec | length == 0
 
+- name: Remove PDB if disabled on Kubernetes
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.pod_disruption_budget.api_version }}"
+    kind: "PodDisruptionBudget"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.pod_disruption_budget.spec | length == 0
+
 - name: Create Kiali objects on Kubernetes
   include_tasks: process-resource.yml
   vars:
@@ -27,6 +38,7 @@
     - "{{ 'templates/kubernetes/deployment.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
     - "{{ 'templates/kubernetes/service.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
     - "{{ 'templates/kubernetes/hpa.yaml' if ((kiali_vars.deployment.hpa.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/kubernetes/pdb.yaml' if ((kiali_vars.deployment.pod_disruption_budget.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
     - "{{ 'templates/kubernetes/ingress.yaml' if ((kiali_vars.deployment.ingress.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
     - "{{ 'templates/kubernetes/networkpolicy.yaml' if ((kiali_vars.deployment.network_policy.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
   when:

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -271,6 +271,11 @@
       {% set kv = kv | combine({'deployment': {'hpa': {'api_version': autoscaling_api_version }}}, recursive=True) %}
       {% endif %}
 
+      {# Set default PDB api_version #}
+      {% if kv.deployment.pod_disruption_budget.api_version == "" %}
+      {% set kv = kv | combine({'deployment': {'pod_disruption_budget': {'api_version': 'policy/v1'}}}, recursive=True) %}
+      {% endif %}
+
       {# Provide some default resource limits #}
       {% if kv.deployment.resources is not defined %}
       {% set kv = kv | combine({'deployment': {'resources': resource_limits_default }}, recursive=True) %}

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -25,6 +25,17 @@
   - is_openshift == True
   - kiali_vars.deployment.hpa.spec | length == 0
 
+- name: Remove PDB if disabled on OpenShift
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.pod_disruption_budget.api_version }}"
+    kind: "PodDisruptionBudget"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.pod_disruption_budget.spec | length == 0
+
 - name: Create Kiali objects on OpenShift
   include_tasks: process-resource.yml
   vars:
@@ -40,6 +51,7 @@
     - "{{ 'templates/openshift/deployment.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
     - "{{ 'templates/openshift/service.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
     - "{{ 'templates/openshift/hpa.yaml' if ((kiali_vars.deployment.hpa.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/openshift/pdb.yaml' if ((kiali_vars.deployment.pod_disruption_budget.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
     - "{{ 'templates/openshift/route.yaml' if ((kiali_vars.deployment.ingress.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
     - "{{ 'templates/openshift/networkpolicy.yaml' if ((kiali_vars.deployment.network_policy.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
   when:

--- a/roles/default/kiali-deploy/tasks/snake_camel_case.yaml
+++ b/roles/default/kiali-deploy/tasks/snake_camel_case.yaml
@@ -83,6 +83,12 @@
       {%   set kiali_vars=kiali_vars | combine({'deployment': {'hpa': {'spec': current_cr.spec.deployment.hpa.spec }}}, recursive=True) %}
       {% endif %}
       {# #}
+      {# deployment.pod_disruption_budget.spec #}
+      {% if kiali_vars.deployment.pod_disruption_budget is defined and kiali_vars.deployment.pod_disruption_budget.spec is defined and kiali_vars.deployment.pod_disruption_budget.spec | length > 0 %}
+      {%   set _=kiali_vars['deployment']['pod_disruption_budget'].pop('spec') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'pod_disruption_budget': {'spec': current_cr.spec.deployment.pod_disruption_budget.spec }}}, recursive=True) %}
+      {% endif %}
+      {# #}
       {# deployment.node_selector #}
       {% if kiali_vars.deployment.node_selector is defined and kiali_vars.deployment.node_selector | length > 0 %}
       {%   set _=kiali_vars['deployment'].pop('node_selector') %}

--- a/roles/default/kiali-deploy/templates/kubernetes/pdb.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/pdb.yaml
@@ -1,0 +1,14 @@
+{% if kiali_vars.deployment.pod_disruption_budget.spec | length > 0 %}
+apiVersion: {{ kiali_vars.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  {{ kiali_vars.deployment.pod_disruption_budget.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}

--- a/roles/default/kiali-deploy/templates/openshift/pdb.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/pdb.yaml
@@ -1,0 +1,14 @@
+{% if kiali_vars.deployment.pod_disruption_budget.spec | length > 0 %}
+apiVersion: {{ kiali_vars.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  {{ kiali_vars.deployment.pod_disruption_budget.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}

--- a/roles/default/kiali-remove/defaults/main.yml
+++ b/roles/default/kiali-remove/defaults/main.yml
@@ -4,6 +4,8 @@ kiali_defaults_remove:
     hpa:
       api_version: ""
     instance_name: "kiali"
+    pod_disruption_budget:
+      api_version: ""
 
 # Will be auto-detected, but for debugging purposes you can force one of these to true
 is_k8s: false

--- a/roles/default/kiali-remove/tasks/main.yml
+++ b/roles/default/kiali-remove/tasks/main.yml
@@ -57,6 +57,13 @@
   when:
   - kiali_vars_remove.deployment.hpa.api_version == ""
 
+- name: Set default PDB api_version
+  ignore_errors: yes
+  set_fact:
+    kiali_vars_remove: "{{ kiali_vars_remove | combine({'deployment': {'pod_disruption_budget': {'api_version': 'policy/v1'}}}, recursive=True) }}"
+  when:
+  - kiali_vars_remove.deployment.pod_disruption_budget.api_version == ""
+
 # There is an edge case where a user installed Kiali with one instance name, then changed the instance name in the CR.
 # This is not allowed. When this happens, the operator will abort with an error message telling the user to uninstall Kiali.
 # The user will do this by deleting the Kiali CR, at which time this ansible role is executed.

--- a/roles/default/kiali-remove/tasks/resources-to-remove.yml
+++ b/roles/default/kiali-remove/tasks/resources-to-remove.yml
@@ -5,6 +5,12 @@ metadata:
   namespace: "{{ kiali_vars_remove.deployment.namespace }}"
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
+apiVersion: {{ kiali_vars_remove.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:


### PR DESCRIPTION
Add opt-in PodDisruptionBudget (PDB) support to the Kiali operator, mirroring the existing HorizontalPodAutoscaler pattern. Users can configure a PDB via the new `deployment.pod_disruption_budget` CR field, which accepts an `api_version` (defaults to "policy/v1" when left empty) and a `spec` passthrough. When `spec` is empty no PDB is created; when populated the operator creates, updates, and removes the PDB resource as part of the normal deploy and remove lifecycle.

Fixes: https://github.com/kiali/kiali/issues/9590