### PR TITLE
Deprecate obsolete istio_labels fields

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -480,10 +480,6 @@ spec:
 
   istio_labels:
     app_label_name: ""
-    egress_gateway_label: "istio=egressgateway"
-    ingress_gateway_label: "istio=ingressgateway"
-    injection_label_name: "istio-injection"
-    injection_label_rev: "istio.io/rev"
     version_label_name: ""
 
   kiali_feature_flags:

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -1736,21 +1736,17 @@ spec:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string
                   egress_gateway_label:
-                    description: "The selector label for Egress Gateway workload. This is typically `istio=egressgateway`."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored."
                     type: string
-                    default: "istio=egressgateway"
                   ingress_gateway_label:
-                    description: "The selector label for Ingress Gateway workload. This is typically `istio=ingressgateway`."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored."
                     type: string
-                    default: "istio=ingressgateway"
                   injection_label_name:
-                    description: "The name of the label used to instruct Istio to automatically inject sidecar proxies when applications are deployed."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored. The injection label name is now hardcoded to the standard value."
                     type: string
-                    default: "istio-injection"
                   injection_label_rev:
-                    description: "The label used to identify the Istio revision."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored. The injection label revision is now hardcoded to the standard value."
                     type: string
-                    default: "istio.io/rev"
                   version_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the version label name being used. This is typically `version` or `app.kubernetes.io/version`. The default is unset, and Kiali will handle mixed schemes."
                     type: string

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -1736,21 +1736,17 @@ spec:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string
                   egress_gateway_label:
-                    description: "The selector label for Egress Gateway workload. This is typically `istio=egressgateway`."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored."
                     type: string
-                    default: "istio=egressgateway"
                   ingress_gateway_label:
-                    description: "The selector label for Ingress Gateway workload. This is typically `istio=ingressgateway`."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored."
                     type: string
-                    default: "istio=ingressgateway"
                   injection_label_name:
-                    description: "The name of the label used to instruct Istio to automatically inject sidecar proxies when applications are deployed."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored. The injection label name is now hardcoded to the standard value."
                     type: string
-                    default: "istio-injection"
                   injection_label_rev:
-                    description: "The label used to identify the Istio revision."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored. The injection label revision is now hardcoded to the standard value."
                     type: string
-                    default: "istio.io/rev"
                   version_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the version label name being used. This is typically `version` or `app.kubernetes.io/version`. The default is unset, and Kiali will handle mixed schemes."
                     type: string

--- a/manifests/kiali-upstream/2.27.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.27.0/manifests/kiali.crd.yaml
@@ -1736,21 +1736,17 @@ spec:
                     description: "If using a single scheme for app/version labeling, set this to the app label name being used. This is typically `app` or `app.kubernetes.io/name`. The default is unset, and Kiali will handle mixed schemes."
                     type: string
                   egress_gateway_label:
-                    description: "The selector label for Egress Gateway workload. This is typically `istio=egressgateway`."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored."
                     type: string
-                    default: "istio=egressgateway"
                   ingress_gateway_label:
-                    description: "The selector label for Ingress Gateway workload. This is typically `istio=ingressgateway`."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored."
                     type: string
-                    default: "istio=ingressgateway"
                   injection_label_name:
-                    description: "The name of the label used to instruct Istio to automatically inject sidecar proxies when applications are deployed."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored. The injection label name is now hardcoded to the standard value."
                     type: string
-                    default: "istio-injection"
                   injection_label_rev:
-                    description: "The label used to identify the Istio revision."
+                    description: "DEPRECATED AFTER v2.27: This setting is deprecated and will be ignored. The injection label revision is now hardcoded to the standard value."
                     type: string
-                    default: "istio.io/rev"
                   version_label_name:
                     description: "If using a single scheme for app/version labeling, set this to the version label name being used. This is typically `version` or `app.kubernetes.io/version`. The default is unset, and Kiali will handle mixed schemes."
                     type: string

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -213,10 +213,6 @@ spec:
 
   istio_labels:
     app_label_name: "app.kubernetes.io/name"
-    egress_gateway_label: "istio=egressgateway"
-    ingress_gateway_label: "istio=ingressgateway"
-    injection_label_name: "istio-injection"
-    injection_label_rev: "istio.io/rev"
     version_label_name: "app.kubernetes.io/version"
 
   kiali_feature_flags:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -313,10 +313,6 @@ kiali_defaults:
 
   istio_labels:
     app_label_name: ""
-    egress_gateway_label: "istio=egressgateway"
-    ingress_gateway_label: "istio=ingressgateway"
-    injection_label_name: "istio-injection"
-    injection_label_rev: "istio.io/rev"
     version_label_name: ""
 
   kiali_feature_flags:


### PR DESCRIPTION
## Summary

- Deprecate `egress_gateway_label`, `ingress_gateway_label`, `injection_label_name`, and `injection_label_rev` in the CRD schema by marking their descriptions with `DEPRECATED AFTER v2.27`
- Remove these fields from operator defaults, sample CR, and molecule test CR
- After this change, only `app_label_name` and `version_label_name` remain as active `istio_labels` fields

## Context

Coordinated with [kiali/kiali#9690](https://github.com/kiali/kiali/pull/9690), which removes 10 fields from the `IstioLabels` Go struct and replaces them with constants. Of the removed fields, `injection_label_name` and `injection_label_rev` were in the CRD schema.

Additionally, `egress_gateway_label` and `ingress_gateway_label` were in the CRD but were never consumed by the Kiali server — they are dead config that should also be deprecated.

## CRD Safety

Existing user CRs that specify these fields will **not break**. The `istio_labels` CRD property uses `type: object` without `additionalProperties: false`, so Kubernetes silently accepts unknown/deprecated properties. The values will simply be ignored.

Made with [Cursor](https://cursor.com)