### PR TITLE
Add ability to enable/disable Prometheus via external_services.prometheus.enabled

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -404,6 +404,7 @@ spec:
       # default: custom_headers is empty
       custom_headers:
         customHeader1: "customHeader1Value"
+      enabled: true
       health_check_url: ""
       is_core: true
       # default: query_scope is empty

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1482,6 +1482,10 @@ spec:
                         type: object
                         additionalProperties:
                           type: string
+                      enabled:
+                        description: "When true, Kiali will connect to the Prometheus instance for Istio telemetry metrics. When false, Kiali will run without metrics support - the graph, health based on request rates, and metrics displays will be unavailable."
+                        type: boolean
+                        default: true
                       health_check_url:
                         description: "Used in the Components health feature. This is the url which Kiali will ping to determine whether the component is reachable or not. It defaults to `url` when not provided."
                         type: string

--- a/deploy/deploy-kiali-operator.sh
+++ b/deploy/deploy-kiali-operator.sh
@@ -206,7 +206,7 @@ while [[ $# -gt 0 ]]; do
       shift;shift
       ;;
     -hs|--helm-set)
-      HELM_SET_ARGS="${HELM_SET_ARGS:-} --set \"$2\""
+      HELM_SET_ARGS="${HELM_SET_ARGS:-} --set $2"
       shift;shift
       ;;
     -kcn|--kiali-cr-namespace)
@@ -264,7 +264,8 @@ while [[ $# -gt 0 ]]; do
       shift;shift
       ;;
     -own|--operator-watch-namespace)
-      OPERATOR_WATCH_NAMESPACE="$2"
+      # Strip surrounding quotes if the value is '""' (Makefile convention for empty string)
+      OPERATOR_WATCH_NAMESPACE="${2//\"/}"
       shift;shift
       ;;
     -v|--version)
@@ -460,7 +461,7 @@ export OPERATOR_IMAGE_VERSION="${OPERATOR_IMAGE_VERSION:-lastrelease}"
 export OPERATOR_INSTALL_KIALI=${OPERATOR_INSTALL_KIALI:-true}
 export OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-kiali-operator}"
 export OPERATOR_VIEW_ONLY_MODE="${OPERATOR_VIEW_ONLY_MODE:-false}"
-export OPERATOR_WATCH_NAMESPACE="${OPERATOR_WATCH_NAMESPACE:-\"\"}"
+export OPERATOR_WATCH_NAMESPACE="${OPERATOR_WATCH_NAMESPACE:-}"
 
 # Determine what tool to use to download files. This supports environments that have either wget or curl.
 # After return, $downloader will be a command to stream a URL's content to stdout.

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1482,6 +1482,10 @@ spec:
                         type: object
                         additionalProperties:
                           type: string
+                      enabled:
+                        description: "When true, Kiali will connect to the Prometheus instance for Istio telemetry metrics. When false, Kiali will run without metrics support - the graph, health based on request rates, and metrics displays will be unavailable."
+                        type: boolean
+                        default: true
                       health_check_url:
                         description: "Used in the Components health feature. This is the url which Kiali will ping to determine whether the component is reachable or not. It defaults to `url` when not provided."
                         type: string

--- a/manifests/kiali-upstream/2.26.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.26.0/manifests/kiali.crd.yaml
@@ -1482,6 +1482,10 @@ spec:
                         type: object
                         additionalProperties:
                           type: string
+                      enabled:
+                        description: "When true, Kiali will connect to the Prometheus instance for Istio telemetry metrics. When false, Kiali will run without metrics support - the graph, health based on request rates, and metrics displays will be unavailable."
+                        type: boolean
+                        default: true
                       health_check_url:
                         description: "Used in the Components health feature. This is the url which Kiali will ping to determine whether the component is reachable or not. It defaults to `url` when not provided."
                         type: string

--- a/molecule/config-values-test/converge.yml
+++ b/molecule/config-values-test/converge.yml
@@ -45,6 +45,11 @@
     when:
     - is_openshift == True
 
+  - name: Test that prometheus.enabled defaults to true in the ConfigMap
+    assert:
+      that:
+      - kiali_configmap.external_services.prometheus.enabled | bool == True
+
   - name: Test the default deployment.resources is what we expect
     vars:
       kiali_pod_spec: "{{ kiali_pod.resources[0].spec }}"

--- a/molecule/metrics-test/converge.yml
+++ b/molecule/metrics-test/converge.yml
@@ -175,11 +175,11 @@
       validate_certs: no
       status_code: 200
 
-  - name: Assert graph endpoint returns 503 when Prometheus is disabled
+  - name: Assert graph endpoint returns 200 with empty graph when Prometheus is disabled
     uri:
       url: "{{ kiali_base_url }}/api/namespaces/graph?namespaces={{ kiali.install_namespace }}&duration=60s"
       validate_certs: no
-      status_code: 503
+      status_code: 200
 
   - name: Get istio status with Prometheus disabled
     uri:

--- a/molecule/metrics-test/converge.yml
+++ b/molecule/metrics-test/converge.yml
@@ -82,3 +82,135 @@
   - assert:
       that:
       - prometheus_query_results.json.data.result | length > 0
+
+  # ==========================================================================
+  # Test: external_services.prometheus.enabled
+  # First verify baseline (enabled), then disable and verify behavior changes.
+  # ==========================================================================
+
+  # --- Baseline assertions (Prometheus enabled) ---
+
+  - name: Get /api/config (baseline)
+    uri:
+      url: "{{ kiali_base_url }}/api/config"
+      validate_certs: no
+      return_content: yes
+    register: config_response_baseline
+
+  - assert:
+      that:
+      - config_response_baseline.json.prometheus.enabled | bool == True
+
+  - name: Assert graph endpoint returns 200 (baseline)
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces/graph?namespaces={{ kiali.install_namespace }}&duration=60s"
+      validate_certs: no
+      status_code: 200
+
+  - name: Get istio status (baseline)
+    uri:
+      url: "{{ kiali_base_url }}/api/istio/status"
+      validate_certs: no
+      return_content: yes
+    register: istio_status_baseline
+
+  - name: Check Prometheus is reported as healthy (baseline)
+    set_fact:
+      prom_healthy_baseline: "{{ item.status }}"
+    loop: "{{ istio_status_baseline.json }}"
+    when: item.name == 'prometheus'
+
+  - assert:
+      that:
+      - prom_healthy_baseline is defined
+      - prom_healthy_baseline == 'Healthy'
+
+  - name: Get mesh graph (baseline)
+    uri:
+      url: "{{ kiali_base_url }}/api/mesh/graph"
+      validate_certs: no
+      return_content: yes
+    register: mesh_graph_baseline
+
+  - name: Check Prometheus node exists in mesh graph (baseline)
+    set_fact:
+      prom_node_found_baseline: true
+    loop: "{{ mesh_graph_baseline.json.elements.nodes | default([]) }}"
+    when: item.data.infraName is defined and item.data.infraName == 'Prometheus'
+
+  - assert:
+      that:
+      - prom_node_found_baseline is defined
+      - prom_node_found_baseline == true
+
+  # --- Disable Prometheus and re-verify ---
+
+  - name: Disable external_services.prometheus
+    vars:
+      current_kiali_cr: "{{ kiali_cr_list.resources[0] }}"
+    set_fact:
+      new_kiali_cr: "{{ current_kiali_cr | combine({'spec': {'external_services': {'prometheus': {'enabled': false}}}}, recursive=True) }}"
+
+  - import_tasks: ../common/set_kiali_cr.yml
+
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  - name: Assert /api/config shows prometheus.enabled is false
+    uri:
+      url: "{{ kiali_base_url }}/api/config"
+      validate_certs: no
+      return_content: yes
+    register: config_response_disabled
+
+  - assert:
+      that:
+      - config_response_disabled.json.prometheus.enabled | bool == False
+
+  - name: Assert non-metrics endpoint still works when Prometheus is disabled (graceful degradation)
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces"
+      validate_certs: no
+      status_code: 200
+
+  - name: Assert graph endpoint returns 503 when Prometheus is disabled
+    uri:
+      url: "{{ kiali_base_url }}/api/namespaces/graph?namespaces={{ kiali.install_namespace }}&duration=60s"
+      validate_certs: no
+      status_code: 503
+
+  - name: Get istio status with Prometheus disabled
+    uri:
+      url: "{{ kiali_base_url }}/api/istio/status"
+      validate_certs: no
+      return_content: yes
+    register: istio_status_disabled
+
+  - name: Check Prometheus is not reported as unhealthy
+    set_fact:
+      prom_unhealthy_disabled: true
+    loop: "{{ istio_status_disabled.json }}"
+    when: item.name == 'prometheus' and item.status != 'Healthy' and item.status != 'NotFound'
+
+  - assert:
+      that:
+      - prom_unhealthy_disabled is not defined
+
+  - name: Get mesh graph with Prometheus disabled
+    uri:
+      url: "{{ kiali_base_url }}/api/mesh/graph"
+      validate_certs: no
+      return_content: yes
+    register: mesh_graph_disabled
+
+  - name: Check Prometheus node is absent from mesh graph
+    set_fact:
+      prom_node_found_disabled: true
+    loop: "{{ mesh_graph_disabled.json.elements.nodes | default([]) }}"
+    when: item.data.infraName is defined and item.data.infraName == 'Prometheus'
+
+  - assert:
+      that:
+      - prom_node_found_disabled is not defined

--- a/molecule/metrics-test/molecule.yml
+++ b/molecule/metrics-test/molecule.yml
@@ -28,7 +28,7 @@ provisioner:
           spec_version: "{{ lookup('env', 'MOLECULE_KIALI_CR_SPEC_VERSION') | default('default', True) }}"
           install_namespace: istio-system
           cluster_wide_access: true
-          auth_strategy: token
+          auth_strategy: anonymous
           operator_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}" # if external operator, assume operator is in OLM location
           operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
           operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -257,6 +257,7 @@ kiali_defaults:
       cache_enabled: true
       cache_expiration: 300
       custom_headers: {}
+      enabled: true
       health_check_url: ""
       is_core: true
       query_scope: {}

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -262,7 +262,7 @@
       {% endif %}
 
       {# Set default Prometheus URL #}
-      {% if kv.external_services.prometheus.url == "" %}
+      {% if kv.external_services.prometheus.enabled|bool == True and kv.external_services.prometheus.url == "" %}
       {% set kv = kv | combine({'external_services': {'prometheus': {'url': 'http://prometheus.' + kv.deployment.namespace + ':9090'}}}, recursive=True) %}
       {% endif %}
 
@@ -634,27 +634,27 @@
       {% set d = {} %}
 
       {# Prepare the secret volume for prometheus username #}
-      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.username | default('')) | regex_search('secret:.+:.+') %}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.username | default('')) | regex_search('secret:.+:.+') %}
       {% set d = d | combine({'prometheus-username': {'secret_name': kiali_vars.external_services.prometheus.auth.username | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.username | regex_replace('secret:.+:(.+)', '\\1') }}) %}
       {% endif %}
 
       {# Prepare the secret volume for prometheus password #}
-      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.password | default('')) | regex_search('secret:.+:.+') %}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.password | default('')) | regex_search('secret:.+:.+') %}
       {% set d = d | combine({'prometheus-password': {'secret_name': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) %}
       {% endif %}
 
       {# Prepare the secret volume for prometheus token #}
-      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.token | default('')) | regex_search('secret:.+:.+') %}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.token | default('')) | regex_search('secret:.+:.+') %}
       {% set d = d | combine({'prometheus-token': {'secret_name': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) %}
       {% endif %}
 
       {# Prepare the secret volume for prometheus cert_file #}
-      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.cert_file | default('')) | regex_search('secret:.+:.+') %}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.cert_file | default('')) | regex_search('secret:.+:.+') %}
       {% set d = d | combine({'prometheus-cert': {'secret_name': kiali_vars.external_services.prometheus.auth.cert_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.prometheus.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
       {% endif %}
 
       {# Prepare the secret volume for prometheus key_file #}
-      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.key_file | default('')) | regex_search('secret:.+:.+') %}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.key_file | default('')) | regex_search('secret:.+:.+') %}
       {% set d = d | combine({'prometheus-key': {'secret_name': kiali_vars.external_services.prometheus.auth.key_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.key_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.prometheus.auth.key_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
       {% endif %}
 


### PR DESCRIPTION
Introduce a new `external_services.prometheus.enabled` configuration field (default true) that allows Kiali to run without a Prometheus metrics store. When disabled, a no-op Prometheus client is injected so the server starts without a Prometheus connection. Metrics-dependent features degrade gracefully: the graph page and mini-graph cards show an empty state with an explanation, health badges fall back to Kubernetes-only replica status, metrics and traffic tabs are hidden from detail pages, mesh target panels display a disabled message, and MCP/AI metric tools return an informative error. Non-metrics features (workload/service/app listing, Istio config, mesh topology, logs, traces) continue to work normally.

Changes span the Kiali server (config, noop client, handler guards, mesh generator, addon status, version probe), operator (CRD schema, defaults, conditional URL defaulting and secret mounts), Helm charts (credential gating, values, template tests), frontend (config type, empty states, tab hiding, test data), molecule tests (baseline and disabled assertions in metrics-test and config-values-test), and kiali.io documentation.

Part of: https://github.com/kiali/kiali/issues/8654