### PR TITLE
Enable i18n translation loading for OSSMC ConsolePlugin

### DIFF
--- a/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -5,6 +5,8 @@ metadata:
   labels: {{ ossmconsole_resource_metadata_labels }}
 spec:
   displayName: "OpenShift Service Mesh Console"
+  i18n:
+    loadType: Preload
   backend:
     service:
       name: ossmconsole


### PR DESCRIPTION
## Summary

- Add `spec.i18n.loadType: Preload` to the ConsolePlugin template so the OpenShift Console fetches and applies plugin translation files at load time.
- Without this field, navigation sidebar items rendered via the `%plugin__ossmconsole~...%` pattern remain in English even when the console locale is set to another language, because the console never fetches `locales/{lang}/plugin__ossmconsole.json`.

## Test plan

- [ ] Deploy OSSMC on an OpenShift cluster with the operator using this change
- [ ] Set the OpenShift Console language to Spanish (or another supported language)
- [ ] Verify that the "Service Mesh" navigation section and all its items (Overview, Traffic Graph, Mesh, Namespaces, Applications, Services, Workloads, Istio Config) are translated in the sidebar
- [ ] Verify that the "Service Mesh" tab on K8s resource pages (Deployments, Services, etc.) is also translated

Made with [Cursor](https://cursor.com)