### PR TITLE
OAuth2 client_credentials: fix validation gaps and harden test coverage

### DIFF
--- a/manifests/kiali-upstream/2.27.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.27.0/manifests/kiali.crd.yaml
@@ -1093,32 +1093,6 @@ spec:
                               key_file:
                                 description: "The client private key file to use when accessing Prometheus using https with mTLS. An empty string means no client private key is used. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the key is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                                 type: string
-                              oauth2:
-                                description: "Settings for OAuth2 client_credentials authentication. When auth.type is `oauth2`, these settings are used to obtain an access token."
-                                type: object
-                                properties:
-                                  audience:
-                                    description: "The audience parameter sent with the token request. Some providers require this to scope the token."
-                                    type: string
-                                  auth_style:
-                                    description: "How to send client credentials to the token endpoint. Use `params` to send in the request body or `header` to send as HTTP Basic Auth (default)."
-                                    type: string
-                                    default: "header"
-                                    enum: ["header", "params"]
-                                  client_id:
-                                    description: "The OAuth2 client ID (a public identifier per RFC 6749 §2.2)."
-                                    type: string
-                                  client_secret:
-                                    description: "The OAuth2 client secret. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the value is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
-                                    type: string
-                                  scopes:
-                                    description: "A list of scopes to request with the token."
-                                    type: array
-                                    items:
-                                      type: string
-                                  token_url:
-                                    description: "The URL of the OAuth2 token endpoint."
-                                    type: string
                               password:
                                 description: "Password to be used when making requests to Prometheus, for basic authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the password is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                                 type: string
@@ -1126,7 +1100,7 @@ spec:
                                 description: "Token / API key to access Prometheus, for token-based authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the token is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                                 type: string
                               type:
-                                description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Prometheus server. Use `basic` to connect with username and password credentials. Use `oauth2` to use OAuth2 client_credentials flow. Use `none` to not use any authentication."
+                                description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Prometheus server. Use `basic` to connect with username and password credentials. Use `none` to not use any authentication."
                                 type: string
                                 default: "none"
                               use_kiali_token:
@@ -1205,32 +1179,6 @@ spec:
                           key_file:
                             description: "The client private key file to use when accessing Grafana using https with mTLS. An empty string means no client private key is used. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the key is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
-                          oauth2:
-                            description: "Settings for OAuth2 client_credentials authentication. When auth.type is `oauth2`, these settings are used to obtain an access token."
-                            type: object
-                            properties:
-                              audience:
-                                description: "The audience parameter sent with the token request. Some providers require this to scope the token."
-                                type: string
-                              auth_style:
-                                description: "How to send client credentials to the token endpoint. Use `params` to send in the request body or `header` to send as HTTP Basic Auth (default)."
-                                type: string
-                                default: "header"
-                                enum: ["header", "params"]
-                              client_id:
-                                description: "The OAuth2 client ID (a public identifier per RFC 6749 §2.2)."
-                                type: string
-                              client_secret:
-                                description: "The OAuth2 client secret. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the value is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
-                                type: string
-                              scopes:
-                                description: "A list of scopes to request with the token."
-                                type: array
-                                items:
-                                  type: string
-                              token_url:
-                                description: "The URL of the OAuth2 token endpoint."
-                                type: string
                           password:
                             description: "Password to be used when making requests to Grafana, for basic authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the password is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
@@ -1238,7 +1186,7 @@ spec:
                             description: "Token / API key to access Grafana, for token-based authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the token is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
                           type:
-                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Grafana server. Use `basic` to connect with username and password credentials. Use `oauth2` to use OAuth2 client_credentials flow. Use `none` to not use any authentication."
+                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Grafana server. Use `basic` to connect with username and password credentials. Use `none` to not use any authentication."
                             type: string
                             default: "none"
                           use_kiali_token:
@@ -1444,37 +1392,11 @@ spec:
                           key_file:
                             description: "The client private key file to use when accessing Perses using https with mTLS. An empty string means no client private key is used. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the key is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
-                          oauth2:
-                            description: "Settings for OAuth2 client_credentials authentication. When auth.type is `oauth2`, these settings are used to obtain an access token."
-                            type: object
-                            properties:
-                              audience:
-                                description: "The audience parameter sent with the token request. Some providers require this to scope the token."
-                                type: string
-                              auth_style:
-                                description: "How to send client credentials to the token endpoint. Use `params` to send in the request body or `header` to send as HTTP Basic Auth (default)."
-                                type: string
-                                default: "header"
-                                enum: ["header", "params"]
-                              client_id:
-                                description: "The OAuth2 client ID (a public identifier per RFC 6749 §2.2)."
-                                type: string
-                              client_secret:
-                                description: "The OAuth2 client secret. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the value is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
-                                type: string
-                              scopes:
-                                description: "A list of scopes to request with the token."
-                                type: array
-                                items:
-                                  type: string
-                              token_url:
-                                description: "The URL of the OAuth2 token endpoint."
-                                type: string
                           password:
                             description: "Password to be used when making requests to Perses, for basic authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the password is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
                           type:
-                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Perses server. Use `basic` to connect with username and password credentials. Use `oauth2` to use OAuth2 client_credentials flow. Use `none` to not use any authentication."
+                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Perses server. Use `basic` to connect with username and password credentials. Use `none` to not use any authentication."
                             type: string
                             default: "none"
                           use_kiali_token:
@@ -1561,32 +1483,6 @@ spec:
                           key_file:
                             description: "The client private key file to use when accessing Prometheus using https with mTLS. An empty string means no client private key is used. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the key is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
-                          oauth2:
-                            description: "Settings for OAuth2 client_credentials authentication. When auth.type is `oauth2`, these settings are used to obtain an access token."
-                            type: object
-                            properties:
-                              audience:
-                                description: "The audience parameter sent with the token request. Some providers require this to scope the token."
-                                type: string
-                              auth_style:
-                                description: "How to send client credentials to the token endpoint. Use `params` to send in the request body or `header` to send as HTTP Basic Auth (default)."
-                                type: string
-                                default: "header"
-                                enum: ["header", "params"]
-                              client_id:
-                                description: "The OAuth2 client ID (a public identifier per RFC 6749 §2.2)."
-                                type: string
-                              client_secret:
-                                description: "The OAuth2 client secret. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the value is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
-                                type: string
-                              scopes:
-                                description: "A list of scopes to request with the token."
-                                type: array
-                                items:
-                                  type: string
-                              token_url:
-                                description: "The URL of the OAuth2 token endpoint."
-                                type: string
                           password:
                             description: "Password to be used when making requests to Prometheus, for basic authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the password is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
@@ -1594,7 +1490,7 @@ spec:
                             description: "Token / API key to access Prometheus, for token-based authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the token is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
                           type:
-                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Prometheus server. Use `basic` to connect with username and password credentials. Use `oauth2` to use OAuth2 client_credentials flow. Use `none` to not use any authentication (this is the default)."
+                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Prometheus server. Use `basic` to connect with username and password credentials. Use `none` to not use any authentication (this is the default)."
                             type: string
                             default: "none"
                           use_kiali_token:
@@ -1677,32 +1573,6 @@ spec:
                           key_file:
                             description: "The client private key file to use when accessing the Tracing server using https with mTLS. An empty string means no client private key is used. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the key is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
-                          oauth2:
-                            description: "Settings for OAuth2 client_credentials authentication. When auth.type is `oauth2`, these settings are used to obtain an access token."
-                            type: object
-                            properties:
-                              audience:
-                                description: "The audience parameter sent with the token request. Some providers require this to scope the token."
-                                type: string
-                              auth_style:
-                                description: "How to send client credentials to the token endpoint. Use `params` to send in the request body or `header` to send as HTTP Basic Auth (default)."
-                                type: string
-                                default: "header"
-                                enum: ["header", "params"]
-                              client_id:
-                                description: "The OAuth2 client ID (a public identifier per RFC 6749 §2.2)."
-                                type: string
-                              client_secret:
-                                description: "The OAuth2 client secret. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the value is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
-                                type: string
-                              scopes:
-                                description: "A list of scopes to request with the token."
-                                type: array
-                                items:
-                                  type: string
-                              token_url:
-                                description: "The URL of the OAuth2 token endpoint."
-                                type: string
                           password:
                             description: "Password to be used when making requests to the Tracing server, for basic authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the password is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
@@ -1710,7 +1580,7 @@ spec:
                             description: "Token / API key to access the Tracing server, for token-based authentication. May refer to a secret using the pattern `secret:<secretName>:<secretKey>`. When using a secret, the token is cached and automatically refreshed when the secret changes, enabling rotation without pod restart."
                             type: string
                           type:
-                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Tracing server. Use `basic` to connect with username and password credentials. Use `oauth2` to use OAuth2 client_credentials flow (only supported when use_grpc is false). Use `none` to not use any authentication (this is the default)."
+                            description: "The type of authentication to use when contacting the server. Use `bearer` to send the token to the Tracing server. Use `basic` to connect with username and password credentials. Use `none` to not use any authentication (this is the default)."
                             type: string
                             default: "none"
                           use_kiali_token:

--- a/molecule/config-values-test/converge.yml
+++ b/molecule/config-values-test/converge.yml
@@ -877,3 +877,40 @@
 
   - import_tasks: ../common/wait_for_kiali_cr_changes.yml
   - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../common/tasks.yml
+
+  - name: Assert prometheus oauth2 config is written to ConfigMap
+    assert:
+      that:
+      - kiali_configmap.external_services.prometheus.auth.type == 'oauth2'
+      - kiali_configmap.external_services.prometheus.auth.oauth2.client_id == 'test-client-id'
+      - kiali_configmap.external_services.prometheus.auth.oauth2.token_url == 'https://login.example.com/token'
+      fail_msg: "Expected prometheus auth.type=oauth2 in ConfigMap, got: {{ kiali_configmap.external_services.prometheus.auth }}"
+      success_msg: "Verified prometheus oauth2 config is correctly written to ConfigMap"
+
+  - name: Assert tracing oauth2 config is written to ConfigMap
+    assert:
+      that:
+      - kiali_configmap.external_services.tracing.auth.type == 'oauth2'
+      - kiali_configmap.external_services.tracing.auth.oauth2.client_id == 'test-client-id'
+      - kiali_configmap.external_services.tracing.auth.oauth2.token_url == 'https://login.example.com/token'
+      fail_msg: "Expected tracing auth.type=oauth2 in ConfigMap, got: {{ kiali_configmap.external_services.tracing.auth }}"
+      success_msg: "Verified tracing oauth2 config is correctly written to ConfigMap"
+
+  - name: Assert grafana oauth2 config is written to ConfigMap
+    assert:
+      that:
+      - kiali_configmap.external_services.grafana.auth.type == 'oauth2'
+      - kiali_configmap.external_services.grafana.auth.oauth2.client_id == 'test-grafana-client'
+      - kiali_configmap.external_services.grafana.auth.oauth2.token_url == 'https://login.example.com/token'
+      fail_msg: "Expected grafana auth.type=oauth2 in ConfigMap, got: {{ kiali_configmap.external_services.grafana.auth }}"
+      success_msg: "Verified grafana oauth2 config is correctly written to ConfigMap"
+
+  - name: Assert custom_dashboards prometheus oauth2 config is written to ConfigMap
+    assert:
+      that:
+      - kiali_configmap.external_services.custom_dashboards.prometheus.auth.type == 'oauth2'
+      - kiali_configmap.external_services.custom_dashboards.prometheus.auth.oauth2.client_id == 'test-cd-client'
+      - kiali_configmap.external_services.custom_dashboards.prometheus.auth.oauth2.token_url == 'https://login.example.com/token'
+      fail_msg: "Expected custom_dashboards.prometheus auth.type=oauth2 in ConfigMap, got: {{ kiali_configmap.external_services.custom_dashboards.prometheus.auth }}"
+      success_msg: "Verified custom_dashboards prometheus oauth2 config is correctly written to ConfigMap"

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -95,10 +95,23 @@ spec:
     custom_dashboards:
       discovery_auto_threshold: 10
       discovery_enabled: "auto"
-      enabled: false
+      enabled: true
       is_core: false
       namespace_label: "namespace"
+      prometheus:
+        auth:
+          type: oauth2
+          oauth2:
+            client_id: "test-cd-client"
+            client_secret: "test-cd-secret"
+            token_url: "https://login.example.com/token"
     grafana:
+      auth:
+        type: oauth2
+        oauth2:
+          client_id: "test-grafana-client"
+          client_secret: "test-grafana-secret"
+          token_url: "https://login.example.com/token"
       dashboards:
       - name: "Istio Service Dashboard"
         variables:
@@ -204,7 +217,7 @@ spec:
         org_id: "1"
         tenant: ""
         url_format: "grafana"
-      use_grpc: false
+      use_grpc: false # must be false when auth.type=oauth2 (oauth2 token injection is not implemented for gRPC transport)
       use_waypoint_name: false
       whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
 

--- a/roles/default/kiali-deploy/tasks/main.yml
+++ b/roles/default/kiali-deploy/tasks/main.yml
@@ -508,116 +508,44 @@
   - can_i_create_clusterrolebindings.result.status.allowed is defined
   - can_i_create_clusterrolebindings.result.status.allowed == False
 
-- name: Validate oauth2 auth config for prometheus
-  fail:
-    msg: "external_services.prometheus.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
-  when:
-  - kiali_vars.external_services.prometheus is defined
-  - kiali_vars.external_services.prometheus.auth is defined
-  - kiali_vars.external_services.prometheus.auth.type | default('') == 'oauth2'
-  - (kiali_vars.external_services.prometheus.auth.oauth2 is not defined) or
-    (kiali_vars.external_services.prometheus.auth.oauth2.client_id | default('') == '') or
-    (kiali_vars.external_services.prometheus.auth.oauth2.token_url | default('') == '')
+- name: Validate oauth2 auth configuration for all external services
+  vars:
+    oauth2_services:
+      - name: "prometheus"
+        svc: "{{ kiali_vars.external_services.prometheus }}"
+      - name: "tracing"
+        svc: "{{ kiali_vars.external_services.tracing }}"
+      - name: "grafana"
+        svc: "{{ kiali_vars.external_services.grafana }}"
+      - name: "perses"
+        svc: "{{ kiali_vars.external_services.perses }}"
+      - name: "custom_dashboards.prometheus"
+        svc: "{{ kiali_vars.external_services.custom_dashboards.prometheus }}"
+        enabled_override: "{{ kiali_vars.external_services.custom_dashboards.enabled | bool }}"
+    oauth2_error_msg: |
+      {% set errors = [] %}
+      {% for item in oauth2_services %}
+      {% set svc = item.svc %}
+      {% set enabled = item.enabled_override | default(svc.enabled) | bool %}
+      {% set is_oauth2 = enabled and (svc.auth.type | default('')) == 'oauth2' %}
+      {% if is_oauth2 %}
+      {% if (svc.auth.oauth2 is not defined) or (svc.auth.oauth2.client_id | default('') == '') or (svc.auth.oauth2.client_secret | default('') == '') or (svc.auth.oauth2.token_url | default('') == '') %}
+      {% set _ = errors.append('external_services.' ~ item.name ~ '.auth.oauth2 requires client_id, client_secret, and token_url when auth.type is oauth2') %}
+      {% elif svc.auth.use_kiali_token | default(False) | bool %}
+      {% set _ = errors.append('external_services.' ~ item.name ~ ' cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)') %}
+      {% elif 'use_grpc' in svc and svc.use_grpc | bool %}
+      {% set _ = errors.append('external_services.' ~ item.name ~ ' cannot use oauth2 auth with use_grpc=true (oauth2 token injection is not implemented for gRPC transport)') %}
+      {% endif %}
+      {% endif %}
+      {% endfor %}
+      {{ errors | join('; ') }}
+  set_fact:
+    oauth2_validation_error: "{{ oauth2_error_msg | trim }}"
 
-- name: Validate oauth2 auth config for tracing
+- name: Fail if oauth2 configuration is invalid
   fail:
-    msg: "external_services.tracing.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
-  when:
-  - kiali_vars.external_services.tracing is defined
-  - kiali_vars.external_services.tracing.auth is defined
-  - kiali_vars.external_services.tracing.auth.type | default('') == 'oauth2'
-  - (kiali_vars.external_services.tracing.auth.oauth2 is not defined) or
-    (kiali_vars.external_services.tracing.auth.oauth2.client_id | default('') == '') or
-    (kiali_vars.external_services.tracing.auth.oauth2.token_url | default('') == '')
-
-- name: Validate oauth2 auth config for grafana
-  fail:
-    msg: "external_services.grafana.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
-  when:
-  - kiali_vars.external_services.grafana is defined
-  - kiali_vars.external_services.grafana.auth is defined
-  - kiali_vars.external_services.grafana.auth.type | default('') == 'oauth2'
-  - (kiali_vars.external_services.grafana.auth.oauth2 is not defined) or
-    (kiali_vars.external_services.grafana.auth.oauth2.client_id | default('') == '') or
-    (kiali_vars.external_services.grafana.auth.oauth2.token_url | default('') == '')
-
-- name: Validate oauth2 auth config for perses
-  fail:
-    msg: "external_services.perses.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
-  when:
-  - kiali_vars.external_services.perses is defined
-  - kiali_vars.external_services.perses.auth is defined
-  - kiali_vars.external_services.perses.auth.type | default('') == 'oauth2'
-  - (kiali_vars.external_services.perses.auth.oauth2 is not defined) or
-    (kiali_vars.external_services.perses.auth.oauth2.client_id | default('') == '') or
-    (kiali_vars.external_services.perses.auth.oauth2.token_url | default('') == '')
-
-- name: Validate oauth2 auth config for custom_dashboards prometheus
-  fail:
-    msg: "external_services.custom_dashboards.prometheus.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
-  when:
-  - kiali_vars.external_services.custom_dashboards is defined
-  - kiali_vars.external_services.custom_dashboards.prometheus is defined
-  - kiali_vars.external_services.custom_dashboards.prometheus.auth is defined
-  - kiali_vars.external_services.custom_dashboards.prometheus.auth.type | default('') == 'oauth2'
-  - (kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2 is not defined) or
-    (kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2.client_id | default('') == '') or
-    (kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2.token_url | default('') == '')
-
-- name: Validate tracing oauth2 is not used with gRPC
-  fail:
-    msg: "external_services.tracing cannot use oauth2 auth with use_grpc=true (gRPC does not support HTTP-based OAuth2 token injection)"
-  when:
-  - kiali_vars.external_services.tracing is defined
-  - kiali_vars.external_services.tracing.auth is defined
-  - kiali_vars.external_services.tracing.auth.type | default('') == 'oauth2'
-  - kiali_vars.external_services.tracing.use_grpc | default(True) | bool == True
-
-- name: Validate prometheus oauth2 is not used with use_kiali_token
-  fail:
-    msg: "external_services.prometheus cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
-  when:
-  - kiali_vars.external_services.prometheus is defined
-  - kiali_vars.external_services.prometheus.auth is defined
-  - kiali_vars.external_services.prometheus.auth.type | default('') == 'oauth2'
-  - kiali_vars.external_services.prometheus.auth.use_kiali_token | default(False) | bool == True
-
-- name: Validate tracing oauth2 is not used with use_kiali_token
-  fail:
-    msg: "external_services.tracing cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
-  when:
-  - kiali_vars.external_services.tracing is defined
-  - kiali_vars.external_services.tracing.auth is defined
-  - kiali_vars.external_services.tracing.auth.type | default('') == 'oauth2'
-  - kiali_vars.external_services.tracing.auth.use_kiali_token | default(False) | bool == True
-
-- name: Validate grafana oauth2 is not used with use_kiali_token
-  fail:
-    msg: "external_services.grafana cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
-  when:
-  - kiali_vars.external_services.grafana is defined
-  - kiali_vars.external_services.grafana.auth is defined
-  - kiali_vars.external_services.grafana.auth.type | default('') == 'oauth2'
-  - kiali_vars.external_services.grafana.auth.use_kiali_token | default(False) | bool == True
-
-- name: Validate perses oauth2 is not used with use_kiali_token
-  fail:
-    msg: "external_services.perses cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
-  when:
-  - kiali_vars.external_services.perses is defined
-  - kiali_vars.external_services.perses.auth is defined
-  - kiali_vars.external_services.perses.auth.type | default('') == 'oauth2'
-  - kiali_vars.external_services.perses.auth.use_kiali_token | default(False) | bool == True
-
-- name: Validate custom_dashboards prometheus oauth2 is not used with use_kiali_token
-  fail:
-    msg: "external_services.custom_dashboards.prometheus cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
-  when:
-  - kiali_vars.external_services.custom_dashboards is defined
-  - kiali_vars.external_services.custom_dashboards.prometheus is defined
-  - kiali_vars.external_services.custom_dashboards.prometheus.auth is defined
-  - kiali_vars.external_services.custom_dashboards.prometheus.auth.type | default('') == 'oauth2'
-  - kiali_vars.external_services.custom_dashboards.prometheus.auth.use_kiali_token | default(False) | bool == True
+    msg: "{{ oauth2_validation_error }}"
+  when: oauth2_validation_error != ''
 
 - include_tasks: get-discovery-selector-namespaces.yml
 


### PR DESCRIPTION
Addresses follow-up issues identified during review of the OAuth2 client_credentials feature: missing client_secret validation, validation firing for disabled services, and gaps in test coverage across services.

fixes: https://github.com/kiali/kiali/issues/9787