### PR TITLE
update workflows

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         ref: ${{ github.event.inputs.tag_branch }}
 

--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -16,8 +16,12 @@ on:
         default: v2.22
         type: string
 
+permissions: read-all
+
 jobs:
   bump_version:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch

--- a/.github/workflows/check-helm-chart-pr.yml
+++ b/.github/workflows/check-helm-chart-pr.yml
@@ -6,8 +6,13 @@ on:
     paths:
       - 'crd-docs/crd/**'
 
+permissions: read-all
+
 jobs:
   validate-crd-sync:
+    permissions:
+      contents: read
+      pull-requests: read
     name: Validate CRD Synchronization with Helm Charts
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-helm-chart-pr.yml
+++ b/.github/workflows/check-helm-chart-pr.yml
@@ -54,7 +54,7 @@ jobs:
         echo "$helm_prs" | jq -r '.[] | "  - #\(.number): \(.title)"'
 
     - name: Check out helm-charts PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         repository: ${{ github.event.pull_request.head.repo.owner.login }}/helm-charts
         ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         # Fetch enough history to compare CRDs against base branch for backward compatibility check
         fetch-depth: 0
@@ -26,6 +26,8 @@ jobs:
         YQ_VERSION: v4.40.5
       run: |
         sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+        wget -qO /tmp/yq_checksums "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums"
+        echo "$(grep 'yq_linux_amd64' /tmp/yq_checksums | awk '{print $1}')  /usr/local/bin/yq" | sha256sum --check
         sudo chmod +x /usr/local/bin/yq
         make validate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
         wget -qO /tmp/yq_checksums "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums"
-        echo "$(grep 'yq_linux_amd64' /tmp/yq_checksums | awk '{print $1}')  /usr/local/bin/yq" | sha256sum --check
+        echo "$(grep '^yq_linux_amd64 ' /tmp/yq_checksums | awk '{print $19}')  /usr/local/bin/yq" | sha256sum --check
         sudo chmod +x /usr/local/bin/yq
         make validate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [master]
 
+permissions: read-all
+
 jobs:
   build:
+    permissions:
+      contents: read
     name: Build and Test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout kiali-operator source
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         path: kiali-operator
         fetch-depth: 0
@@ -146,18 +146,18 @@ jobs:
         echo "KIALI_OPERATOR_FORK=$KIALI_OPERATOR_FORK" >> $GITHUB_OUTPUT
 
     - name: Install Helm
-      uses: Azure/setup-helm@v4.3.1
+      uses: Azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
       with:
         version: 'v3.18.4'
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
       with:
         go-version: 'stable'
         cache: false
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
       with:
         node-version: '24'
 

--- a/.github/workflows/molecule-tests.yml
+++ b/.github/workflows/molecule-tests.yml
@@ -8,8 +8,12 @@ on:
       - 'roles/default/**'
       - '.github/workflows/molecule-tests.yml'
 
+permissions: read-all
+
 jobs:
   molecule-tests:
+    permissions:
+      contents: read
     name: Molecule Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,8 +17,12 @@ on:
         default: quay.io/kiali/kiali-operator
         required: true
 
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:
@@ -53,6 +57,8 @@ jobs:
         echo "Quay tag": ${{ steps.quay_tag.outputs.quay_tag }}
 
   push:
+    permissions:
+      contents: read
     name: Push latest
     # Avoid schedule workflows from forks to push images
     if: ${{ (github.event_name == 'schedule' && github.repository == 'kiali/kiali-operator') || github.event_name != 'schedule' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       quay_tag: ${{ steps.quay_tag.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -62,7 +62,7 @@ jobs:
       OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       quay_tag: ${{ steps.quay_tag.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 
@@ -199,7 +199,7 @@ jobs:
       OPERATOR_QUAY_TAG: ${{ needs.initialize.outputs.quay_tag }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,12 @@ on:
         default: quay.io/kiali/kiali-operator
         required: true
 
+permissions: read-all
+
 jobs:
   initialize:
+    permissions:
+      contents: read
     name: Initialize
     runs-on: ubuntu-latest
     outputs:
@@ -186,6 +190,9 @@ jobs:
         echo "Quay tag": ${{ steps.quay_tag.outputs.quay_tag }}
 
   release:
+    permissions:
+      contents: write
+      pull-requests: write
     name: Release
     if: ${{ needs.initialize.outputs.release_type != 'skip' && ((github.event_name == 'schedule' && github.repository == 'kiali/kiali-operator') || github.event_name != 'schedule') }}
     runs-on: ubuntu-latest

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -9,8 +9,12 @@ on:
         default: v2.22
         type: string
 
+permissions: read-all
+
 jobs:
   release_tag:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       with:
         ref: ${{ github.event.inputs.tag_branch }}
         # We need to fetch the full history to determine the latest tag

--- a/.github/workflows/verify-defaults.yml
+++ b/.github/workflows/verify-defaults.yml
@@ -42,7 +42,7 @@ jobs:
       run: |
         sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
         wget -qO /tmp/yq_checksums "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums"
-        echo "$(grep 'yq_linux_amd64' /tmp/yq_checksums | awk '{print $1}')  /usr/local/bin/yq" | sha256sum --check
+        echo "$(grep '^yq_linux_amd64 ' /tmp/yq_checksums | awk '{print $19}')  /usr/local/bin/yq" | sha256sum --check
         sudo chmod +x /usr/local/bin/yq
 
     - name: Verify CRD defaults match Ansible defaults

--- a/.github/workflows/verify-defaults.yml
+++ b/.github/workflows/verify-defaults.yml
@@ -34,13 +34,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
     - name: Install yq
       env:
         YQ_VERSION: v4.40.5
       run: |
         sudo wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+        wget -qO /tmp/yq_checksums "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/checksums"
+        echo "$(grep 'yq_linux_amd64' /tmp/yq_checksums | awk '{print $1}')  /usr/local/bin/yq" | sha256sum --check
         sudo chmod +x /usr/local/bin/yq
 
     - name: Verify CRD defaults match Ansible defaults

--- a/.github/workflows/verify-defaults.yml
+++ b/.github/workflows/verify-defaults.yml
@@ -28,8 +28,12 @@ on:
       # Makefile changes that might affect verification
       - 'Makefile'
 
+permissions: read-all
+
 jobs:
   verify-defaults:
+    permissions:
+      contents: read
     name: Verify CRD Defaults Match Ansible Defaults
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR hardens the GitHub Actions workflows against several known vulnerability classes.

**Supply chain risk (unpinned actions):** All third-party actions were using floating version tags (e.g. `@v4`, `@v5`). These are mutable references — a compromised action maintainer can silently retag them to malicious code that executes in CI with access to repository secrets. All action references have been pinned to their full immutable commit SHA, with the version tag retained as a comment.

**Unverified binary download (yq):** Multiple workflows downloaded the `yq` binary from GitHub releases and executed it without verifying a checksum. If the `mikefarah/yq` release infrastructure were compromised, a malicious binary would be executed with `sudo` privileges. Checksum verification has been added using the SHA-256 value from the official `checksums` file published alongside each release.

**Missing `permissions:` blocks:** None of the workflows declared explicit token permissions, meaning they inherited the repository default (typically broad write access). All workflows now declare `permissions: read-all` at the top level, with `contents: write` and/or `pull-requests: write` granted only to the specific jobs that actually need them (release, tag creation, version bumping).

Generated-by: Claude