### PR TITLE
[v2.27] Add Ansible role for version v2.27

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -221,7 +221,9 @@ spec:
   - name: operator
     image: "${KIALI_OPERATOR}"
   - name: kiali_default
-    image: "${KIALI_2_22}"
+    image: "${KIALI_2_27}"
+  - name: kiali_v2_27
+    image: "${KIALI_2_27}"
   - name: kiali_v2_22
     image: "${KIALI_2_22}"
   - name: kiali_v2_17
@@ -233,7 +235,9 @@ spec:
   - name: kiali_v1_73
     image: "${KIALI_1_73}"
   - name: ossmconsole_default
-    image: "${OSSMCONSOLE_2_22}"
+    image: "${OSSMCONSOLE_2_27}"
+  - name: ossmconsole_v2_27
+    image: "${OSSMCONSOLE_2_27}"
   - name: ossmconsole_v2_22
     image: "${OSSMCONSOLE_2_22}"
   - name: ossmconsole_v2_17
@@ -359,7 +363,9 @@ spec:
                 - name: WATCHES_FILE
                   value: "watches-os.yaml"
                 - name: RELATED_IMAGE_kiali_default
-                  value: "${KIALI_2_22}"
+                  value: "${KIALI_2_27}"
+                - name: RELATED_IMAGE_kiali_v2_27
+                  value: "${KIALI_2_27}"
                 - name: RELATED_IMAGE_kiali_v2_22
                   value: "${KIALI_2_22}"
                 - name: RELATED_IMAGE_kiali_v2_17
@@ -371,7 +377,9 @@ spec:
                 - name: RELATED_IMAGE_kiali_v1_73
                   value: "${KIALI_1_73}"
                 - name: RELATED_IMAGE_ossmconsole_default
-                  value: "${OSSMCONSOLE_2_22}"
+                  value: "${OSSMCONSOLE_2_27}"
+                - name: RELATED_IMAGE_ossmconsole_v2_27
+                  value: "${OSSMCONSOLE_2_27}"
                 - name: RELATED_IMAGE_ossmconsole_v2_22
                   value: "${OSSMCONSOLE_2_22}"
                 - name: RELATED_IMAGE_ossmconsole_v2_17

--- a/playbooks/kiali-default-supported-images.yml
+++ b/playbooks/kiali-default-supported-images.yml
@@ -4,3 +4,4 @@ v2.4: {"image_name": "quay.io/kiali/kiali", "image_version": "v2.4"}
 v2.11: {"image_name": "quay.io/kiali/kiali", "image_version": "v2.11"}
 v2.17: {"image_name": "quay.io/kiali/kiali", "image_version": "v2.17"}
 v2.22: {"image_name": "quay.io/kiali/kiali", "image_version": "v2.22"}
+v2.27: {"image_name": "quay.io/kiali/kiali", "image_version": "v2.27"}

--- a/playbooks/ossmconsole-default-supported-images.yml
+++ b/playbooks/ossmconsole-default-supported-images.yml
@@ -4,3 +4,4 @@ v2.4: {"imageName": "quay.io/kiali/ossmconsole", "imageVersion": "v2.4"}
 v2.11: {"imageName": "quay.io/kiali/ossmconsole", "imageVersion": "v2.11"}
 v2.17: {"imageName": "quay.io/kiali/ossmconsole", "imageVersion": "v2.17"}
 v2.22: {"imageName": "quay.io/kiali/ossmconsole", "imageVersion": "v2.22"}
+v2.27: {"imageName": "quay.io/kiali/ossmconsole", "imageVersion": "v2.27"}

--- a/roles/v2.27/kiali-deploy/defaults/main.yml
+++ b/roles/v2.27/kiali-deploy/defaults/main.yml
@@ -1,0 +1,480 @@
+# Defaults for all user-facing Kiali settings.
+#
+# Note that these are under the main dictionary group "kiali_defaults".
+# The actual vars used by the role are found in the vars/ directory.
+# These defaults (the dictionaries under "kiali_defaults") are merged into the vars such that the values
+# below (e.g. deployment, server, etc.) are merged in rather than completely replaced by user-supplied values.
+#
+# If new groups are added to these defaults, you must remember to add the merge code to vars/main.yml.
+
+kiali_defaults:
+  installation_tag: ""
+  version: "default"
+
+  additional_display_details:
+  - title: "API Documentation"
+    annotation: "kiali.io/api-spec"
+    icon_annotation: "kiali.io/api-type"
+
+  auth:
+    openid:
+      additional_request_params: {}
+      allowed_domains: []
+      api_proxy: ""
+      api_proxy_ca_data: ""
+      api_token: "id_token"
+      authentication_timeout: 300
+      authorization_endpoint: ""
+      client_id: ""
+      disable_rbac: false
+      http_proxy: ""
+      https_proxy: ""
+      insecure_skip_verify_tls: false
+      issuer_uri: ""
+      scopes: ["openid", "profile", "email"]
+      username_claim: "sub"
+      discovery_override:
+        authorization_endpoint: ""
+        jwks_uri: ""
+        token_endpoint: ""
+        userinfo_endpoint: ""
+    openshift:
+      insecure_skip_verify_tls: false
+      #redirect_uris:
+      #token_inactivity_timeout:
+      #token_max_age:
+    strategy: ""
+
+  chat_ai:
+    default_provider: ""
+    enabled: false
+    providers: []
+    store_config:
+      enabled: true
+      inactivity_timeout: "30m"
+      max_cache_memory_mb: 1024
+      reduce_threshold: 15
+      reduce_with_ai: false
+    tools: {}
+
+  clustering:
+    autodetect_secrets:
+      enabled: true
+      label: "kiali.io/multiCluster=true"
+    clusters: []
+    enable_exec_provider: false
+    ignore_home_cluster: false
+    kiali_urls: []
+
+  custom_dashboards: []
+
+  deployment:
+    additional_pod_containers_yaml: []
+    additional_pod_init_containers_yaml: []
+    #additional_service_yaml:
+    affinity:
+      node: {}
+      pod: {}
+      pod_anti: {}
+    cluster_wide_access: true
+    configmap_annotations: {}
+    custom_envs: []
+    custom_secrets: []
+    discovery_selectors: {}
+    dns:
+      config: {}
+      policy: ""
+    extra_labels: {}
+    host_aliases: []
+    hpa:
+      api_version: ""
+      spec: {}
+    image_digest: ""
+    image_name: ""
+    image_pull_policy: "IfNotPresent"
+    image_pull_secrets: []
+    image_version: ""
+    ingress:
+      additional_labels: {}
+      class_name: "nginx"
+      #enabled:
+      #override_yaml:
+    instance_name: "kiali"
+    logger:
+      log_format: "text"
+      log_level: "info"
+      sampler_rate: "1"
+      time_field_format: "2006-01-02T15:04:05Z07:00"
+    namespace: ""
+    network_policy:
+      enabled: true
+    node_selector: {}
+    pod_annotations:
+      proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+    pod_disruption_budget:
+      api_version: ""
+      spec: {}
+    pod_labels: {}
+    priority_class_name: ""
+    probes:
+      liveness:
+        initial_delay_seconds: 5
+        period_seconds: 30
+      readiness:
+        initial_delay_seconds: 5
+        period_seconds: 30
+      startup:
+        failure_threshold: 6
+        initial_delay_seconds: 30
+        period_seconds: 10
+    remote_cluster_resources_only: false
+    replicas: 1
+    #resources:
+    secret_name: "kiali"
+    security_context: {}
+    service_annotations: {}
+    #service_type: "NodePort"
+    strategy: {}
+    tls_config:
+      cipher_suites: []
+      max_version: ""
+      min_version: ""
+      source: ""
+    tolerations: []
+    topology_spread_constraints: []
+    version_label: ""
+    view_only_mode: false
+
+  extensions: []
+
+  external_services:
+    custom_dashboards:
+      discovery_auto_threshold: 10
+      discovery_enabled: "auto"
+      enabled: true
+      is_core: false
+      namespace_label: "namespace"
+      prometheus:
+        auth:
+          insecure_skip_verify: false
+          oauth2:
+            audience: ""
+            auth_style: "header"
+            client_id: ""
+            client_secret: ""
+            scopes: []
+            token_url: ""
+          password: ""
+          token: ""
+          type: "none"
+          use_kiali_token: false
+          username: ""
+        cache_duration: 7
+        cache_enabled: true
+        cache_expiration: 300
+        custom_headers: {}
+        health_check_url: ""
+        is_core: true
+        query_scope: {}
+        thanos_proxy:
+          enabled: false
+          retention_period: "7d"
+          scrape_interval: "30s"
+        url: ""
+    grafana:
+      auth:
+        insecure_skip_verify: false
+        oauth2:
+          audience: ""
+          auth_style: "header"
+          client_id: ""
+          client_secret: ""
+          scopes: []
+          token_url: ""
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      dashboards:
+      - name: "Istio Service Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          service: "var-service"
+          version: "var-version"
+      - name: "Istio Workload Dashboard"
+        variables:
+          datasource: "var-datasource"
+          namespace: "var-namespace"
+          workload: "var-workload"
+          version: "var-version"
+      - name: "Istio Mesh Dashboard"
+      - name: "Istio Control Plane Dashboard"
+      - name: "Istio Performance Dashboard"
+      - name: "Istio Wasm Extension Dashboard"
+      datasource_uid: ""
+      enabled: true
+      external_url: ""
+      health_check_url: ""
+      internal_url: "http://grafana.istio-system:3000"
+      is_core: false
+    istio:
+      component_status:
+        components: []
+        enabled: true
+      gateway_api_classes: []
+      gateway_api_classes_label_selector: ""
+      istio_api_enabled: true
+      istio_identity_domain: ""
+      istiod_polling_interval_seconds: 20
+      validation_change_detection_enabled: true
+      validation_reconcile_interval: "1m"
+    perses:
+      auth:
+        insecure_skip_verify: false
+        oauth2:
+          audience: ""
+          auth_style: "header"
+          client_id: ""
+          client_secret: ""
+          scopes: []
+          token_url: ""
+        password: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      dashboards:
+        - name: "Istio Service Dashboard"
+          variables:
+            datasource: "var-datasource"
+            namespace: "var-namespace"
+            service: "var-service"
+            version: "var-version"
+        - name: "Istio Workload Dashboard"
+          variables:
+            datasource: "var-datasource"
+            namespace: "var-namespace"
+            workload: "var-workload"
+            version: "var-version"
+        - name: "Istio Mesh Dashboard"
+        - name: "Istio Control Plane Dashboard"
+        - name: "Istio Performance Dashboard"
+        - name: "Istio Wasm Extension Dashboard"
+      enabled: false
+      external_url: ""
+      health_check_url: ""
+      internal_url: ""
+      is_core: false
+      project: "istio"
+      url_format: ""
+    prometheus:
+      auth:
+        insecure_skip_verify: false
+        oauth2:
+          audience: ""
+          auth_style: "header"
+          client_id: ""
+          client_secret: ""
+          scopes: []
+          token_url: ""
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      cache_duration: 7
+      cache_enabled: true
+      cache_expiration: 300
+      custom_headers: {}
+      enabled: true
+      health_check_url: ""
+      is_core: true
+      query_scope: {}
+      thanos_proxy:
+        enabled: false
+        retention_period: "7d"
+        scrape_interval: "30s"
+      url: ""
+    tracing:
+      auth:
+        insecure_skip_verify: false
+        oauth2:
+          audience: ""
+          auth_style: "header"
+          client_id: ""
+          client_secret: ""
+          scopes: []
+          token_url: ""
+        password: ""
+        token: ""
+        type: "none"
+        use_kiali_token: false
+        username: ""
+      custom_headers: {}
+      disable_version_check: false
+      enabled: false
+      external_url: ""
+      grpc_port: 9095
+      health_check_url: ""
+      internal_url: ""
+      is_core: false
+      namespace_selector: true
+      provider: "jaeger"
+      query_scope: {}
+      query_timeout: 5
+      tempo_config:
+        cache_capacity: 200
+        cache_enabled: true
+        datasource_uid: ""
+        name: ""
+        namespace: ""
+        org_id: ""
+        tenant: ""
+        url_format: "grafana"
+      use_grpc: true
+      use_waypoint_name: false
+      whitelist_istio_system: ["jaeger-query", "istio-ingressgateway"]
+
+  health_config:
+    compute:
+      duration: "5m"
+      refresh_interval: "3m"
+      timeout: "10m"
+    rate: []
+
+  identity: {}
+    #cert_file:
+    #private_key_file:
+
+  istio_labels:
+    app_label_name: ""
+    version_label_name: ""
+
+  kiali_feature_flags:
+    authz:
+      require_namespace_get: false
+    clustering:
+      enable_exec_provider: false
+    custom_workload_types: []
+    disabled_features: []
+    istio_annotation_action: true
+    istio_injection_action: true
+    istio_upgrade_action: false
+    ui_defaults:
+      graph:
+        find_options:
+        - auto_select: false
+          description: "Find: slow edges (> 1s)"
+          expression: "rt > 1000"
+        - auto_select: false
+          description: "Find: unhealthy nodes"
+          expression:  "! healthy"
+        - auto_select: false
+          description: "Find: unknown nodes"
+          expression:  "name = unknown"
+        - auto_select: false
+          description: "Find: nodes with the 2 top rankings"
+          expression:  "rank <= 2"
+        hide_options:
+        - auto_select: false
+          description: "Hide: healthy nodes"
+          expression: "healthy"
+        - auto_select: false
+          description: "Hide: unknown nodes"
+          expression:  "name = unknown"
+        - auto_select: false
+          description: "Hide: nodes ranked lower than the 2 top rankings"
+          expression:  "rank > 2"
+        settings:
+          animation: "point"
+        traffic:
+          ambient: "total"
+          grpc: "requests"
+          http: "requests"
+          tcp: "sent"
+      list:
+        include_health: true
+        include_istio_resources: true
+        include_validations: true
+        show_include_toggles: false
+      i18n:
+        show_selector: false
+      mesh:
+        find_options:
+        - description: "Find: unhealthy nodes"
+          expression: "! healthy"
+        hide_options:
+        - description: "Hide: healthy nodes"
+          expression: "healthy"
+      metrics_inbound:
+        aggregations: []
+      metrics_outbound:
+        aggregations: []
+      metrics_per_refresh: "1m"
+      namespaces: []
+      refresh_interval: "1m"
+      tracing:
+        limit: 100
+    validations:
+      ignore: ["KIA1301"]
+      skip_wildcard_gateway_hosts: false
+
+  kiali_internal: {}
+
+  kubernetes_config:
+    burst: 200
+    cache_duration: 300
+    cache_token_namespace_duration: 10
+    cluster_name: ""
+    excluded_workloads:
+    - "CronJob"
+    - "DeploymentConfig"
+    - "Job"
+    - "ReplicationController"
+    qps: 175
+
+  login_token:
+    expiration_seconds: 86400
+    signing_key: ""
+
+  server:
+    address: ""
+    audit_log: true
+    cors_allow_all: false
+    gzip_enabled: true
+    #node_port:
+    observability:
+      metrics:
+        enabled: true
+        health_status:
+          enabled: false
+          max_consecutive_na: 3
+        port: 9090
+      tracing:
+        collector_type: "otel"
+        collector_url: "jaeger-collector.istio-system:4318"
+        enabled: false
+        otel:
+          ca_name: ""
+          protocol: "http"
+          skip_verify: false
+          tls_enabled: false
+        sampling_rate: 0.5
+    port: 20001
+    profiler:
+      enabled: false
+    require_auth: false
+    web_fqdn: ""
+    web_history_mode: "browser"
+    web_port: ""
+    web_root: ""
+    web_schema: ""
+    write_timeout: "60s"
+
+# These variables are outside of the kiali_defaults. Their values will be
+# auto-detected by the role and are not meant to be set by the user.
+# However, for debugging purposes you can change these.
+
+is_k8s: false
+is_openshift: false

--- a/roles/v2.27/kiali-deploy/filter_plugins/parse_selectors.py
+++ b/roles/v2.27/kiali-deploy/filter_plugins/parse_selectors.py
@@ -1,0 +1,110 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.errors import AnsibleFilterError
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Given a list of label selectors in the standard k8s format, convert to the format that the k8s ansible collection wants.
+# For example, given this input:
+# - matchLabels:
+#     foo: bar
+# - matchLabels:
+#     color: blue
+#   matchExpressions:
+#   - key: region
+#     operator: In
+#     values:
+#     - east
+#     - west
+# an array will be returned with two items.
+# The first is a list with one item that is "foo=bar".
+# The second is a list with two items. The first item being "color=blue" and the second item being "region in (east, west)"
+#
+# See:
+# * https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+# * https://docs.ansible.com/ansible/latest/collections/kubernetes/core/k8s_info_module.html#parameter-label_selectors
+def parse_selectors(value):
+  # these are the selectors that should be OR'ed together - this is the final result returned back from this function
+  selectorOr = []
+  selectorOrIndex = 0
+
+  # for each item in the selectors list, there can be one matchLabels and one matchExpressions (both can be there, or just one of them).
+  for selectors in value:
+    selectorOr.append([])
+
+    # process the matchLabels (or matchLabels) - each results in "labelName=labelValue" strings
+    matchLabelsString = "matchLabels"
+    if matchLabelsString in selectors:
+      if (selectors[matchLabelsString] is None) or (len(selectors[matchLabelsString]) == 0):
+        raise AnsibleFilterError("Selector matchLabels is empty")
+      for k, v in selectors[matchLabelsString].items():
+        expr = k + "=" + v
+        selectorOr[selectorOrIndex].append(expr)
+
+    # process the matchExpressions - each results in something like "labelName notin (labelValue, labelValue2)"
+    matchExpressionsString = "matchExpressions"
+    if matchExpressionsString in selectors:
+      for me in selectors[matchExpressionsString]:
+        if "key" not in me:
+          raise AnsibleFilterError("Selector matchExpression is missing 'key'")
+        key = me["key"]
+
+        if "operator" not in me:
+          raise AnsibleFilterError("Selector matchExpression is missing 'operator'")
+        operator = me["operator"].lower()
+
+        if (operator == "in" or operator == "notin") and ("values" not in me or me["values"] is None or (len(me["values"]) == 0)):
+          raise AnsibleFilterError("Selector matchExpression is missing a non-empty 'values'")
+        values = me["values"] if "values" in me else []
+        valuesStr = "("
+        for i, v in enumerate(values):
+          if i > 0:
+            valuesStr += ","
+          valuesStr += v
+        valuesStr += ")"
+
+        if operator == "in":
+          selectorOr[selectorOrIndex].append(key + " in " + valuesStr)
+        elif operator == "notin":
+          selectorOr[selectorOrIndex].append(key + " notin " + valuesStr)
+        elif operator == "exists":
+          selectorOr[selectorOrIndex].append(key)
+        elif operator == "doesnotexist":
+          selectorOr[selectorOrIndex].append("!" + key)
+        else:
+          raise AnsibleFilterError("Selector matchExpression has invalid operator: " + operator)
+
+    selectorOrIndex = selectorOrIndex + 1
+
+  return selectorOr
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'parse_selectors': parse_selectors
+    }
+
+# TEST
+# first = {
+#  "matchLabels":      { "sport": "football", "region": "west" },
+#  "matchExpressions": [{ "key": "region", "operator": "In", "values": ["east" ]}, { "key": "sport", "operator": "Exists"}]
+# }
+# second = {
+#  "matchLabels":      { "region": "east", "sport": "golf" },
+# }
+# third = {
+#  "matchExpressions": [{ "key": "sport", "operator": "In", "values": ["baseball", "football" ]},{ "key": "region", "operator": "NotIn", "values": ["east" ]}]
+# }
+# fourth = {
+#  "matchExpressions": [{ "key": "sport", "operator": "NotIn", "values": ["baseball", "football" ]},{ "key": "region", "operator": "Exists"},{ "key": "foo", "operator": "DoesNotExist"}]
+# }
+# print ("\n=====The following should be successful:\n")
+# print (parse_selectors([first, second, third, fourth]))
+# print ("\n=====The following should result in an error:\n")
+# print (parse_selectors([{"matchExpressions": [{ "key": "sport", "operator": "XIn"}]}]))

--- a/roles/v2.27/kiali-deploy/filter_plugins/stripnone.py
+++ b/roles/v2.27/kiali-deploy/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/roles/v2.27/kiali-deploy/meta/main.yml
+++ b/roles/v2.27/kiali-deploy/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+- kubernetes.core

--- a/roles/v2.27/kiali-deploy/tasks/clusterroles-to-remove.yml
+++ b/roles/v2.27/kiali-deploy/tasks/clusterroles-to-remove.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-viewer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}-oauth
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}-oauth

--- a/roles/v2.27/kiali-deploy/tasks/get-api-versions.yaml
+++ b/roles/v2.27/kiali-deploy/tasks/get-api-versions.yaml
@@ -1,0 +1,14 @@
+# We want to avoid using k8s_cluster_info because it is resource intensive. So just look for the API versions we are interested in.
+
+### AUTOSCALING API
+
+- name: See if autoscaling/v2 HorizontalPodAutoscaler is available
+  k8s_info:
+    api_version: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+  register: api_check_autoscaling_v2
+  ignore_errors: true
+
+- name: Set autoscaling_api_version based on whether autoscaling/v2 is supported or not
+  set_fact:
+    autoscaling_api_version: "{{ 'autoscaling/v2' if (api_check_autoscaling_v2 is defined and api_check_autoscaling_v2.api_found is defined and api_check_autoscaling_v2.api_found) else 'autoscaling/v2beta2' }}"

--- a/roles/v2.27/kiali-deploy/tasks/get-discovery-selector-namespaces.yml
+++ b/roles/v2.27/kiali-deploy/tasks/get-discovery-selector-namespaces.yml
@@ -1,0 +1,65 @@
+# These tasks are not performed if cluster_wide_access is true - this is because the operator will
+# grant Kiali permission to see all namespaces via ClusterRole, so the operator does not need to
+# process discovery selectors.
+#
+# These tasks are performed if cluster wide access is false - this is because the operator will
+# need to create Roles in all the namespaces found by the discovery selectors so Kiali can be
+# granted permission to see those namespaces (but only those namespaces).
+#
+# These tasks will use discovery selectors found in the Kiali configuration setting
+# spec.deployment.discovery_selectors["default"]. These discovery selectors will be used to discover
+# namespaces that Kiali should be given access to.
+#
+# When these tasks finish, "discovery_selector_namespaces" will be a list of namespaces discovered by the selectors.
+#
+# NOTE: Regardless of what discovery selectors are defined, the Kiali Operator should always give the server
+# access to the Kiali Server deployment namespace and the Istio control plane namespace. But that is
+# not done here - these tasks simply scan all namespaces and match them to selectors. The operator
+# will add those two namespaces later if appropriate.
+#
+# NOTE: These tasks specifically ignore Istio's own discovery selectors found in Istio meshConfig.
+
+- name: Get Kiali discovery selectors if they are defined
+  set_fact:
+    discovery_selectors: "{{ kiali_vars.deployment.discovery_selectors.default }}"
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+  - kiali_vars.deployment.discovery_selectors.default is defined
+
+- name: If cluster wide access is disabled and no discovery selectors are found, warn the user that this is probably not what they want
+  debug:
+    msg: "Cluster wide access is disabled, but no discovery selectors were specified. You likely will want to define discovery selectors in the Kiali CR."
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+  - kiali_vars.discovery_selectors.default is not defined
+  - discovery_selectors is not defined
+
+- name: Find namespaces selected by the discovery selectors
+  set_fact:
+    discovery_selector_namespaces_raw: "{{ (discovery_selector_namespaces_raw|default([]) + query(k8s_plugin, kind='Namespace', label_selector=(item|join(',')))) | unique }}"
+  loop: "{{ discovery_selectors | parse_selectors }}"
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+  - discovery_selectors is defined
+
+- name: Get just the names of the discovered namespaces
+  set_fact:
+    discovery_selector_namespaces: "{{ discovery_selector_namespaces|default([]) + [item.metadata.name] }}"
+  loop: "{{ discovery_selector_namespaces_raw|default([]) }}"
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+  - discovery_selector_namespaces_raw is defined
+
+- name: Garbage collect discovered namespaces to free up space
+  set_fact:
+    discovery_selector_namespaces_raw: []
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+  - discovery_selector_namespaces_raw is defined
+
+- name: If no namespaces were discovered, make sure discovery_selector_namespaces is set to an empty list
+  set_fact:
+    discovery_selector_namespaces: []
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+  - discovery_selector_namespaces is not defined

--- a/roles/v2.27/kiali-deploy/tasks/kubernetes/k8s-main.yml
+++ b/roles/v2.27/kiali-deploy/tasks/kubernetes/k8s-main.yml
@@ -1,0 +1,85 @@
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Creating core resources"
+  when:
+  - is_k8s == True
+
+- name: Remove HPA if disabled on Kubernetes
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
+    kind: "HorizontalPodAutoscaler"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.hpa.spec | length == 0
+
+- name: Remove PDB if disabled on Kubernetes
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.pod_disruption_budget.api_version }}"
+    kind: "PodDisruptionBudget"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.pod_disruption_budget.spec | length == 0
+
+- name: Create Kiali objects on Kubernetes
+  include_tasks: process-resource.yml
+  vars:
+    role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
+    process_resource_templates:
+    - "templates/kubernetes/serviceaccount.yaml"
+    - "templates/kubernetes/configmap.yaml"
+    - "templates/kubernetes/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/kubernetes/rolebinding.yaml"
+    - "{{ 'templates/kubernetes/deployment.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/kubernetes/service.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/kubernetes/hpa.yaml' if ((kiali_vars.deployment.hpa.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/kubernetes/pdb.yaml' if ((kiali_vars.deployment.pod_disruption_budget.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/kubernetes/ingress.yaml' if ((kiali_vars.deployment.ingress.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/kubernetes/networkpolicy.yaml' if ((kiali_vars.deployment.network_policy.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+  when:
+  - is_k8s == True
+
+- name: Delete Ingress on Kubernetes if disabled
+  k8s:
+    state: absent
+    api_version: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
+    kind: "Ingress"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.ingress.enabled|bool == False
+
+- name: Delete NetworkPolicy on Kubernetes if disabled
+  k8s:
+    state: absent
+    api_version: "networking.k8s.io/v1"
+    kind: "NetworkPolicy"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.network_policy.enabled|bool == False
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Creating additional roles"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.cluster_wide_access == False
+
+- name: Create additional Kiali roles/bindings on all namespaces that are accessible on Kubernetes
+  vars:
+    role_namespaces: "{{ discovery_selector_namespaces }}"
+  k8s:
+    template:
+    - "templates/kubernetes/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/kubernetes/rolebinding.yaml"
+  when:
+  - is_k8s == True
+  - kiali_vars.deployment.cluster_wide_access == False

--- a/roles/v2.27/kiali-deploy/tasks/main.yml
+++ b/roles/v2.27/kiali-deploy/tasks/main.yml
@@ -1,0 +1,1445 @@
+- set_fact:
+    k8s_plugin: kubernetes.core.k8s
+
+- name: Get the original CR as-is for the camelCase keys and so we can update its status field
+  set_fact:
+    current_cr: "{{ _kiali_io_kiali }}"
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Initializing"
+    status_vars:
+      specVersion: "{{ kiali_vars.version }}"
+      deployment:
+        discoverySelectorNamespaces: null
+
+- name: Get api group information from the cluster
+  set_fact:
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+- name: Get api versions from the cluster
+  include_tasks: get-api-versions.yaml
+
+- name: Determine the cluster type
+  set_fact:
+    is_openshift: "{{ True if 'operator.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'operator.openshift.io' in api_groups else True }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+# Indicate what kind of cluster we are in (OpenShift or Kubernetes).
+- debug:
+    msg: "CLUSTER TYPE: is_openshift={{ is_openshift }}; is_k8s={{ is_k8s }}"
+- fail:
+    msg: "Cannot determine what type of cluster we are in"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+- name: Determine the Kubernetes version
+  set_fact:
+    k8s_version: "{{ lookup(k8s_plugin, cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
+  ignore_errors: yes
+
+- name: Determine the OpenShift version
+  vars:
+    kube_apiserver_cluster_op_raw: "{{ lookup(k8s_plugin, api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
+    ri_query: "status.versions[?name == 'raw-internal'].version"
+  set_fact:
+    openshift_version: "{{ kube_apiserver_cluster_op_raw | json_query(ri_query) | join }}"
+  when:
+  - is_openshift == True
+
+- name: Get information about the operator
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+    name: "{{ lookup('env', 'POD_NAME') }}"
+  register: operator_pod_raw
+  ignore_errors: yes
+- name: Determine the version of the operator based on the version label
+  set_fact:
+    operator_version: "{{ operator_pod_raw.resources[0].metadata.labels.version }}"
+  when:
+  - operator_pod_raw is defined
+  - operator_pod_raw.resources[0] is defined
+  - operator_pod_raw.resources[0].metadata is defined
+  - operator_pod_raw.resources[0].metadata.labels is defined
+  - operator_pod_raw.resources[0].metadata.labels.version is defined
+- set_fact:
+    operator_version: "unknown"
+  when:
+  - operator_version is not defined
+- debug:
+    msg: "OPERATOR VERSION: [{{ operator_version }}]"
+
+# To remain backward compatible with some settings that have changed in later releases,
+# let's take some deprecated settings and set the current settings appropriately.
+
+- name: deployment.ingress_enabled is deprecated but if deployment.ingress.enabled is not set then use the old setting
+  set_fact:
+    kiali_vars: |
+      {% set ie=kiali_vars['deployment'].pop('ingress_enabled') %}
+      {{ kiali_vars | combine({'deployment': {'ingress': {'enabled': ie|bool }}}, recursive=True) }}
+  when:
+  - kiali_vars.deployment.ingress_enabled is defined
+  - kiali_vars.deployment.ingress is not defined or kiali_vars.deployment.ingress.enabled is not defined
+
+# convert snake case to camelCase where appropriate
+- include_tasks: snake_camel_case.yaml
+
+- name: Print some debug information
+  vars:
+    msg: |
+        Kiali Variables:
+        --------------------------------
+        {{ kiali_vars | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.namespace is not defined or kiali_vars.deployment.namespace == ""
+
+# Never allow the deployment.instance_name, deployment.namespace, or deployment.remote_cluster_resources_only to change to avoid leaking resources - to uninstall resources you must delete the Kiali CR
+- name: Ensure the deployment.instance_name has not changed
+  fail:
+    msg: "The deployment.instance_name cannot be changed to a different value. It was [{{ current_cr.status.deployment.instanceName }}] but is now [{{ kiali_vars.deployment.instance_name }}]. In order to install Kiali with a different deployment.instance_name, please uninstall Kiali first."
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.instanceName is defined
+  - current_cr.status.deployment.instanceName != kiali_vars.deployment.instance_name
+
+- name: Ensure the deployment.namespace has not changed
+  fail:
+    msg: "The deployment.namespace cannot be changed to a different value. It was [{{ current_cr.status.deployment.namespace }}] but is now [{{ kiali_vars.deployment.namespace }}]. In order to install Kiali with a different deployment.namespace, please uninstall Kiali first."
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.namespace is defined
+  - current_cr.status.deployment.namespace != kiali_vars.deployment.namespace
+
+- name: Ensure the deployment.remote_cluster_resources_only has not changed
+  fail:
+    msg: "The deployment.remote_cluster_resources_only cannot be changed to a different value. It was [{{ current_cr.status.deployment.remoteClusterResourcesOnly }}] but is now [{{ kiali_vars.deployment.remote_cluster_resources_only }}]. In order to change to a different deployment.remote_cluster_resources_only value, please delete the Kiali CR first."
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment.remoteClusterResourcesOnly is defined
+  - current_cr.status.deployment.remoteClusterResourcesOnly is defined
+  - current_cr.status.deployment.remoteClusterResourcesOnly != kiali_vars.deployment.remote_cluster_resources_only
+
+- name: Only allow ad-hoc kiali namespace when appropriate
+  fail:
+    msg: "The operator is forbidden from installing Kiali in a namespace [{{ kiali_vars.deployment.namespace }}] that is different from the namespace where the CR was created [{{ current_cr.metadata.namespace }}]"
+  when:
+  - kiali_vars.deployment.namespace != current_cr.metadata.namespace
+  - lookup('env', 'ALLOW_AD_HOC_KIALI_NAMESPACE') | default('false', True) != "true"
+
+- name: Only allow ad-hoc containers when appropriate
+  fail:
+    msg: "The operator is forbidden from installing additional containers into the Kiali pod."
+  when:
+  - kiali_vars.deployment.additional_pod_containers_yaml|length > 0
+  - lookup('env', 'ALLOW_AD_HOC_CONTAINERS') | default('false', True) != "true"
+
+- name: Only allow ad-hoc initContainers when appropriate
+  fail:
+    msg: "The operator is forbidden from installing additional initContainers into the Kiali pod."
+  when:
+  - kiali_vars.deployment.additional_pod_init_containers_yaml|length > 0
+  - lookup('env', 'ALLOW_AD_HOC_CONTAINERS') | default('false', True) != "true"
+
+- name: Make sure instance_name follows the DNS label standard because it will be a Service name
+  fail:
+    msg: "The value for deployment.instance_name [{{ kiali_vars.deployment.instance_name }}] does not follow the DNS label standard as defined in RFC 1123. In short, it must only contain lowercase alphanumeric characters or '-'."
+  when:
+  # regex must follow https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names
+  # restrict to 40 chars, not 63, because instance_name is a prefix and we need to prepend additional chars for some resource names (like "-service-account")
+  - kiali_vars.deployment.instance_name is not regex('^(?![0-9]+$)(?!-)[a-z0-9-]{,40}(?<!-)$')
+
+# We know that when CWA=true we will create a cluster role binding whose name is deployment.instance_name and has a
+# single "subjects" item that refers to the Kiali SA. Make sure there is no cluster role binding that already exists
+# with that name but does not have a subject pointing to this Kiali's SA. If there is, that means another Kiali is
+# already installed with CWA=true and with the same instance name. This is not allowed because it will conflict
+# with the cluster role binding for the Kiali we are installing. Abort the reconciliation when this is detected.
+- name: Do not allow multiple Kiali Servers with the same deployment.instance_name to have CWA=true
+  vars:
+    current_rolebinding: "{{ query(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, api_version='rbac.authorization.k8s.io/v1', kind='ClusterRoleBinding', errors='ignore') }}"
+  fail:
+    msg: "There is already a Kiali Server installed with `deployment.instance_name` of [{{ kiali_vars.deployment.instance_name }}] that has 'deployment.cluster_wide_access' set to true. You must use a different instance name."
+  when:
+  - kiali_vars.deployment.cluster_wide_access == True
+  - current_rolebinding is defined
+  - current_rolebinding | length > 0
+  - current_rolebinding[0].subjects is defined
+  - current_rolebinding[0].subjects | length > 0
+  - current_rolebinding[0].subjects[0].name != kiali_vars.deployment.instance_name + '-service-account' or current_rolebinding[0].subjects[0].namespace != kiali_vars.deployment.namespace
+
+- name: "Determine environment to store in status"
+  set_fact:
+    status_environment: "{{ status_environment | default({}) | combine({item.0: item.1}) }}"
+  loop: "{{ data[0] | zip(data[1]) | list }}"
+  vars:
+    data:
+    - ['isKubernetes', 'isOpenshift', 'kubernetesVersion', 'openshiftVersion', 'operatorVersion']
+    - ["{{is_k8s}}", "{{is_openshift}}", "{{k8s_version|default('')}}", "{{openshift_version|default('')}}", "{{operator_version}}"]
+  when:
+  - item.1 != ""
+  - item.1 != "false"
+  - item.1 != False
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Setting up configuration"
+    status_vars:
+      environment: "{{ status_environment | default({}) }}"
+      deployment:
+        instanceName: "{{ kiali_vars.deployment.instance_name }}"
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+        remoteClusterResourcesOnly: "{{ kiali_vars.deployment.remote_cluster_resources_only }}"
+
+- name: Validate web_schema configuration
+  fail:
+    msg: "Invalid server.web_schema [{{ kiali_vars.server.web_schema }}]! Must be empty, or one of either 'http' or 'https'"
+  when:
+  - kiali_vars.server.web_schema != ''
+  - kiali_vars.server.web_schema != 'https'
+  - kiali_vars.server.web_schema != 'http'
+
+- name: Validate web_history_mode configuration
+  fail:
+    msg: "Invalid server.web_history_mode [{{ kiali_vars.server.web_history_mode }}]! Must be empty, or one of either 'browser' or 'hash'"
+  when:
+  - kiali_vars.server.web_history_mode != ''
+  - kiali_vars.server.web_history_mode != 'browser'
+  - kiali_vars.server.web_history_mode != 'hash'
+
+- name: Only allow ad-hoc kiali image when appropriate
+  fail:
+    msg: "The operator is forbidden from accepting a Kiali CR that defines an ad hoc Kiali image [{{ kiali_vars.deployment.image_name }}{{ '@' + kiali_vars.deployment.image_digest if kiali_vars.deployment.image_digest != '' else '' }}:{{ kiali_vars.deployment.image_version }}]. Remove spec.deployment.image_name, spec.deployment.image_version, and spec.deployment.image_digest from the Kiali CR."
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.deployment.image_name != "" or kiali_vars.deployment.image_version != "" or kiali_vars.deployment.image_digest != ""
+  - lookup('env', 'ALLOW_AD_HOC_KIALI_IMAGE') | default('false', True) != "true"
+
+# We do not want to blindly default to istio-system for some namespaces. Unless otherwise specified, assume it
+# is the same namespace where Kiali is being deployed. Set the other istio namespace values accordingly.
+# We determine the default Istio namespace var first, and the rest will use it for their default as appropriate.
+
+- name: Set configuration defaults
+  vars:
+    resource_limits_default:
+      requests:
+        cpu: "10m"
+        memory: "64Mi"
+      limits:
+        memory: "1Gi"
+    kiali_vars_yaml: |
+      {# Initialize #}
+      {% set kv = kiali_vars %}
+
+      {# Set default Grafana internal_url #}
+      {% if kv.external_services.grafana.internal_url is not defined %}
+      {% set kv = kv | combine({'external_services': {'grafana': {'internal_url': 'http://grafana.' + kv.deployment.namespace + ':3000'}}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default Tracing internal_url for grpc consumption #}
+      {% if kv.external_services.tracing.internal_url == "" and (kv.external_services.tracing.use_grpc is not defined or kv.external_services.tracing.use_grpc|bool == True) %}
+      {% set kv = kv | combine({'external_services': {'tracing': {'internal_url': 'http://tracing.' + kv.deployment.namespace + ':16685/jaeger'}}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default Tracing internal_url for http consumption #}
+      {% if kv.external_services.tracing.internal_url == "" and kv.external_services.tracing.use_grpc is defined and kv.external_services.tracing.use_grpc|bool == False %}
+      {% set kv = kv | combine({'external_services': {'tracing': {'internal_url': 'http://tracing.' + kv.deployment.namespace + '/jaeger'}}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default Prometheus URL #}
+      {% if kv.external_services.prometheus.enabled|bool == True and kv.external_services.prometheus.url == "" %}
+      {% set kv = kv | combine({'external_services': {'prometheus': {'url': 'http://prometheus.' + kv.deployment.namespace + ':9090'}}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default HPA api_version #}
+      {% if kv.deployment.hpa.api_version == "" %}
+      {% set kv = kv | combine({'deployment': {'hpa': {'api_version': autoscaling_api_version }}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default PDB api_version #}
+      {% if kv.deployment.pod_disruption_budget.api_version == "" %}
+      {% set kv = kv | combine({'deployment': {'pod_disruption_budget': {'api_version': 'policy/v1'}}}, recursive=True) %}
+      {% endif %}
+
+      {# Provide some default resource limits #}
+      {% if kv.deployment.resources is not defined %}
+      {% set kv = kv | combine({'deployment': {'resources': resource_limits_default }}, recursive=True) %}
+      {% endif %}
+
+      {# Default TLS policy source: auto on OpenShift, config elsewhere #}
+      {% if kv.deployment.tls_config.source is not defined or kv.deployment.tls_config.source == "" %}
+      {% set kv = kv | combine({'deployment': {'tls_config': {'source': 'auto' if is_openshift else 'config'}}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default deployment.ingress.enabled based on cluster type (disable on k8s; enable on OpenShift) #}
+      {% if kv.deployment.ingress.enabled is not defined or kv.deployment.ingress.enabled == "" %}
+      {% set kv = kv | combine({'deployment': {'ingress': {'enabled': true if is_openshift else false }}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default tracing use_grpc setting #}
+      {% if kv.external_services.tracing.use_grpc is not defined %}
+      {% set kv = kv | combine({'external_services': {'tracing': { 'use_grpc': True }}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default web root based on cluster type #}
+      {% if kv.server.web_root == "" %}
+      {% set kv = kv | combine({'server': {'web_root': '/' if is_openshift else '/kiali'}}, recursive=True) %}
+      {% endif %}
+
+      {# Make sure web root never ends with a slash #}
+      {% if kv.server.web_root != "/" and kv.server.web_root is match(".*/$") %}
+      {% set kv = kv | combine({'server': {'web_root': kv.server.web_root | regex_replace('\\/$', '')}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default identity cert_file based on cluster type (non-OpenShift clusters do not get a default identity) #}
+      {% if kv.identity.cert_file is not defined %}
+      {% set kv = kv | combine({'identity': {'cert_file': '/kiali-cert/tls.crt' if is_openshift else ''}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default identity private_key_file based on cluster type (non-OpenShift clusters do not get a default identity) #}
+      {% if kv.identity.private_key_file is not defined %}
+      {% set kv = kv | combine({'identity': {'private_key_file': '/kiali-cert/tls.key' if is_openshift else ''}}, recursive=True) %}
+      {% endif %}
+
+      {# Default the image name to a known supported image. #}
+      {% if kv.deployment.image_name == "" %}
+      {% set kv = kv | combine({'deployment': {'image_name': supported_kiali_images[kv.version].image_name}}, recursive=True) %}
+      {% endif %}
+
+      {# Default the image version to a known supported image. #}
+      {% if kv.deployment.image_version == "" %}
+      {% set kv = kv | combine({'deployment': {'image_version': ('latest' if operator_version == 'master' else operator_version) if supported_kiali_images[kv.version].image_version == 'operator_version' else supported_kiali_images[kv.version].image_version}}, recursive=True) %}
+      {% endif %}
+
+      {# If image version is latest then we will want to always pull #}
+      {% if kv.deployment.image_version == "latest" %}
+      {% set kv = kv | combine({'deployment': {'image_pull_policy': 'Always'}}, recursive=True) %}
+      {% endif %}
+
+      {# Set default auth strategy based on cluster type #}
+      {% if kv.auth.strategy == "" %}
+      {% set kv = kv | combine({'auth': {'strategy': 'openshift' if is_openshift else 'token'}}, recursive=True) %}
+      {% endif %}
+
+      {# Set the yaml to the new kv dict #}
+      {{ kv | to_nice_yaml }}
+  set_fact:
+    kiali_vars: "{{ kiali_vars_yaml | from_yaml }}"
+
+# Indicate how users are to authenticate to Kiali, making sure the strategy is valid.
+- debug:
+    msg: "AUTH STRATEGY={{ kiali_vars.auth.strategy }}"
+- name: Confirm auth strategy is valid for OpenShift environments
+  fail:
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'openshift', 'openid', 'token' or 'anonymous'"
+  when:
+  - is_openshift == True
+  - kiali_vars.auth.strategy != 'anonymous'
+  - kiali_vars.auth.strategy != 'openid'
+  - kiali_vars.auth.strategy != 'openshift'
+  - kiali_vars.auth.strategy != 'token'
+- name: Confirm auth strategy is valid for Kubernetes environments
+  fail:
+    msg: "Invalid auth.strategy [{{ kiali_vars.auth.strategy }}]! Must be one of either 'token', 'openid', 'anonymous', or 'header'"
+  when:
+  - is_k8s == True
+  - kiali_vars.auth.strategy != 'anonymous'
+  - kiali_vars.auth.strategy != 'token'
+  - kiali_vars.auth.strategy != 'openid'
+  - kiali_vars.auth.strategy != 'header'
+- name: Confirm OpenID configuration when auth strategy is 'openid'
+  fail:
+    msg: "Invalid configuration for OpenID connect! The mandatory parameters should be provided: 'issuer_uri', 'client_id'. Also, the 'username_claim' cannot be set to the empty string."
+  when:
+  - kiali_vars.auth.strategy == "openid"
+  - kiali_vars.auth.openid.issuer_uri == "" or kiali_vars.auth.openid.client_id == "" or kiali_vars.auth.openid.username_claim == ""
+- name: Check valid value for api_token on OpenID configuration
+  fail:
+    msg: "Invalid configuration for OpenID connect! The api_token must be either 'id_token' or 'access_token'"
+  when:
+    - kiali_vars.auth.strategy == "openid"
+    - kiali_vars.auth.openid.api_token != "id_token"
+    - kiali_vars.auth.openid.api_token != "access_token"
+# Fail if ingress is disabled but auth_strategy is openshift. This is because the openshift auth strategy
+# requires OAuth Client which requires a Route. So ingress must be enabled if strategy is openshift.
+- name: Ensure Ingress is Enabled if Auth Strategy is openshift
+  fail:
+    msg: "The auth.strategy is 'openshift' which requires a Route, but deployment.ingress.enabled is false. Aborting."
+  when:
+  - kiali_vars.auth.strategy == "openshift"
+  - kiali_vars.deployment.ingress.enabled|bool == False
+
+- name: Confirm the cluster can access github.com when it needs to determine the last release of Kiali
+  uri:
+    url: https://api.github.com/repos/kiali/kiali-operator/releases
+  when:
+  - kiali_vars.deployment.image_version == "lastrelease"
+- name: Determine image version when last release is to be installed
+  shell: echo -n $(curl -s https://api.github.com/repos/kiali/kiali-operator/releases 2> /dev/null | grep "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//' | grep -v "snapshot" | sort -t "." -k 1.2g,1 -k 2g,2 -k 3g | tail -n 1)
+  register: github_lastrelease
+  when:
+  - kiali_vars.deployment.image_version == "lastrelease"
+- set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': github_lastrelease.stdout}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_version == "lastrelease"
+
+- name: Determine image version when it explicitly was configured as the operator_version
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'image_version': 'latest' if operator_version == 'master' else operator_version}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.image_version == "operator_version"
+
+- fail:
+    msg: "Could not determine what the image version should be. Set deployment.image_version to a valid value"
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.deployment.image_version == "" or kiali_vars.deployment.image_version == "unknown"
+
+- name: Determine version_label based on image_version
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': 'master' if kiali_vars.deployment.image_version == 'latest' else kiali_vars.deployment.image_version}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.version_label == ""
+
+# Kubernetes limits the length of version label strings to 63 characters or less - make sure the label is valid.
+- name: Trim version_label when appropriate
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'version_label': kiali_vars.deployment.version_label[:60] + 'XXX' }}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.version_label | length > 63
+
+# Indicate which Kiali image we are going to use.
+- debug:
+    msg: "IMAGE_NAME={{ kiali_vars.deployment.image_name }}; IMAGE VERSION={{ kiali_vars.deployment.image_version }}; VERSION LABEL={{ kiali_vars.deployment.version_label }}"
+
+- name: Determine what metadata labels to apply to all created resources
+  set_fact:
+    kiali_resource_metadata_labels:
+      app: kiali
+      version: "{{ kiali_vars.deployment.version_label }}"
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/version: "{{ kiali_vars.deployment.version_label }}"
+      app.kubernetes.io/instance: "{{ kiali_vars.deployment.instance_name }}"
+      app.kubernetes.io/part-of: kiali
+
+- name: Determine the extra custom labels to apply to all created resources
+  set_fact:
+    kiali_resource_metadata_labels: "{{ kiali_vars.deployment.extra_labels | combine(kiali_resource_metadata_labels) }}"
+  when:
+  - kiali_vars.deployment.extra_labels is defined
+  - kiali_vars.deployment.extra_labels | length > 0
+
+# Determine the namespaces Kiali is to be given access.
+# If the user did not specify Kiali's own namespace in the discovery selectors, it will be added to the list automatically.
+# NOTE: if deployment.cluster_wide_access is true, that means Kiali is to be given access to all namespaces via ClusterRoles
+#       (as opposed to individual roles in each accessible namespace). If deployment.cluster_wide_access is False then we
+#       create individual Roles per namespace.
+
+- name: Determine the Role and RoleBinding kinds that the operator will create and that the role templates will use
+  set_fact:
+    role_kind: "{{ 'ClusterRole' if kiali_vars.deployment.cluster_wide_access == True else 'Role' }}"
+    role_binding_kind: "{{ 'ClusterRoleBinding' if kiali_vars.deployment.cluster_wide_access == True else 'RoleBinding' }}"
+
+- name: Determine if the operator can support cluster wide access - can_i create clusterroles
+  register: can_i_create_clusterroles
+  ignore_errors: yes
+  k8s:
+    state: present
+    definition:
+      apiVersion: authorization.k8s.io/v1
+      kind: SelfSubjectAccessReview
+      spec:
+        resourceAttributes:
+          group: rbac.authorization.k8s.io
+          resource: clusterroles
+          verb: create
+  when:
+  - kiali_vars.deployment.cluster_wide_access == True
+
+- name: Determine if the operator can support cluster wide access - can_i create clusterrolebindings
+  register: can_i_create_clusterrolebindings
+  ignore_errors: yes
+  k8s:
+    state: present
+    definition:
+      apiVersion: authorization.k8s.io/v1
+      kind: SelfSubjectAccessReview
+      spec:
+        resourceAttributes:
+          group: rbac.authorization.k8s.io
+          resource: clusterrolebindings
+          verb: create
+  when:
+  - kiali_vars.deployment.cluster_wide_access == True
+
+- fail:
+    msg: "The operator cannot support deployment.cluster_wide_access set to 'true' because it does not have permissions to create ClusterRoles"
+  when:
+  - kiali_vars.deployment.cluster_wide_access == True
+  - can_i_create_clusterroles is defined
+  - can_i_create_clusterroles.result is defined
+  - can_i_create_clusterroles.result.status is defined
+  - can_i_create_clusterroles.result.status.allowed is defined
+  - can_i_create_clusterroles.result.status.allowed == False
+
+- fail:
+    msg: "The operator cannot support deployment.cluster_wide_access set to 'true' because it does not have permissions to create ClusterRoleBindings"
+  when:
+  - kiali_vars.deployment.cluster_wide_access == True
+  - can_i_create_clusterrolebindings is defined
+  - can_i_create_clusterrolebindings.result is defined
+  - can_i_create_clusterrolebindings.result.status is defined
+  - can_i_create_clusterrolebindings.result.status.allowed is defined
+  - can_i_create_clusterrolebindings.result.status.allowed == False
+
+- name: Validate oauth2 auth config for prometheus
+  fail:
+    msg: "external_services.prometheus.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
+  when:
+  - kiali_vars.external_services.prometheus is defined
+  - kiali_vars.external_services.prometheus.auth is defined
+  - kiali_vars.external_services.prometheus.auth.type | default('') == 'oauth2'
+  - (kiali_vars.external_services.prometheus.auth.oauth2 is not defined) or
+    (kiali_vars.external_services.prometheus.auth.oauth2.client_id | default('') == '') or
+    (kiali_vars.external_services.prometheus.auth.oauth2.token_url | default('') == '')
+
+- name: Validate oauth2 auth config for tracing
+  fail:
+    msg: "external_services.tracing.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
+  when:
+  - kiali_vars.external_services.tracing is defined
+  - kiali_vars.external_services.tracing.auth is defined
+  - kiali_vars.external_services.tracing.auth.type | default('') == 'oauth2'
+  - (kiali_vars.external_services.tracing.auth.oauth2 is not defined) or
+    (kiali_vars.external_services.tracing.auth.oauth2.client_id | default('') == '') or
+    (kiali_vars.external_services.tracing.auth.oauth2.token_url | default('') == '')
+
+- name: Validate oauth2 auth config for grafana
+  fail:
+    msg: "external_services.grafana.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
+  when:
+  - kiali_vars.external_services.grafana is defined
+  - kiali_vars.external_services.grafana.auth is defined
+  - kiali_vars.external_services.grafana.auth.type | default('') == 'oauth2'
+  - (kiali_vars.external_services.grafana.auth.oauth2 is not defined) or
+    (kiali_vars.external_services.grafana.auth.oauth2.client_id | default('') == '') or
+    (kiali_vars.external_services.grafana.auth.oauth2.token_url | default('') == '')
+
+- name: Validate oauth2 auth config for perses
+  fail:
+    msg: "external_services.perses.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
+  when:
+  - kiali_vars.external_services.perses is defined
+  - kiali_vars.external_services.perses.auth is defined
+  - kiali_vars.external_services.perses.auth.type | default('') == 'oauth2'
+  - (kiali_vars.external_services.perses.auth.oauth2 is not defined) or
+    (kiali_vars.external_services.perses.auth.oauth2.client_id | default('') == '') or
+    (kiali_vars.external_services.perses.auth.oauth2.token_url | default('') == '')
+
+- name: Validate oauth2 auth config for custom_dashboards prometheus
+  fail:
+    msg: "external_services.custom_dashboards.prometheus.auth.oauth2 requires both client_id and token_url when auth.type is 'oauth2'"
+  when:
+  - kiali_vars.external_services.custom_dashboards is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus.auth is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus.auth.type | default('') == 'oauth2'
+  - (kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2 is not defined) or
+    (kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2.client_id | default('') == '') or
+    (kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2.token_url | default('') == '')
+
+- name: Validate tracing oauth2 is not used with gRPC
+  fail:
+    msg: "external_services.tracing cannot use oauth2 auth with use_grpc=true (gRPC does not support HTTP-based OAuth2 token injection)"
+  when:
+  - kiali_vars.external_services.tracing is defined
+  - kiali_vars.external_services.tracing.auth is defined
+  - kiali_vars.external_services.tracing.auth.type | default('') == 'oauth2'
+  - kiali_vars.external_services.tracing.use_grpc | default(True) | bool == True
+
+- name: Validate prometheus oauth2 is not used with use_kiali_token
+  fail:
+    msg: "external_services.prometheus cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
+  when:
+  - kiali_vars.external_services.prometheus is defined
+  - kiali_vars.external_services.prometheus.auth is defined
+  - kiali_vars.external_services.prometheus.auth.type | default('') == 'oauth2'
+  - kiali_vars.external_services.prometheus.auth.use_kiali_token | default(False) | bool == True
+
+- name: Validate tracing oauth2 is not used with use_kiali_token
+  fail:
+    msg: "external_services.tracing cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
+  when:
+  - kiali_vars.external_services.tracing is defined
+  - kiali_vars.external_services.tracing.auth is defined
+  - kiali_vars.external_services.tracing.auth.type | default('') == 'oauth2'
+  - kiali_vars.external_services.tracing.auth.use_kiali_token | default(False) | bool == True
+
+- name: Validate grafana oauth2 is not used with use_kiali_token
+  fail:
+    msg: "external_services.grafana cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
+  when:
+  - kiali_vars.external_services.grafana is defined
+  - kiali_vars.external_services.grafana.auth is defined
+  - kiali_vars.external_services.grafana.auth.type | default('') == 'oauth2'
+  - kiali_vars.external_services.grafana.auth.use_kiali_token | default(False) | bool == True
+
+- name: Validate perses oauth2 is not used with use_kiali_token
+  fail:
+    msg: "external_services.perses cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
+  when:
+  - kiali_vars.external_services.perses is defined
+  - kiali_vars.external_services.perses.auth is defined
+  - kiali_vars.external_services.perses.auth.type | default('') == 'oauth2'
+  - kiali_vars.external_services.perses.auth.use_kiali_token | default(False) | bool == True
+
+- name: Validate custom_dashboards prometheus oauth2 is not used with use_kiali_token
+  fail:
+    msg: "external_services.custom_dashboards.prometheus cannot use both oauth2 auth and use_kiali_token (conflicting authentication methods)"
+  when:
+  - kiali_vars.external_services.custom_dashboards is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus.auth is defined
+  - kiali_vars.external_services.custom_dashboards.prometheus.auth.type | default('') == 'oauth2'
+  - kiali_vars.external_services.custom_dashboards.prometheus.auth.use_kiali_token | default(False) | bool == True
+
+- include_tasks: get-discovery-selector-namespaces.yml
+
+# If Istio and Kiali are not co-located, the user will need to explicitly set discovery selectors themselves to tell Kiali where that namespace is.
+# TODO: Is there a way to ensure the Istio control plane namespace(s) are also accessible?
+- name: Make sure the Kiali deployment namespace is accessible
+  set_fact:
+    discovery_selector_namespaces: "{{ ((discovery_selector_namespaces | default([])) + [ kiali_vars.deployment.namespace ]) | unique | sort }}"
+
+- name: Listing of all namespaces that are accessible to Kiali
+  debug:
+    msg: "Cluster-wide Access=[{{ kiali_vars.deployment.cluster_wide_access }}], Discovered Namespaces={{ discovery_selector_namespaces }}"
+
+- name: Abort if all namespace access is not allowed
+  fail:
+    msg: "The operator is forbidden from installing Kiali with deployment.cluster_wide_access set to 'true'"
+  when:
+  - kiali_vars.deployment.cluster_wide_access == True
+  - lookup('env', 'ALLOW_ALL_ACCESSIBLE_NAMESPACES') | default('false', True) != "true"
+
+# We want to convert discovery selectors so they use only matchExpressions values on namespace names so the server can find the exact
+# namespaces we found since these namespaces are the only ones that the Kiali Server will be granted permission to see.
+# Note that we only do this if cluster_wide_access is False, because that is when the operator will create the Roles for each namespace.
+# If the server will have cluster wide access, all namespaces can be accessed via the main ClusterRole, so it is OK if the server
+# discovers different namespaces using the original selectors.
+- name: Convert the discovery selectors to all matchExpressions values so they match the namespace names.
+  set_fact:
+    discovery_selectors_match_expressions: "{{ (discovery_selectors_match_expressions|default([])) + [{'matchExpressions': [{'key': 'kubernetes.io/metadata.name', 'operator': 'In', 'values': discovery_selector_namespaces }] }] }}"
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+- set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'discovery_selectors': {'default': discovery_selectors_match_expressions}}}, recursive=True) }}"
+  when:
+  - discovery_selectors_match_expressions is defined
+
+- name: Define the namespace labels that will be used when needed
+  set_fact:
+    kiali_instance_label_name: "kiali.io/{{ kiali_vars.deployment.instance_name }}.home"
+    kiali_instance_label_value: "{{ kiali_vars.deployment.namespace }}"
+
+# If the signing key is not empty string, and is not of the special value secret:name:key,
+# do some validation on it's length
+- name: Validate signing key, if it is set in the CR
+  fail:
+    msg: "Signing key must be 16, 24 or 32 byte length"
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.auth.strategy != 'anonymous'
+  - kiali_vars.login_token.signing_key != ""
+  - not(kiali_vars.login_token.signing_key | regex_search('secret:.+:.+'))
+  - kiali_vars.login_token.signing_key | length != 16
+  - kiali_vars.login_token.signing_key | length != 24
+  - kiali_vars.login_token.signing_key | length != 32
+
+# If the signing key is empty string, we need to ensure a signing key secret exists. If one does not exist, we need to generate one.
+# Note that to avoid granting to the operator the very powerful permission to CRUD all secrets in all namespaces, we always generate
+# a signing key secret with the name "kiali-signing-key" regardless of the value of kiali_vars.deployment.instance_name.
+# Thus, all Kiali instances will be using the same signing key secret name. If the user does not want this, they can generate their
+# own secret with their own key (which is a smart thing to do anyway). The user tells the operator what the name of that secret
+# signing key is via "login_token.signing_key" with value "secret:<theSecretName>:<theSecretKey>".
+
+- name: Get information about any existing signing key secret if we need to know if it exists or not
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: kiali-signing-key
+  register: signing_key_secret_raw
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.login_token.signing_key == ""
+
+- name: Create kiali-signing-key secret to store a random signing key if a secret does not already exist and we need one
+  k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+        name: kiali-signing-key
+        labels: "{{ kiali_resource_metadata_labels }}"
+      type: Opaque
+      data:
+        key: "{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') | b64encode }}"
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.login_token.signing_key == ""
+  - signing_key_secret_raw is defined
+  - signing_key_secret_raw.resources is defined
+  - signing_key_secret_raw.resources | length == 0
+
+# Because we must use a fixed name for the secret, we need to attach a label to indicate this Kiali install will be using it.
+# This allows multiple Kiali instances deployed in the same namespace to share the secret. This secret won't be removed
+# as long as our label exists on the secret resource.
+- name: Add label to kiali-signing-key secret to make it known this Kiali instance will be using it
+  k8s:
+    state: present
+    definition: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: "{{ kiali_vars.deployment.namespace }}"
+        name: kiali-signing-key
+        labels:
+          {{ kiali_instance_label_name }}: {{ kiali_instance_label_value }}
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.login_token.signing_key == ""
+
+- name: Point signing key to the generated secret
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'login_token': {'signing_key': 'secret:kiali-signing-key:key'}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.login_token.signing_key == ""
+
+# Some credentials in the config can be overridden by secrets that are to be mounted on the file system.
+# Prepare these overrides that need to be defined as volumes in the deployment.
+
+- name: Prepare secret volumes for external services
+  vars:
+    kiali_deployment_secret_volumes_yaml: |-
+      {# Initialize #}
+      {% set d = {} %}
+
+      {# Prepare the secret volume for prometheus username #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.username | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'prometheus-username': {'secret_name': kiali_vars.external_services.prometheus.auth.username | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.username | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for prometheus password #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.password | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'prometheus-password': {'secret_name': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for prometheus token #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.token | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'prometheus-token': {'secret_name': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for prometheus cert_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.cert_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'prometheus-cert': {'secret_name': kiali_vars.external_services.prometheus.auth.cert_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.prometheus.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for prometheus key_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.key_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'prometheus-key': {'secret_name': kiali_vars.external_services.prometheus.auth.key_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.key_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.prometheus.auth.key_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for tracing username #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.tracing is defined and kiali_vars.external_services.tracing.enabled is defined and kiali_vars.external_services.tracing.enabled|bool == True and kiali_vars.external_services.tracing.auth is defined and (kiali_vars.external_services.tracing.auth.username | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'tracing-username': {'secret_name': kiali_vars.external_services.tracing.auth.username | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.username | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for tracing password #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.tracing is defined and kiali_vars.external_services.tracing.enabled is defined and kiali_vars.external_services.tracing.enabled|bool == True and kiali_vars.external_services.tracing.auth is defined and (kiali_vars.external_services.tracing.auth.password | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'tracing-password': {'secret_name': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for tracing token #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.tracing is defined and kiali_vars.external_services.tracing.enabled is defined and kiali_vars.external_services.tracing.enabled|bool == True and kiali_vars.external_services.tracing.auth is defined and (kiali_vars.external_services.tracing.auth.token | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'tracing-token': {'secret_name': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for tracing cert_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.tracing is defined and kiali_vars.external_services.tracing.enabled is defined and kiali_vars.external_services.tracing.enabled|bool == True and kiali_vars.external_services.tracing.auth is defined and (kiali_vars.external_services.tracing.auth.cert_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'tracing-cert': {'secret_name': kiali_vars.external_services.tracing.auth.cert_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.tracing.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for tracing key_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.tracing is defined and kiali_vars.external_services.tracing.enabled is defined and kiali_vars.external_services.tracing.enabled|bool == True and kiali_vars.external_services.tracing.auth is defined and (kiali_vars.external_services.tracing.auth.key_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'tracing-key': {'secret_name': kiali_vars.external_services.tracing.auth.key_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.key_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.tracing.auth.key_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for grafana username #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.grafana is defined and kiali_vars.external_services.grafana.enabled is defined and kiali_vars.external_services.grafana.enabled|bool == True and kiali_vars.external_services.grafana.auth is defined and (kiali_vars.external_services.grafana.auth.username | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'grafana-username': {'secret_name': kiali_vars.external_services.grafana.auth.username | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.username | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for grafana password #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.grafana is defined and kiali_vars.external_services.grafana.enabled is defined and kiali_vars.external_services.grafana.enabled|bool == True and kiali_vars.external_services.grafana.auth is defined and (kiali_vars.external_services.grafana.auth.password | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'grafana-password': {'secret_name': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for grafana token #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.grafana is defined and kiali_vars.external_services.grafana.enabled is defined and kiali_vars.external_services.grafana.enabled|bool == True and kiali_vars.external_services.grafana.auth is defined and (kiali_vars.external_services.grafana.auth.token | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'grafana-token': {'secret_name': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for grafana cert_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.grafana is defined and kiali_vars.external_services.grafana.enabled is defined and kiali_vars.external_services.grafana.enabled|bool == True and kiali_vars.external_services.grafana.auth is defined and (kiali_vars.external_services.grafana.auth.cert_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'grafana-cert': {'secret_name': kiali_vars.external_services.grafana.auth.cert_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.grafana.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for grafana key_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.grafana is defined and kiali_vars.external_services.grafana.enabled is defined and kiali_vars.external_services.grafana.enabled|bool == True and kiali_vars.external_services.grafana.auth is defined and (kiali_vars.external_services.grafana.auth.key_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'grafana-key': {'secret_name': kiali_vars.external_services.grafana.auth.key_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.key_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.grafana.auth.key_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for perses username #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.perses is defined and kiali_vars.external_services.perses.enabled is defined and kiali_vars.external_services.perses.enabled|bool == True and kiali_vars.external_services.perses.auth is defined and (kiali_vars.external_services.perses.auth.username | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'perses-username': {'secret_name': kiali_vars.external_services.perses.auth.username | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.perses.auth.username | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for perses password #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.perses is defined and kiali_vars.external_services.perses.enabled is defined and kiali_vars.external_services.perses.enabled|bool == True and kiali_vars.external_services.perses.auth is defined and (kiali_vars.external_services.perses.auth.password | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'perses-password': {'secret_name': kiali_vars.external_services.perses.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.perses.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for perses cert_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.perses is defined and kiali_vars.external_services.perses.enabled is defined and kiali_vars.external_services.perses.enabled|bool == True and kiali_vars.external_services.perses.auth is defined and (kiali_vars.external_services.perses.auth.cert_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'perses-cert': {'secret_name': kiali_vars.external_services.perses.auth.cert_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.perses.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.perses.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for perses key_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.perses is defined and kiali_vars.external_services.perses.enabled is defined and kiali_vars.external_services.perses.enabled|bool == True and kiali_vars.external_services.perses.auth is defined and (kiali_vars.external_services.perses.auth.key_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'perses-key': {'secret_name': kiali_vars.external_services.perses.auth.key_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.perses.auth.key_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.perses.auth.key_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for prometheus oauth2 client_secret #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.prometheus is defined and kiali_vars.external_services.prometheus.enabled is defined and kiali_vars.external_services.prometheus.enabled|bool == True and kiali_vars.external_services.prometheus.auth is defined and (kiali_vars.external_services.prometheus.auth.type | default('')) == 'oauth2' and kiali_vars.external_services.prometheus.auth.oauth2 is defined and (kiali_vars.external_services.prometheus.auth.oauth2.client_secret | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'prometheus-oauth2-client-secret': {'secret_name': kiali_vars.external_services.prometheus.auth.oauth2.client_secret | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.prometheus.auth.oauth2.client_secret | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for tracing oauth2 client_secret #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.tracing is defined and kiali_vars.external_services.tracing.enabled is defined and kiali_vars.external_services.tracing.enabled|bool == True and kiali_vars.external_services.tracing.auth is defined and (kiali_vars.external_services.tracing.auth.type | default('')) == 'oauth2' and kiali_vars.external_services.tracing.auth.oauth2 is defined and (kiali_vars.external_services.tracing.auth.oauth2.client_secret | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'tracing-oauth2-client-secret': {'secret_name': kiali_vars.external_services.tracing.auth.oauth2.client_secret | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.tracing.auth.oauth2.client_secret | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for grafana oauth2 client_secret #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.grafana is defined and kiali_vars.external_services.grafana.enabled is defined and kiali_vars.external_services.grafana.enabled|bool == True and kiali_vars.external_services.grafana.auth is defined and (kiali_vars.external_services.grafana.auth.type | default('')) == 'oauth2' and kiali_vars.external_services.grafana.auth.oauth2 is defined and (kiali_vars.external_services.grafana.auth.oauth2.client_secret | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'grafana-oauth2-client-secret': {'secret_name': kiali_vars.external_services.grafana.auth.oauth2.client_secret | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.grafana.auth.oauth2.client_secret | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for perses oauth2 client_secret #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.perses is defined and kiali_vars.external_services.perses.enabled is defined and kiali_vars.external_services.perses.enabled|bool == True and kiali_vars.external_services.perses.auth is defined and (kiali_vars.external_services.perses.auth.type | default('')) == 'oauth2' and kiali_vars.external_services.perses.auth.oauth2 is defined and (kiali_vars.external_services.perses.auth.oauth2.client_secret | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'perses-oauth2-client-secret': {'secret_name': kiali_vars.external_services.perses.auth.oauth2.client_secret | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.perses.auth.oauth2.client_secret | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for login token signing key #}
+      {% if kiali_vars is defined and kiali_vars.login_token is defined and (kiali_vars.login_token.signing_key | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'login-token-signing-key': {'secret_name': kiali_vars.login_token.signing_key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.login_token.signing_key | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for customdashboards prometheus username #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.custom_dashboards is defined and kiali_vars.external_services.custom_dashboards.enabled is defined and kiali_vars.external_services.custom_dashboards.enabled|bool == True and kiali_vars.external_services.custom_dashboards.prometheus is defined and kiali_vars.external_services.custom_dashboards.prometheus.auth is defined and (kiali_vars.external_services.custom_dashboards.prometheus.auth.username | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'customdashboards-prometheus-username': {'secret_name': kiali_vars.external_services.custom_dashboards.prometheus.auth.username | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.custom_dashboards.prometheus.auth.username | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for customdashboards prometheus password #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.custom_dashboards is defined and kiali_vars.external_services.custom_dashboards.enabled is defined and kiali_vars.external_services.custom_dashboards.enabled|bool == True and kiali_vars.external_services.custom_dashboards.prometheus is defined and kiali_vars.external_services.custom_dashboards.prometheus.auth is defined and (kiali_vars.external_services.custom_dashboards.prometheus.auth.password | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'customdashboards-prometheus-password': {'secret_name': kiali_vars.external_services.custom_dashboards.prometheus.auth.password | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.custom_dashboards.prometheus.auth.password | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for customdashboards prometheus token #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.custom_dashboards is defined and kiali_vars.external_services.custom_dashboards.enabled is defined and kiali_vars.external_services.custom_dashboards.enabled|bool == True and kiali_vars.external_services.custom_dashboards.prometheus is defined and kiali_vars.external_services.custom_dashboards.prometheus.auth is defined and (kiali_vars.external_services.custom_dashboards.prometheus.auth.token | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'customdashboards-prometheus-token': {'secret_name': kiali_vars.external_services.custom_dashboards.prometheus.auth.token | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.custom_dashboards.prometheus.auth.token | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for customdashboards prometheus cert_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.custom_dashboards is defined and kiali_vars.external_services.custom_dashboards.enabled is defined and kiali_vars.external_services.custom_dashboards.enabled|bool == True and kiali_vars.external_services.custom_dashboards.prometheus is defined and kiali_vars.external_services.custom_dashboards.prometheus.auth is defined and (kiali_vars.external_services.custom_dashboards.prometheus.auth.cert_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'customdashboards-prometheus-cert': {'secret_name': kiali_vars.external_services.custom_dashboards.prometheus.auth.cert_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.custom_dashboards.prometheus.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.custom_dashboards.prometheus.auth.cert_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for customdashboards prometheus key_file #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.custom_dashboards is defined and kiali_vars.external_services.custom_dashboards.enabled is defined and kiali_vars.external_services.custom_dashboards.enabled|bool == True and kiali_vars.external_services.custom_dashboards.prometheus is defined and kiali_vars.external_services.custom_dashboards.prometheus.auth is defined and (kiali_vars.external_services.custom_dashboards.prometheus.auth.key_file | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'customdashboards-prometheus-key': {'secret_name': kiali_vars.external_services.custom_dashboards.prometheus.auth.key_file | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.custom_dashboards.prometheus.auth.key_file | regex_replace('secret:.+:(.+)', '\\1'), 'path': kiali_vars.external_services.custom_dashboards.prometheus.auth.key_file | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volume for customdashboards prometheus oauth2 client_secret #}
+      {% if kiali_vars is defined and kiali_vars.external_services is defined and kiali_vars.external_services.custom_dashboards is defined and kiali_vars.external_services.custom_dashboards.enabled is defined and kiali_vars.external_services.custom_dashboards.enabled|bool == True and kiali_vars.external_services.custom_dashboards.prometheus is defined and kiali_vars.external_services.custom_dashboards.prometheus.auth is defined and (kiali_vars.external_services.custom_dashboards.prometheus.auth.type | default('')) == 'oauth2' and kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2 is defined and (kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2.client_secret | default('')) | regex_search('secret:.+:.+') %}
+      {% set d = d | combine({'customdashboards-prometheus-oauth2-client-secret': {'secret_name': kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2.client_secret | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': kiali_vars.external_services.custom_dashboards.prometheus.auth.oauth2.client_secret | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+
+      {# Prepare the secret volumes for chat_ai provider and model keys #}
+      {# Note: provider.enabled and model.enabled default to false if not specified #}
+      {% if kiali_vars is defined and kiali_vars.chat_ai is defined and kiali_vars.chat_ai.enabled is defined and kiali_vars.chat_ai.enabled|bool and kiali_vars.chat_ai.providers is defined and kiali_vars.chat_ai.providers|length > 0 %}
+      {% for provider in kiali_vars.chat_ai.providers %}
+      {% set provider_name = (provider.name | default('', true) | lower | regex_replace('[^a-z0-9-]+', '-') | regex_replace('(^-+|-+$)', '')) | default('unknown', true) %}
+      {% if provider.enabled is defined and provider.enabled|bool %}
+      {% if (provider.key | default('', true)) | regex_search('secret:.+:.+') %}
+      {% set _ = d.update({('chat-ai-provider-' ~ provider_name): {'secret_name': provider.key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': provider.key | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+      {% endif %}
+      {% if provider.models is defined and provider.models|length > 0 %}
+      {% for model in provider.models %}
+      {% set model_name = (model.name | default('', true) | lower | regex_replace('[^a-z0-9-]+', '-') | regex_replace('(^-+|-+$)', '')) | default('unknown', true) %}
+      {% if (provider.enabled is defined and provider.enabled|bool) and (model.enabled is defined and model.enabled|bool) %}
+      {% if (model.key | default('', true)) | regex_search('secret:.+:.+') %}
+      {% set _ = d.update({('chat-ai-model-' ~ provider_name ~ '-' ~ model_name): {'secret_name': model.key | regex_replace('secret:(.+):.+', '\\1'), 'secret_key': model.key | regex_replace('secret:.+:(.+)', '\\1') }}) %}
+      {% endif %}
+      {% endif %}
+      {% endfor %}
+      {% endif %}
+      {% endfor %}
+      {% endif %}
+
+      {# Set the yaml to the new dict #}
+      {{ d | to_nice_yaml }}
+  set_fact:
+    kiali_deployment_secret_volumes: "{{ kiali_deployment_secret_volumes_yaml | from_yaml }}"
+
+# Prepare to mount remote cluster secrets. These must exist in the Kiali deployment namespace because that is required in order to mount them to the pod.
+# We ignore any secrets named "kiali-multi-cluster-secret" because that will always be mounted, though it is optional.
+- set_fact:
+    kiali_deployment_remote_cluster_secret_volumes: {}
+
+- name: Autodetect remote cluster secrets within the Kiali deployment namespace
+  vars:
+    all_remote_cluster_secrets: "{{ query(k8s_plugin, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='Secret', label_selector=kiali_vars.clustering.autodetect_secrets.label) }}"
+  loop: "{{ all_remote_cluster_secrets }}"
+  set_fact:
+    kiali_deployment_remote_cluster_secret_volumes: "{{ kiali_deployment_remote_cluster_secret_volumes | combine({ item.metadata.annotations['kiali.io/cluster']|default(item.metadata.name): {'secret_name': item.metadata.name }}) }}"
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.clustering.autodetect_secrets.enabled
+  - item.metadata.name != "kiali-multi-cluster-secret"
+
+- name: Prepare the manually declared remote clusters
+  loop: "{{ kiali_vars.clustering.clusters }}"
+  set_fact:
+    kiali_deployment_remote_cluster_secret_volumes: "{{ kiali_deployment_remote_cluster_secret_volumes | combine(({ item.name: {'secret_name': item.secret_name }}) if (item.secret_name is defined and item.secret_name | length > 0) else {}) }}"
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.clustering.clusters | length > 0
+  - (item.secret_name is not defined) or (item.secret_name != "kiali-multi-cluster-secret")
+
+# Security guardrails for user-defined initContainers.
+#
+# These tasks implement security protections against:
+# 1. Privilege Escalation: Enforces restrictive security context (same as main Kiali container)
+# 2. Filesystem-based Attacks: Prevents write access to sensitive volumes
+# 3. Environment Tampering: Ensures initContainers run with minimal privileges
+#
+# The security context enforced includes:
+# - allowPrivilegeEscalation: false
+# - privileged: false
+# - readOnlyRootFilesystem: true
+# - runAsNonRoot: true
+# - capabilities: drop ALL
+#
+# Secret-backed volumes are automatically forced to read-only.
+# These security settings cannot be overridden by user-defined initContainers.
+
+- name: Identify secret-backed volumes in Kiali deployment
+  set_fact:
+    kiali_secret_volume_names: >-
+      {{
+        ([
+          'kiali-secret',
+          'kiali-multi-cluster-secret'
+        ] +
+        (kiali_deployment_secret_volumes | list) +
+        (kiali_deployment_remote_cluster_secret_volumes | list) +
+        (kiali_vars.deployment.custom_secrets | selectattr('csi', 'undefined') | map(attribute='name') | list))
+        | unique
+      }}
+  when:
+  - kiali_vars.deployment.additional_pod_containers_yaml|length > 0 or kiali_vars.deployment.additional_pod_init_containers_yaml|length > 0
+
+- name: Validate container volume mount security
+  vars:
+    kiali_unsafe_volume_mounts: >-
+      {{
+        kiali_vars.deployment.additional_pod_containers_yaml
+        | selectattr('volumeMounts', 'defined')
+        | map(attribute='volumeMounts')
+        | flatten
+        | selectattr('name', 'in', kiali_secret_volume_names)
+        | selectattr('readOnly', 'defined')
+        | selectattr('readOnly', 'equalto', false)
+        | list
+      }}
+    kiali_unsafe_volume_names: >-
+      {{
+        kiali_unsafe_volume_mounts
+        | map(attribute='name')
+        | unique
+        | list
+      }}
+  fail:
+    msg: "User-defined containers cannot mount these secret-backed volumes as read-write; they must be mounted read-only for security purposes: {{ kiali_unsafe_volume_names | join(', ') }}"
+  when:
+  - kiali_vars.deployment.additional_pod_containers_yaml|length > 0
+  - kiali_unsafe_volume_mounts|length > 0
+
+# Note: initContainer volume mount security is automatically enforced
+# by the security guardrails below which force secret volumes to readOnly: true
+
+- name: Apply security guardrails to user-defined containers
+  vars:
+    # Define the mandatory security context
+    kiali_mandatory_security_context:
+      allowPrivilegeEscalation: false
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: ['ALL']
+    # Apply security guardrails to each container using pure Ansible
+    # If ALLOW_SECURITY_CONTEXT_OVERRIDE is true, preserve user-provided security contexts
+    # Otherwise, apply mandatory security context
+    kiali_secured_containers: >-
+      {%- set secured_containers = [] -%}
+      {%- for container in kiali_vars.deployment.additional_pod_containers_yaml -%}
+        {%- if lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') == "true" and 'securityContext' in container and container.securityContext -%}
+          {%- set secured_container = container.copy() -%}
+        {%- else -%}
+          {%- set secured_container = container | combine({'securityContext': kiali_mandatory_security_context}) -%}
+        {%- endif -%}
+        {%- if 'volumeMounts' in secured_container -%}
+          {%- set secured_mounts = [] -%}
+          {%- for mount in secured_container.volumeMounts -%}
+            {%- set secured_mount = mount.copy() -%}
+            {%- if mount.name in kiali_secret_volume_names -%}
+              {%- set _ = secured_mount.update({'readOnly': true}) -%}
+            {%- endif -%}
+            {%- set _ = secured_mounts.append(secured_mount) -%}
+          {%- endfor -%}
+          {%- set _ = secured_container.update({'volumeMounts': secured_mounts}) -%}
+        {%- endif -%}
+        {%- set _ = secured_containers.append(secured_container) -%}
+      {%- endfor -%}
+      {{ secured_containers }}
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'additional_pod_containers_yaml': kiali_secured_containers}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.additional_pod_containers_yaml|length > 0
+
+- name: Log security context overrides for additional containers
+  vars:
+    kiali_privileged_containers: >-
+      {{
+        kiali_vars.deployment.additional_pod_containers_yaml
+        | selectattr('securityContext', 'defined')
+        | selectattr('securityContext.privileged', 'defined')
+        | selectattr('securityContext.privileged', 'equalto', true)
+        | map(attribute='name')
+        | list
+      }}
+    kiali_privilege_escalation_containers: >-
+      {{
+        kiali_vars.deployment.additional_pod_containers_yaml
+        | selectattr('securityContext', 'defined')
+        | selectattr('securityContext.allowPrivilegeEscalation', 'defined')
+        | selectattr('securityContext.allowPrivilegeEscalation', 'equalto', true)
+        | map(attribute='name')
+        | list
+      }}
+    kiali_dangerous_capabilities_containers: >-
+      {%- set dangerous_caps = ['SYS_ADMIN', 'NET_ADMIN', 'SYS_TIME', 'SYS_MODULE', 'SYS_PTRACE'] -%}
+      {%- set containers_with_dangerous_caps = [] -%}
+      {%- for container in kiali_vars.deployment.additional_pod_containers_yaml -%}
+        {%- if container.securityContext is defined and container.securityContext.capabilities is defined and container.securityContext.capabilities.add is defined -%}
+          {%- set has_dangerous_cap = false -%}
+          {%- for cap in container.securityContext.capabilities.add -%}
+            {%- if cap in dangerous_caps -%}
+              {%- set has_dangerous_cap = true -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- if has_dangerous_cap -%}
+            {%- set _ = containers_with_dangerous_caps.append(container.name) -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ containers_with_dangerous_caps | list }}
+    kiali_writable_root_containers: >-
+      {{
+        kiali_vars.deployment.additional_pod_containers_yaml
+        | selectattr('securityContext', 'defined')
+        | selectattr('securityContext.readOnlyRootFilesystem', 'defined')
+        | selectattr('securityContext.readOnlyRootFilesystem', 'equalto', false)
+        | map(attribute='name')
+        | list
+      }}
+  debug:
+    msg: >-
+      SECURITY INFO: Additional containers security analysis:
+      - Container names: {{ kiali_vars.deployment.additional_pod_containers_yaml | map(attribute='name') | join(', ') }}
+      - ALLOW_SECURITY_CONTEXT_OVERRIDE: {{ lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') | default('false') }}
+      - Security behavior: {{ 'User security contexts preserved (if provided)' if lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') == 'true' else 'Mandatory restrictive security context applied' }}
+      {% if lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') == "true" and (kiali_privileged_containers|length > 0 or kiali_privilege_escalation_containers|length > 0 or kiali_dangerous_capabilities_containers|length > 0 or kiali_writable_root_containers|length > 0) -%}
+      - SECURITY ALERT: Containers with elevated privileges detected:
+        * Privileged containers (privileged: true): {{ kiali_privileged_containers | join(', ') if kiali_privileged_containers else 'None' }}
+        * Privilege escalation allowed: {{ kiali_privilege_escalation_containers | join(', ') if kiali_privilege_escalation_containers else 'None' }}
+        * Dangerous capabilities: {{ kiali_dangerous_capabilities_containers | join(', ') if kiali_dangerous_capabilities_containers else 'None' }}
+        * Writable root filesystem: {{ kiali_writable_root_containers | join(', ') if kiali_writable_root_containers else 'None' }}
+      {%- else -%}
+      - No elevated privileges detected in containers or security contexts enforced by operator
+      {%- endif %}
+  when:
+  - kiali_vars.deployment.additional_pod_containers_yaml|length > 0
+
+- name: Apply security guardrails to user-defined initContainers
+  vars:
+    # Define the mandatory security context
+    kiali_mandatory_security_context:
+      allowPrivilegeEscalation: false
+      privileged: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: ['ALL']
+    # Apply security guardrails to each initContainer using pure Ansible
+    # If ALLOW_SECURITY_CONTEXT_OVERRIDE is true, preserve user-provided security contexts
+    # Otherwise, apply mandatory security context
+    kiali_secured_init_containers: >-
+      {%- set secured_containers = [] -%}
+      {%- for container in kiali_vars.deployment.additional_pod_init_containers_yaml -%}
+        {%- if lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') == "true" and 'securityContext' in container and container.securityContext -%}
+          {%- set secured_container = container.copy() -%}
+        {%- else -%}
+          {%- set secured_container = container | combine({'securityContext': kiali_mandatory_security_context}) -%}
+        {%- endif -%}
+        {%- if 'volumeMounts' in secured_container -%}
+          {%- set secured_mounts = [] -%}
+          {%- for mount in secured_container.volumeMounts -%}
+            {%- set secured_mount = mount.copy() -%}
+            {%- if mount.name in kiali_secret_volume_names -%}
+              {%- set _ = secured_mount.update({'readOnly': true}) -%}
+            {%- endif -%}
+            {%- set _ = secured_mounts.append(secured_mount) -%}
+          {%- endfor -%}
+          {%- set _ = secured_container.update({'volumeMounts': secured_mounts}) -%}
+        {%- endif -%}
+        {%- set _ = secured_containers.append(secured_container) -%}
+      {%- endfor -%}
+      {{ secured_containers }}
+  set_fact:
+    kiali_vars: "{{ kiali_vars | combine({'deployment': {'additional_pod_init_containers_yaml': kiali_secured_init_containers}}, recursive=True) }}"
+  when:
+  - kiali_vars.deployment.additional_pod_init_containers_yaml|length > 0
+
+- name: Log security context overrides for additional initContainers
+  vars:
+    kiali_privileged_init_containers: >-
+      {{
+        kiali_vars.deployment.additional_pod_init_containers_yaml
+        | selectattr('securityContext', 'defined')
+        | selectattr('securityContext.privileged', 'defined')
+        | selectattr('securityContext.privileged', 'equalto', true)
+        | map(attribute='name')
+        | list
+      }}
+    kiali_privilege_escalation_init_containers: >-
+      {{
+        kiali_vars.deployment.additional_pod_init_containers_yaml
+        | selectattr('securityContext', 'defined')
+        | selectattr('securityContext.allowPrivilegeEscalation', 'defined')
+        | selectattr('securityContext.allowPrivilegeEscalation', 'equalto', true)
+        | map(attribute='name')
+        | list
+      }}
+    kiali_dangerous_capabilities_init_containers: >-
+      {%- set dangerous_caps = ['SYS_ADMIN', 'NET_ADMIN', 'SYS_TIME', 'SYS_MODULE', 'SYS_PTRACE'] -%}
+      {%- set containers_with_dangerous_caps = [] -%}
+      {%- for container in kiali_vars.deployment.additional_pod_init_containers_yaml -%}
+        {%- if container.securityContext is defined and container.securityContext.capabilities is defined and container.securityContext.capabilities.add is defined -%}
+          {%- set has_dangerous_cap = false -%}
+          {%- for cap in container.securityContext.capabilities.add -%}
+            {%- if cap in dangerous_caps -%}
+              {%- set has_dangerous_cap = true -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- if has_dangerous_cap -%}
+            {%- set _ = containers_with_dangerous_caps.append(container.name) -%}
+          {%- endif -%}
+        {%- endif -%}
+      {%- endfor -%}
+      {{ containers_with_dangerous_caps | list }}
+    kiali_writable_root_init_containers: >-
+      {{
+        kiali_vars.deployment.additional_pod_init_containers_yaml
+        | selectattr('securityContext', 'defined')
+        | selectattr('securityContext.readOnlyRootFilesystem', 'defined')
+        | selectattr('securityContext.readOnlyRootFilesystem', 'equalto', false)
+        | map(attribute='name')
+        | list
+      }}
+  debug:
+    msg: >-
+      SECURITY INFO: InitContainers deployed with security analysis:
+      - InitContainer names: {{ kiali_vars.deployment.additional_pod_init_containers_yaml | map(attribute='name') | join(', ') }}
+      - ALLOW_SECURITY_CONTEXT_OVERRIDE: {{ lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') | default('false') }}
+      - Security behavior: {{ 'User security contexts preserved (if provided)' if lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') == 'true' else 'Mandatory restrictive security context applied' }}
+      {% if lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') == "true" and (kiali_privileged_init_containers|length > 0 or kiali_privilege_escalation_init_containers|length > 0 or kiali_dangerous_capabilities_init_containers|length > 0 or kiali_writable_root_init_containers|length > 0) -%}
+      - SECURITY ALERT: InitContainers with elevated privileges detected:
+        * Privileged initContainers (privileged: true): {{ kiali_privileged_init_containers | join(', ') if kiali_privileged_init_containers else 'None' }}
+        * Privilege escalation allowed: {{ kiali_privilege_escalation_init_containers | join(', ') if kiali_privilege_escalation_init_containers else 'None' }}
+        * Dangerous capabilities: {{ kiali_dangerous_capabilities_init_containers | join(', ') if kiali_dangerous_capabilities_init_containers else 'None' }}
+        * Writable root filesystem: {{ kiali_writable_root_init_containers | join(', ') if kiali_writable_root_init_containers else 'None' }}
+      {%- else -%}
+      - No elevated privileges detected in initContainers or security contexts enforced by operator
+      {%- endif %}
+  when:
+  - kiali_vars.deployment.additional_pod_init_containers_yaml|length > 0
+
+# The following few tasks read the current Kiali configmap (if one exists) in order to find out how Kiali is currently configured.
+
+- name: Find current configmap, if it exists
+  set_fact:
+    current_configmap: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='v1', kind='ConfigMap') }}"
+
+- name: Find some current configuration settings, if they exist
+  set_fact:
+    current_view_only_mode: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.view_only_mode') }}"
+    current_image_name: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_name') }}"
+    current_image_version: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.image_version') }}"
+    current_instance_name: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.instance_name') }}"
+    current_auth_strategy: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('auth.strategy') }}"
+    current_cluster_wide_access: "{{ current_configmap.data['config.yaml'] | from_yaml | json_query('deployment.cluster_wide_access') }}"
+  when:
+  - current_configmap is defined
+  - current_configmap.data is defined
+  - current_configmap.data['config.yaml'] is defined
+
+- name: Examine namespace labels in order to determine the namespaces that Kiali currently has access to
+  vars:
+    label: "{{ kiali_instance_label_name }}={{ kiali_instance_label_value }}"
+  set_fact:
+    namespaces_currently_accessible: "{{ query(k8s_plugin, kind='Namespace', label_selector=label) | default({}) | json_query('[].metadata.name') }}"
+
+- name: Determine if we are moving to cluster-wide-access in which case we need to pretend to make all namespaces inaccessible so the Roles are removed
+  set_fact:
+    namespaces_no_longer_accessible: "{{ namespaces_currently_accessible }}"
+  when:
+  - namespaces_currently_accessible is defined
+  - current_cluster_wide_access is defined
+  - current_cluster_wide_access|bool == False
+  - kiali_vars.deployment.cluster_wide_access == True
+
+- name: Determine the namespaces that were previously accessible but are now inaccessible
+  set_fact:
+    namespaces_no_longer_accessible: "{{ namespaces_currently_accessible | difference(discovery_selector_namespaces) }}"
+  when:
+  - namespaces_no_longer_accessible is not defined
+  - namespaces_currently_accessible is defined
+  - discovery_selector_namespaces is defined
+  - current_cluster_wide_access is defined
+  - current_cluster_wide_access|bool == False
+  - kiali_vars.deployment.cluster_wide_access == False
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Deleting obsolete roles"
+
+- name: Delete all additional Kiali roles from namespaces that Kiali no longer has access to
+  include_tasks: remove-roles.yml
+  vars:
+    role_namespaces: "{{ namespaces_no_longer_accessible }}"
+  when:
+  - namespaces_no_longer_accessible is defined
+
+- name: Delete Kiali cluster roles if no longer given special access to all namespaces
+  include_tasks: remove-clusterroles.yml
+  when:
+  - current_cluster_wide_access is defined
+  - current_cluster_wide_access|bool == True
+  - kiali_vars.deployment.cluster_wide_access == False
+
+# Role Bindings are always "view-only" unless auth.strategy is anonymous and view_only_mode is false.
+# If the view_only_mode or auth.strategy changes, we'll delete the roles to make sure we create the correct ones.
+# We need to see if the currently installed role binding is view-only - this is used to not break upgrades. See: https://github.com/kiali/kiali/issues/5695
+- name: Determine if the currently installed role binding in the deployment namespace is view-only
+  vars:
+    current_rolebinding: "{{ query(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='rbac.authorization.k8s.io/v1', kind=role_binding_kind, errors='ignore') }}"
+  set_fact:
+    current_rolebinding_view_only: "{{ (current_rolebinding | length == 1) and (current_rolebinding[0].roleRef.name is regex('^.*-viewer$')) }}"
+
+- name: Delete all Kiali roles from namespaces if view_only_mode or auth.strategy is changing since role bindings are immutable
+  include_tasks: remove-roles.yml
+  vars:
+    role_namespaces: "{{ discovery_selector_namespaces }}"
+  when:
+  - current_cluster_wide_access is defined
+  - current_cluster_wide_access|bool == False
+  - kiali_vars.deployment.cluster_wide_access == False
+  - current_view_only_mode is defined
+  - current_auth_strategy is defined
+  - (current_view_only_mode|bool != kiali_vars.deployment.view_only_mode|bool) or (current_auth_strategy != kiali_vars.auth.strategy) or (current_rolebinding_view_only|bool == False and kiali_vars.auth.strategy != 'anonymous')
+
+- name: Delete Kiali cluster roles if view_only_mode or auth.strategy is changing since cluster role bindings are immutable
+  include_tasks: remove-clusterroles.yml
+  when:
+  - current_cluster_wide_access is defined
+  - current_cluster_wide_access|bool == True
+  - kiali_vars.deployment.cluster_wide_access == True
+  - current_view_only_mode is defined
+  - current_auth_strategy is defined
+  - (current_view_only_mode|bool != kiali_vars.deployment.view_only_mode|bool) or (current_auth_strategy != kiali_vars.auth.strategy) or (current_rolebinding_view_only|bool == False and kiali_vars.auth.strategy != 'anonymous')
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Processing namespace labels"
+
+- name: Remove Kiali label from namespaces that Kiali no longer has access to
+  # if a namespace happened to have been deleted, we do not want to (nor can we) resurrect it, hence we use state=patched
+  k8s:
+    state: patched
+    definition: |
+      {% for namespace in namespaces_no_longer_accessible %}
+      ---
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ namespace }}"
+        labels:
+          {{ kiali_instance_label_name }}: null
+      ...
+      {% endfor %}
+  when:
+  - namespaces_no_longer_accessible is defined
+
+- name: Create additional Kiali labels on all accessible namespaces
+  vars:
+    namespaces: "{{ discovery_selector_namespaces }}"
+  k8s:
+    state: patched
+    definition: |
+      {% for namespace in namespaces %}
+      ---
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ namespace }}"
+        labels:
+          {{ kiali_instance_label_name }}: "{{ kiali_instance_label_value }}"
+      ...
+      {% endfor %}
+  when:
+  - kiali_vars.deployment.cluster_wide_access == False
+
+- name: Delete Kiali deployment if image is changing - this uninstalled any old version of Kiali that might be running
+  k8s:
+    state: absent
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - current_image_name is defined and current_image_version is defined
+  - (current_image_name != kiali_vars.deployment.image_name) or (current_image_version != kiali_vars.deployment.image_version)
+
+# Get the deployment's custom annotation we set that tells us when we last updated the Deployment.
+# We need this to ensure the Deployment we update retains this same timestamp unless changes are made
+# that requires a pod restart - in which case we update this timestamp.
+- name: Find current deployment, if it exists
+  set_fact:
+    current_deployment: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+
+- name: Get current deployment last-updated annotation timestamp from existing deployment
+  set_fact:
+    current_deployment_last_updated: "{{ current_deployment.spec.template.metadata.annotations['operator.kiali.io/last-updated'] if current_deployment.spec.template.metadata.annotations['operator.kiali.io/last-updated'] is defined else lookup('pipe','date') }}"
+    deployment_is_new: false
+  when:
+  - current_deployment is defined
+  - current_deployment.spec is defined
+  - current_deployment.spec.template is defined
+  - current_deployment.spec.template.metadata is defined
+  - current_deployment.spec.template.metadata.annotations is defined
+
+- name: Set current deployment last-updated annotation timestamp for new deployments
+  set_fact:
+    current_deployment_last_updated: "{{ lookup('pipe','date') }}"
+    deployment_is_new: true
+  when:
+  - current_deployment_last_updated is not defined
+
+# Now deploy all resources for the specific cluster environment
+
+- name: Execute for OpenShift environment
+  include_tasks: openshift/os-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
+  when:
+  - is_openshift == True
+
+- name: Execute for Kubernetes environment
+  include_tasks: kubernetes/k8s-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
+  when:
+  - is_k8s == True
+
+# If something changed that can only be picked up when the Kiali pod starts up, then restart the Kiali pod using a rolling restart
+# We do this by checking the processed_resources_dict created by process-resources.yml task. If there is a map key
+# with the kind (ConfigMap) with the name of our config map appended to it ("-" + the kiali instanance name) see if that config map changed.
+# If it did, we need to restart the kiali pod so it can re-read the new config.
+- name: Force the Kiali pod to restart if necessary
+  vars:
+    keyname: "{{ 'ConfigMap-' + kiali_vars.deployment.instance_name }}"
+    updated_deployment: "{{ lookup(k8s_plugin, resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'operator.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+  k8s:
+    state: "present"
+    definition: "{{ updated_deployment }}"
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool== False
+  - deployment_is_new == False
+  - processed_resources_dict is defined
+  - processed_resources_dict[keyname] is defined
+  - processed_resources_dict[keyname].changed == True
+  - processed_resources_dict[keyname].method == "update"
+
+# If the list of namespaces is manageable, store them in a comma-separate list.
+# Otherwise, we'll just log the count. The purpose of this discoverySelectorNamespaces status field is
+# just to inform the user how many namespaces the operator processed.
+# Note that we only populate the discoverySelectorNamespaces if we are NOT in cluster wide access mode.
+# This is because we really only care about what namespaces the operator discovered when
+# not in cluster wide access mode as these are the namespaces where the Roles are created (they are
+# the namespaces Kiali is granted permission to see).
+- include_tasks: update-status-progress.yml
+  vars:
+    noDsn:
+      discoverySelectorNamespaces: null
+    listDsn:
+      discoverySelectorNamespaces: "{{ ('Number of namespaces (including control plane namespace): ' + (discovery_selector_namespaces | length | string)) if (discovery_selector_namespaces | length > 20) else (discovery_selector_namespaces | join(',')) }}"
+    status_progress_message: "Finished all resource creation"
+    status_vars:
+      deployment: "{{ listDsn if (kiali_vars.deployment.cluster_wide_access == False and discovery_selector_namespaces is defined) else noDsn }}"

--- a/roles/v2.27/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
+++ b/roles/v2.27/kiali-deploy/tasks/openshift/os-get-kiali-route-url.yml
@@ -1,0 +1,50 @@
+# All of this is ultimately to obtain the kiali_route_url
+
+# We need to auto-discover the Kiali Route URL because the OAuthClient (for redirect URIs) and ConsoleLink resources need it.
+# Note that the user can override redirect URIs in auth.openshift.redirect_uris so this route URL will
+# be ignored in the OAuthClient template in that case.
+
+- name: Get the Kiali Route on OpenShift, which may require waiting some time for it to startup
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    name: "{{ kiali_vars.deployment.instance_name }}"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+  register: kiali_route_raw
+  until:
+  - kiali_route_raw['resources'] is defined
+  - kiali_route_raw['resources'][0] is defined
+  - kiali_route_raw['resources'][0]['status'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0] is defined
+  - kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] is defined
+  retries: 30
+  delay: 10
+  when:
+  - is_openshift == True
+
+- name: Set Kiali TLS Termination from OpenShift route
+  set_fact:
+    kiali_route_tls_termination: "{{ kiali_route_raw['resources'][0]['spec']['tls']['termination'] }}"
+  when:
+  - is_openshift == True
+
+- name: Detect HTTP Kiali OpenShift route protocol
+  set_fact:
+    kiali_route_protocol: "http"
+  when:
+  - is_openshift == True
+  - kiali_route_tls_termination == ""
+
+- name: Detect HTTPS Kiali OpenShift route protocol
+  set_fact:
+    kiali_route_protocol: "https"
+  when:
+  - is_openshift == True
+  - kiali_route_tls_termination != ""
+
+- name: Create URL for Kiali OpenShift route
+  set_fact:
+    kiali_route_url: "{{ kiali_route_protocol }}://{{ kiali_route_raw['resources'][0]['status']['ingress'][0]['host'] }}"
+  when:
+  - is_openshift == True

--- a/roles/v2.27/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/v2.27/kiali-deploy/tasks/openshift/os-main.yml
@@ -1,0 +1,205 @@
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Creating core resources"
+  when:
+  - is_openshift == True
+
+# If it is Removed, the web console is disabled.
+# See: https://docs.openshift.com/container-platform/4.13/web_console/disabling-web-console.html
+- name: Determine if OpenShift Console is installed and enabled
+  vars:
+    console_res: "{{ query(k8s_plugin, resource_name='cluster', api_version='operator.openshift.io/v1', kind='Console', errors='ignore') }}"
+  set_fact:
+    has_openshift_console: "{{ console_res | length > 0 and console_res[0].spec.managementState != 'Removed' }}"
+  when:
+  - is_openshift == True
+
+- name: Remove HPA if disabled on OpenShift
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.hpa.api_version }}"
+    kind: "HorizontalPodAutoscaler"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.hpa.spec | length == 0
+
+- name: Remove PDB if disabled on OpenShift
+  k8s:
+    state: absent
+    api_version: "{{ kiali_vars.deployment.pod_disruption_budget.api_version }}"
+    kind: "PodDisruptionBudget"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.pod_disruption_budget.spec | length == 0
+
+- name: Create Kiali objects on OpenShift
+  include_tasks: process-resource.yml
+  vars:
+    role_namespaces: "{{ [ kiali_vars.deployment.namespace ] }}"
+    process_resource_templates:
+    - "templates/openshift/serviceaccount.yaml"
+    - "templates/openshift/configmap.yaml"
+    - "{{ 'templates/openshift/cabundle.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "templates/openshift/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/openshift/rolebinding.yaml"
+    - "{{ 'templates/openshift/clusterrole-openshift.yaml' if (kiali_vars.auth.strategy == 'openshift' or kiali_vars.deployment.tls_config.source == 'auto') else '' }}"
+    - "{{ 'templates/openshift/clusterrolebinding-openshift.yaml' if (kiali_vars.auth.strategy == 'openshift' or kiali_vars.deployment.tls_config.source == 'auto') else '' }}"
+    - "{{ 'templates/openshift/deployment.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/openshift/service.yaml' if kiali_vars.deployment.remote_cluster_resources_only|bool == False else '' }}"
+    - "{{ 'templates/openshift/hpa.yaml' if ((kiali_vars.deployment.hpa.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/openshift/pdb.yaml' if ((kiali_vars.deployment.pod_disruption_budget.spec | length > 0) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/openshift/route.yaml' if ((kiali_vars.deployment.ingress.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+    - "{{ 'templates/openshift/networkpolicy.yaml' if ((kiali_vars.deployment.network_policy.enabled|bool == True) and (kiali_vars.deployment.remote_cluster_resources_only|bool == False)) else '' }}"
+  when:
+  - is_openshift == True
+
+- name: Delete Route on OpenShift if disabled
+  k8s:
+    state: absent
+    api_version: "route.openshift.io/v1"
+    kind: "Route"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.ingress.enabled|bool == False
+
+- name: Delete NetworkPolicy on OpenShift if disabled
+  k8s:
+    state: absent
+    api_version: "networking.k8s.io/v1"
+    kind: "NetworkPolicy"
+    namespace: "{{ kiali_vars.deployment.namespace }}"
+    name: "{{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.network_policy.enabled|bool == False
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Creating additional roles"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.cluster_wide_access == False
+
+- name: Create additional Kiali roles/bindings on all namespaces that are accessible on OpenShift
+  vars:
+    role_namespaces: "{{ discovery_selector_namespaces }}"
+  k8s:
+    template:
+    - "templates/openshift/{{ 'role-viewer' if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else 'role' }}.yaml"
+    - "templates/openshift/rolebinding.yaml"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.cluster_wide_access == False
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Creating OpenShift resources"
+  when:
+  - is_openshift == True
+
+- name: Delete OAuthClient on OpenShift if not using auth.strategy openshift
+  k8s:
+    state: absent
+    api_version: "oauth.openshift.io/v1"
+    kind: "OAuthClient"
+    label_selectors:
+    - "app.kubernetes.io/instance = {{ kiali_vars.deployment.instance_name }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.auth.strategy != "openshift"
+  # Ignore errors because OAuthClient API may not exist when OpenShift uses external OIDC authentication
+  ignore_errors: true
+
+- name: Delete OpenShift ClusterRole if no longer needed
+  k8s:
+    state: absent
+    api_version: "rbac.authorization.k8s.io/v1"
+    kind: "ClusterRole"
+    name: "{{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}-openshift"
+  when:
+  - is_openshift == True
+  - kiali_vars.auth.strategy != "openshift"
+  - kiali_vars.deployment.tls_config.source != "auto"
+
+- name: Delete OpenShift ClusterRoleBinding if no longer needed
+  k8s:
+    state: absent
+    api_version: "rbac.authorization.k8s.io/v1"
+    kind: "ClusterRoleBinding"
+    name: "{{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}-openshift"
+  when:
+  - is_openshift == True
+  - kiali_vars.auth.strategy != "openshift"
+  - kiali_vars.deployment.tls_config.source != "auto"
+
+# For now, when creating remote cluster resources only, we are going to assume there is no way for us to determine what the redirect URIs are
+# going to be other than having the user explicitly configure them. So fail immediately if the user did not tell us what redirect URI[s] to use.
+# Note that this only comes into play when auth.strategy is "openshift".
+- name: Fail if creating remote cluster resources with auth strategy of openshift, but the Kiali redirect URIs are not defined
+  fail:
+    msg: "Redirect URIs for the Kiali Server OAuthClient are not specified via auth.openshift.redirect_uris; this is required when creating remote cluster resources with auth.strategy of openshift."
+  when:
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == True
+  - kiali_vars.auth.strategy == 'openshift'
+  - kiali_vars.auth.openshift.redirect_uris | default([]) | length == 0
+
+# We only need to auto-discover the Kiali route if (a) we know it will exist and (b) we know we need it.
+# We know it will exist if we are creating the Kiali Server itself (i.e. remote_cluster_resources_only == False).
+# We know we need it for ConsoleLinks (and those are only created when we are creating the Kiali Server itself).
+# We know we need it for OAuthClient, too. That is also created when we are creating the Kiali Server itself. But it is also
+# created when creating only remote cluster resources - however, in that case, we are going to require the user to tell us
+# what redirect URIs to use (see the above fail task to ensure the user does that).
+# All of this is to say: we only need to auto-discover the route when we are creating the Kiali Server itself (we do not
+# auto-discover the route when we are creating only the remote cluster resources).
+# We also don't expect the Route if it was disabled (which also disables other features like OAuthClient -- see https://github.com/kiali/kiali/issues/8023)
+- name: Get the Kiali Route URL
+  include_tasks: openshift/os-get-kiali-route-url.yml
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.ingress.enabled|bool == True
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+
+- name: Process OpenShift OAuth client
+  k8s:
+    definition: "{{ lookup('template', 'templates/openshift/oauth.yaml') }}"
+  when:
+  - is_openshift == True
+  - kiali_vars.deployment.ingress.enabled|bool == True
+  - kiali_vars.auth.strategy == "openshift"
+
+- name: Delete all ConsoleLinks for namespaces that are no longer accessible
+  k8s:
+    state: absent
+    definition: |
+      {% for namespace in namespaces_no_longer_accessible  %}
+      ---
+      apiVersion: console.openshift.io/v1
+      kind: ConsoleLink
+      metadata:
+        name: "{{ kiali_vars.deployment.instance_name }}-namespace-{{ namespace }}"
+      ...
+      {% endfor %}
+  when:
+  - is_openshift == True
+  - has_openshift_console is defined
+  - has_openshift_console == True
+  - namespaces_no_longer_accessible is defined
+
+- name: Process OpenShift Console Links
+  k8s:
+    definition: "{{ lookup('template', 'templates/openshift/console-links.yaml') }}"
+  vars:
+    namespaces: "{{ discovery_selector_namespaces }}"
+  when:
+  - is_openshift == True
+  - has_openshift_console is defined
+  - has_openshift_console == True
+  - kiali_route_url is defined
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False
+  - kiali_vars.deployment.cluster_wide_access == False

--- a/roles/v2.27/kiali-deploy/tasks/process-resource.yml
+++ b/roles/v2.27/kiali-deploy/tasks/process-resource.yml
@@ -1,0 +1,31 @@
+# process all template names found in process_resource_templates - any empty strings in the list are ignored.
+# This will keep a running tally of all processed resources in "processed_resources_dict".
+- name: "Create Kiali resources from templates"
+  k8s:
+    state: "present"
+    continue_on_error: false
+    template: "{{ process_resource_templates | select() | list }}"
+  register: process_resource_templates_result
+  retries: 6
+  delay: 10
+
+# Store the results of the processed resources so they can be examined later (e.g. to know if something changed or stayed the same)
+- vars:
+    kinds: "{{ process_resource_templates_result.result.results | map(attribute='result.kind') | list }}"
+    names: "{{ process_resource_templates_result.result.results | map(attribute='result.metadata.name') | list }}"
+    changed: "{{ process_resource_templates_result.result.results | map(attribute='changed') | list }}"
+    method: "{{ process_resource_templates_result.result.results | map(attribute='method') | list }}"
+    thedict: "{{ processed_resources_dict | default({}) }}"
+  set_fact:
+    processed_resources_dict: |
+      {% for kind in kinds %}
+      {%   set _ = thedict.update({ (kind + '-' + names[loop.index0]): {'name': names[loop.index0], 'changed': changed[loop.index0], 'method': method[loop.index0]}}) %}
+      {% endfor %}
+      {{ thedict }}
+  when:
+  - process_resource_templates_result is defined
+  - process_resource_templates_result | length > 0
+
+- name: "Kiali resource creation results"
+  debug:
+    msg: "{{ processed_resources_dict }}"

--- a/roles/v2.27/kiali-deploy/tasks/remove-clusterroles.yml
+++ b/roles/v2.27/kiali-deploy/tasks/remove-clusterroles.yml
@@ -1,0 +1,9 @@
+- name: Delete unused Kiali cluster roles
+  ignore_errors: yes
+  k8s:
+    state: absent
+    continue_on_error: false
+    template:
+    - clusterroles-to-remove.yml
+  retries: 6
+  delay: 10

--- a/roles/v2.27/kiali-deploy/tasks/remove-roles.yml
+++ b/roles/v2.27/kiali-deploy/tasks/remove-roles.yml
@@ -1,0 +1,27 @@
+- name: Delete Kiali roles from previously accessible namespaces
+  k8s:
+    state: absent
+    definition: |
+      {% for namespace in role_namespaces %}
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: "{{ kiali_vars.deployment.instance_name }}"
+        namespace: "{{ namespace }}"
+      ...
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: "{{ kiali_vars.deployment.instance_name }}"
+        namespace: "{{ namespace }}"
+      ...
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: "{{ kiali_vars.deployment.instance_name }}-viewer"
+        namespace: "{{ namespace }}"
+      ...
+      {% endfor %}

--- a/roles/v2.27/kiali-deploy/tasks/snake_camel_case.yaml
+++ b/roles/v2.27/kiali-deploy/tasks/snake_camel_case.yaml
@@ -1,0 +1,188 @@
+# Because we are passing through some yaml directly to Kubernetes resources, we have to retain the camelCase keys.
+# All CR parameters are converted to snake_case, but the original yaml is found in the special _kiali_io_kiali param.
+# We need to copy that original yaml into our vars where appropriate to keep the camelCase.
+
+- name: Replace snake_case with camelCase in all appropriate fields
+  set_fact:
+    kiali_vars: |
+      {# deployment.affinity.node #}
+      {% if kiali_vars.deployment.affinity is defined and kiali_vars.deployment.affinity.node is defined and kiali_vars.deployment.affinity.node | length > 0 %}
+      {%   set _=kiali_vars['deployment']['affinity'].pop('node') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'affinity': {'node': current_cr.spec.deployment.affinity.node }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.affinity.pod #}
+      {% if kiali_vars.deployment.affinity is defined and kiali_vars.deployment.affinity.pod is defined and kiali_vars.deployment.affinity.pod | length > 0 %}
+      {%   set _=kiali_vars['deployment']['affinity'].pop('pod') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'affinity': {'pod': current_cr.spec.deployment.affinity.pod }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# custom_dashboards #}
+      {% if kiali_vars.custom_dashboards is defined and kiali_vars.custom_dashboards | length > 0 %}
+      {%   set _=kiali_vars.pop('custom_dashboards') %}
+      {%   set kiali_vars=kiali_vars | combine({'custom_dashboards': current_cr.spec.custom_dashboards }, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.affinity.pod_anti #}
+      {% if kiali_vars.deployment.affinity is defined and kiali_vars.deployment.affinity.pod_anti is defined and kiali_vars.deployment.affinity.pod_anti | length > 0 %}
+      {%   set _=kiali_vars['deployment']['affinity'].pop('pod_anti') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'affinity': {'pod_anti': current_cr.spec.deployment.affinity.pod_anti }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.tolerations #}
+      {% if kiali_vars.deployment.tolerations is defined and kiali_vars.deployment.tolerations | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('tolerations') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'tolerations': current_cr.spec.deployment.tolerations }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.additional_service_yaml #}
+      {% if kiali_vars.deployment.additional_service_yaml is defined and kiali_vars.deployment.additional_service_yaml | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('additional_service_yaml') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'additional_service_yaml': current_cr.spec.deployment.additional_service_yaml }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.resources #}
+      {% if kiali_vars.deployment.resources is defined and kiali_vars.deployment.resources | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('resources') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'resources': current_cr.spec.deployment.resources }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.ingress.override_yaml #}
+      {% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml | length > 0 %}
+      {%   set _=kiali_vars['deployment']['ingress'].pop('override_yaml') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'ingress': {'override_yaml': current_cr.spec.deployment.ingress.override_yaml }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.ingress.additional_labels #}
+      {% if kiali_vars.deployment.ingress.additional_labels is defined and kiali_vars.deployment.ingress.additional_labels | length > 0 %}
+      {%   set _=kiali_vars['deployment']['ingress'].pop('additional_labels') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'ingress': {'additional_labels': current_cr.spec.deployment.ingress.additional_labels }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.pod_annotations #}
+      {% if kiali_vars.deployment.pod_annotations is defined and kiali_vars.deployment.pod_annotations | length > 0 and current_cr.spec.deployment.pod_annotations is defined and current_cr.spec.deployment.pod_annotations is not none %}
+      {%   set _=kiali_vars['deployment'].pop('pod_annotations') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'pod_annotations': current_cr.spec.deployment.pod_annotations }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.pod_labels #}
+      {% if kiali_vars.deployment.pod_labels is defined and kiali_vars.deployment.pod_labels | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('pod_labels') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'pod_labels': current_cr.spec.deployment.pod_labels }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.service_annotations #}
+      {% if kiali_vars.deployment.service_annotations is defined and kiali_vars.deployment.service_annotations | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('service_annotations') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'service_annotations': current_cr.spec.deployment.service_annotations }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.hpa.spec #}
+      {% if kiali_vars.deployment.hpa is defined and kiali_vars.deployment.hpa.spec is defined and kiali_vars.deployment.hpa.spec | length > 0 %}
+      {%   set _=kiali_vars['deployment']['hpa'].pop('spec') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'hpa': {'spec': current_cr.spec.deployment.hpa.spec }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.pod_disruption_budget.spec #}
+      {% if kiali_vars.deployment.pod_disruption_budget is defined and kiali_vars.deployment.pod_disruption_budget.spec is defined and kiali_vars.deployment.pod_disruption_budget.spec | length > 0 %}
+      {%   set _=kiali_vars['deployment']['pod_disruption_budget'].pop('spec') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'pod_disruption_budget': {'spec': current_cr.spec.deployment.pod_disruption_budget.spec }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.node_selector #}
+      {% if kiali_vars.deployment.node_selector is defined and kiali_vars.deployment.node_selector | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('node_selector') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'node_selector': current_cr.spec.deployment.node_selector }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# external_services.custom_dashboards.prometheus.custom_headers #}
+      {% if kiali_vars.external_services.custom_dashboards.prometheus.custom_headers is defined and kiali_vars.external_services.custom_dashboards.prometheus.custom_headers | length > 0 %}
+      {%   set _=kiali_vars['external_services']['custom_dashboards']['prometheus'].pop('custom_headers') %}
+      {%   set kiali_vars=kiali_vars | combine({'external_services': {'custom_dashboards': {'prometheus': {'custom_headers': current_cr.spec.external_services.custom_dashboards.prometheus.custom_headers }}}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# external_services.custom_dashboards.prometheus.query_scope #}
+      {% if kiali_vars.external_services.custom_dashboards.prometheus.query_scope is defined and kiali_vars.external_services.custom_dashboards.prometheus.query_scope | length > 0 %}
+      {%   set _=kiali_vars['external_services']['custom_dashboards']['prometheus'].pop('query_scope') %}
+      {%   set kiali_vars=kiali_vars | combine({'external_services': {'custom_dashboards': {'prometheus': {'query_scope': current_cr.spec.external_services.custom_dashboards.prometheus.query_scope }}}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# external_services.prometheus.custom_headers #}
+      {% if kiali_vars.external_services.prometheus.custom_headers is defined and kiali_vars.external_services.prometheus.custom_headers | length > 0 %}
+      {%   set _=kiali_vars['external_services']['prometheus'].pop('custom_headers') %}
+      {%   set kiali_vars=kiali_vars | combine({'external_services': {'prometheus': {'custom_headers': current_cr.spec.external_services.prometheus.custom_headers }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# external_services.prometheus.query_scope #}
+      {% if kiali_vars.external_services.prometheus.query_scope is defined and kiali_vars.external_services.prometheus.query_scope | length > 0 %}
+      {%   set _=kiali_vars['external_services']['prometheus'].pop('query_scope') %}
+      {%   set kiali_vars=kiali_vars | combine({'external_services': {'prometheus': {'query_scope': current_cr.spec.external_services.prometheus.query_scope }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.configmap_annotations #}
+      {% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('configmap_annotations') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'configmap_annotations': current_cr.spec.deployment.configmap_annotations }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# external_services.tracing.query_scope #}
+      {% if kiali_vars.external_services.tracing.query_scope is defined and kiali_vars.external_services.tracing.query_scope | length > 0 %}
+      {%   set _=kiali_vars['external_services']['tracing'].pop('query_scope') %}
+      {%   set kiali_vars=kiali_vars | combine({'external_services': {'tracing': {'query_scope': current_cr.spec.external_services.tracing.query_scope }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.security_context #}
+      {% if kiali_vars.deployment.security_context is defined and kiali_vars.deployment.security_context | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('security_context') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'security_context': current_cr.spec.deployment.security_context}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.strategy #}
+      {% if kiali_vars.deployment.strategy is defined and kiali_vars.deployment.strategy | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('strategy') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'strategy': current_cr.spec.deployment.strategy }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.custom_secrets[].csi #}
+      {% if kiali_vars.deployment.custom_secrets is defined and kiali_vars.deployment.custom_secrets | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('custom_secrets') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'custom_secrets': current_cr.spec.deployment.custom_secrets}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# external_services.tracing.custom_headers #}
+      {% if kiali_vars.external_services.tracing.custom_headers is defined and kiali_vars.external_services.tracing.custom_headers | length > 0 %}
+      {%   set _=kiali_vars['external_services']['tracing'].pop('custom_headers') %}
+      {%   set kiali_vars=kiali_vars | combine({'external_services': {'tracing': {'custom_headers': current_cr.spec.external_services.tracing.custom_headers }}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.discovery_selectors #}
+      {% if kiali_vars.deployment.discovery_selectors is defined and kiali_vars.deployment.discovery_selectors | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('discovery_selectors') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'discovery_selectors': current_cr.spec.deployment.discovery_selectors}}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.topology_spread_constraints #}
+      {% if kiali_vars.deployment.topology_spread_constraints is defined and kiali_vars.deployment.topology_spread_constraints | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('topology_spread_constraints') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'topology_spread_constraints': current_cr.spec.deployment.topology_spread_constraints }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.extra_labels #}
+      {% if kiali_vars.deployment.extra_labels is defined and kiali_vars.deployment.extra_labels | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('extra_labels') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'extra_labels': current_cr.spec.deployment.extra_labels }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.additional_pod_containers_yaml #}
+      {% if kiali_vars.deployment.additional_pod_containers_yaml is defined and kiali_vars.deployment.additional_pod_containers_yaml | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('additional_pod_containers_yaml') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'additional_pod_containers_yaml': current_cr.spec.deployment.additional_pod_containers_yaml }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {# deployment.additional_pod_init_containers_yaml #}
+      {% if kiali_vars.deployment.additional_pod_init_containers_yaml is defined and kiali_vars.deployment.additional_pod_init_containers_yaml | length > 0 %}
+      {%   set _=kiali_vars['deployment'].pop('additional_pod_init_containers_yaml') %}
+      {%   set kiali_vars=kiali_vars | combine({'deployment': {'additional_pod_init_containers_yaml': current_cr.spec.deployment.additional_pod_init_containers_yaml }}, recursive=True) %}
+      {% endif %}
+      {# #}
+      {{ kiali_vars }}

--- a/roles/v2.27/kiali-deploy/tasks/update-status-progress.yml
+++ b/roles/v2.27/kiali-deploy/tasks/update-status-progress.yml
@@ -1,0 +1,16 @@
+- name: Prepare status progress facts
+  ignore_errors: yes
+  set_fact:
+    status_progress_step: "{{ 1 if status_progress_step is not defined else (status_progress_step|int + 1) }}"
+    status_progress_start: "{{ ('%Y-%m-%d %H:%M:%S' | strftime) if status_progress_start is not defined else (status_progress_start) }}"
+
+- name: Update CR status progress field with any additional status fields
+  ignore_errors: yes
+  vars:
+    duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
+  operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"

--- a/roles/v2.27/kiali-deploy/tasks/update-status.yml
+++ b/roles/v2.27/kiali-deploy/tasks/update-status.yml
@@ -1,0 +1,8 @@
+- name: Update CR status field
+  ignore_errors: yes
+  operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars }}"

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/configmap.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+{% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
+  annotations:
+    {{ kiali_vars.deployment.configmap_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% endif %}
+data:
+  config.yaml: |
+    {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/deployment.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/deployment.yaml
@@ -1,0 +1,259 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+{% if kiali_vars.deployment.hpa.spec | length == 0 %}
+  replicas: {{ kiali_vars.deployment.replicas }}
+{% endif %}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  strategy:
+{% if kiali_vars.deployment.strategy | length > 0 %}
+    {{ kiali_vars.deployment.strategy | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% else %}
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+{% endif %}
+  template:
+    metadata:
+      name: {{ kiali_vars.deployment.instance_name }}
+      labels: {{ kiali_resource_metadata_labels | combine(kiali_vars.deployment.pod_labels) }}
+      annotations:
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ kiali_vars.server.observability.metrics.port }}"
+        prometheus.io/scheme: "{{ 'http' if kiali_vars.identity.cert_file == '' else 'https' }}"
+{% else %}
+        prometheus.io/scrape: "false"
+        prometheus.io/port: null
+        prometheus.io/scheme: null
+{% endif %}
+        kiali.io/dashboards: go,kiali
+        operator.kiali.io/last-updated: "{{ deployment_last_updated }}"
+{% if kiali_vars.deployment.pod_annotations|length > 0 %}
+        {{ kiali_vars.deployment.pod_annotations | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+    spec:
+      serviceAccount: {{ kiali_vars.deployment.instance_name }}-service-account
+{% if kiali_vars.deployment.priority_class_name != "" %}
+      priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
+{% endif %}
+{% if kiali_vars.deployment.image_pull_secrets | default([]) | length > 0 %}
+      imagePullSecrets:
+{% for n in kiali_vars.deployment.image_pull_secrets %}
+      - name: {{ n }}
+{% endfor %}
+{% endif %}
+{% if kiali_vars.deployment.host_aliases|length > 0 %}
+      hostAliases:
+        {{ kiali_vars.deployment.host_aliases | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+{% if kiali_vars.deployment.dns | length > 0 %}
+{% if kiali_vars.deployment.dns.policy | length > 0 %}
+      dnsPolicy: "{{ kiali_vars.deployment.dns.policy }}"
+{% endif %}
+{% if kiali_vars.deployment.dns.config | length > 0 %}
+      dnsConfig:
+        {{ kiali_vars.deployment.dns.config | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+{% endif %}
+{% if kiali_vars.deployment.additional_pod_init_containers_yaml|length > 0 %}
+      initContainers:
+{% for container in kiali_vars.deployment.additional_pod_init_containers_yaml %}
+      - {{ container | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endfor %}
+{% endif %}
+      containers:
+{% for container in kiali_vars.deployment.additional_pod_containers_yaml %}
+      - {{ container | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endfor %}
+      - image: {{ kiali_vars.deployment.image_name }}{{ '@' + kiali_vars.deployment.image_digest if kiali_vars.deployment.image_digest != '' else '' }}:{{ kiali_vars.deployment.image_version }}
+        imagePullPolicy: {{ kiali_vars.deployment.image_pull_policy }}
+        name: kiali
+        command:
+        - "/opt/kiali/kiali"
+        - "-config"
+        - "/kiali-configuration/config.yaml"
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+{% if kiali_vars.deployment.security_context|length > 0 %}
+          {{ kiali_vars.deployment.security_context | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% if kiali_vars.deployment.security_context|length == 0 or lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') != "true" %}
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+            - ALL
+{% endif %}
+        ports:
+          - name: api-port
+            containerPort: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+          - name: http-metrics
+            containerPort: {{ kiali_vars.server.observability.metrics.port }}
+{% endif %}
+        readinessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: {{ kiali_vars.deployment.probes.readiness.initial_delay_seconds|int }}
+          periodSeconds: {{ kiali_vars.deployment.probes.readiness.period_seconds|int }}
+        livenessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: {{ kiali_vars.deployment.probes.liveness.initial_delay_seconds|int }}
+          periodSeconds: {{ kiali_vars.deployment.probes.liveness.period_seconds|int }}
+        startupProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          failureThreshold: {{ kiali_vars.deployment.probes.startup.failure_threshold|int }}
+          initialDelaySeconds: {{ kiali_vars.deployment.probes.startup.initial_delay_seconds|int }}
+          periodSeconds: {{ kiali_vars.deployment.probes.startup.period_seconds|int }}
+        env:
+        - name: ACTIVE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOG_FORMAT
+          value: "{{ kiali_vars.deployment.logger.log_format }}"
+        - name: LOG_LEVEL
+          value: "{{ kiali_vars.deployment.logger.log_level }}"
+        - name: LOG_SAMPLER_RATE
+          value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
+        - name: LOG_TIME_FIELD_FORMAT
+          value: "{{ kiali_vars.deployment.logger.time_field_format }}"
+{% for env in kiali_vars.deployment.custom_envs %}
+        - name: "{{ env.name }}"
+          value: "{{ env.value }}"
+{% endfor %}
+        volumeMounts:
+        - name: kiali-configuration
+          mountPath: "/kiali-configuration"
+        - name: kiali-secret
+          mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
+{% for sec in kiali_deployment_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-override-secrets/{{ sec }}"
+          readOnly: true
+{% endfor %}
+{% for secret in kiali_vars.deployment.custom_secrets %}
+        - name: {{ secret.name }}
+          mountPath: "{{ secret.mount }}"
+{% endfor %}
+        - name: "kiali-multi-cluster-secret"
+          mountPath: "/kiali-remote-cluster-secrets/kiali-multi-cluster-secret"
+          readOnly: true
+{% for sec in kiali_deployment_remote_cluster_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-remote-cluster-secrets/{{ kiali_deployment_remote_cluster_secret_volumes[sec].secret_name }}"
+          readOnly: true
+{% endfor %}
+{% if kiali_vars.deployment.resources|length > 0 %}
+        resources:
+          {{ kiali_vars.deployment.resources | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        resources: null
+{% endif %}
+      volumes:
+      - name: kiali-configuration
+        configMap:
+          name: {{ kiali_vars.deployment.instance_name }}
+      - name: kiali-secret
+        secret:
+          secretName: {{ kiali_vars.deployment.secret_name }}
+          optional: true
+      - name: kiali-cabundle
+        configMap:
+          name: {{ kiali_vars.deployment.instance_name }}-cabundle
+          optional: true
+{% for sec in kiali_deployment_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_secret_volumes[sec].secret_name }}
+          items:
+          - key: {{ kiali_deployment_secret_volumes[sec].secret_key }}
+            path: {{ kiali_deployment_secret_volumes[sec].path | default('value.txt') }}
+          optional: false
+{% endfor %}
+{% for secret in kiali_vars.deployment.custom_secrets %}
+      - name: {{ secret.name }}
+{% if secret.csi is defined %}
+        csi:
+          {{ secret.csi | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        secret:
+          secretName: {{ secret.name }}
+{% if secret.optional is defined %}
+          optional: {{ secret.optional }}
+{% endif %}
+{% endif %}
+{% endfor %}
+      - name: "kiali-multi-cluster-secret"
+        secret:
+          secretName: "kiali-multi-cluster-secret"
+          optional: true
+{% for sec in kiali_deployment_remote_cluster_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_remote_cluster_secret_volumes[sec].secret_name }}
+{% endfor %}
+{% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+      affinity:
+{% if kiali_vars.deployment.affinity.node|length > 0 %}
+        nodeAffinity:
+          {{ kiali_vars.deployment.affinity.node | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        nodeAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod|length > 0 %}
+        podAffinity:
+          {{ kiali_vars.deployment.affinity.pod | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+        podAntiAffinity:
+          {{ kiali_vars.deployment.affinity.pod_anti | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAntiAffinity: null
+{% endif %}
+{% else %}
+      affinity: null
+{% endif %}
+{% if kiali_vars.deployment.tolerations|length > 0 %}
+      tolerations:
+      {{ kiali_vars.deployment.tolerations | to_nice_yaml(indent=0) | trim | indent(6) }}
+{% else %}
+      tolerations: null
+{% endif %}
+{% if kiali_vars.deployment.node_selector|length > 0 %}
+      nodeSelector:
+        {{ kiali_vars.deployment.node_selector | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% else %}
+      nodeSelector: null
+{% endif %}
+{% if kiali_vars.deployment.topology_spread_constraints|length > 0 %}
+      topologySpreadConstraints:
+        {{ kiali_vars.deployment.topology_spread_constraints | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% else %}
+      topologySpreadConstraints: null
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/hpa.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/hpa.yaml
@@ -1,0 +1,14 @@
+{% if kiali_vars.deployment.hpa.spec | length > 0 %}
+apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ kiali_vars.deployment.instance_name }}
+  {{ kiali_vars.deployment.hpa.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/ingress.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/ingress.yaml
@@ -1,0 +1,43 @@
+apiVersion: "networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}"
+kind: Ingress
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
+  annotations:
+    # For ingress-nginx versions older than 0.20.0
+    # (see: https://github.com/kubernetes/ingress-nginx/issues/3416#issuecomment-438247948)
+    nginx.ingress.kubernetes.io/secure-backends: "{{ 'false' if kiali_vars.identity.cert_file == "" else 'true' }}"
+    # For ingress-nginx versions 0.20.0 and later
+    nginx.ingress.kubernetes.io/backend-protocol: "{{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}"
+{% endif %}
+spec:
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.spec is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
+{% if kiali_vars.deployment.ingress.class_name != "" %}
+  ingressClassName: {{ kiali_vars.deployment.ingress.class_name }}
+{% endif %}
+  rules:
+  - http:
+      paths:
+      - path: {{ kiali_vars.server.web_root }}
+{% if lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable %}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ kiali_vars.deployment.instance_name }}
+            port:
+              number: {{ kiali_vars.server.port }}
+{% else %}
+        backend:
+          serviceName: {{ kiali_vars.deployment.instance_name }}
+          servicePort: {{ kiali_vars.server.port }}
+{% endif %}
+{% if kiali_vars.server.web_fqdn|length != 0 %}
+    host: {{ kiali_vars.server.web_fqdn }}
+{% endif %}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/networkpolicy.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+    - protocol: TCP
+      port: {{ kiali_vars.server.observability.metrics.port }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/pdb.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/pdb.yaml
@@ -1,0 +1,14 @@
+{% if kiali_vars.deployment.pod_disruption_budget.spec | length > 0 %}
+apiVersion: {{ kiali_vars.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  {{ kiali_vars.deployment.pod_disruption_budget.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -1,0 +1,79 @@
+{% for namespace in role_namespaces %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-viewer
+  namespace: "{{ namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+{% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
+  - pods/log
+{% endif %}
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io
+  - inference.networking.k8s.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+{% endfor %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/role.yaml
@@ -1,0 +1,85 @@
+{% for namespace in role_namespaces %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+{% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
+  - pods/log
+{% endif %}
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io
+  - inference.networking.k8s.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+{% endfor %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/rolebinding.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/rolebinding.yaml
@@ -1,0 +1,17 @@
+{% for namespace in role_namespaces %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_binding_kind }}
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ role_kind }}
+  name: {{ (kiali_vars.deployment.instance_name + '-viewer') if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else kiali_vars.deployment.instance_name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+{% endfor %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/service.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/service.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+  annotations:
+{% if kiali_vars.server.web_fqdn|length != 0 and kiali_vars.server.web_schema|length != 0 %}
+    kiali.io/external-url: {{ kiali_vars.server.web_schema + '://' + kiali_vars.server.web_fqdn + ((':' + kiali_vars.server.web_port | string) if (kiali_vars.server.web_port | string | length != 0) else '') + (kiali_vars.server.web_root | default('')) }}
+{% endif %}
+{% if kiali_vars.deployment.service_annotations|length > 0 %}
+    {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% endif %}
+spec:
+{% if kiali_vars.deployment.service_type is defined %}
+  type: {{ kiali_vars.deployment.service_type }}
+{% endif %}
+  ports:
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
+    protocol: TCP
+{% if k8s_version is defined and k8s_version is version('1.20', '>=') %}
+    appProtocol: {{ 'http' if kiali_vars.identity.cert_file == "" else 'https' }}
+{% endif %}
+    port: {{ kiali_vars.server.port }}
+{% if kiali_vars.deployment.service_type is defined and kiali_vars.deployment.service_type == "NodePort" and kiali_vars.server.node_port is defined %}
+    nodePort: {{ kiali_vars.server.node_port }}
+{% endif %}
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}-metrics
+    protocol: TCP
+{% if k8s_version is defined and k8s_version is version('1.20', '>=') %}
+    appProtocol: {{ 'http' if kiali_vars.identity.cert_file == "" else 'https' }}
+{% endif %}
+    port: {{ kiali_vars.server.observability.metrics.port }}
+{% endif %}
+  selector:
+{% if query(k8s_plugin, kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+    app: null
+    version: null
+{% endif %}
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/kubernetes/serviceaccount.yaml
+++ b/roles/v2.27/kiali-deploy/templates/kubernetes/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v2.27/kiali-deploy/templates/openshift/cabundle.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/cabundle.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-cabundle-openshift
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"

--- a/roles/v2.27/kiali-deploy/templates/openshift/clusterrole-openshift.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/clusterrole-openshift.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}-openshift
+  labels: {{ kiali_resource_metadata_labels }}
+rules:
+{% if kiali_vars.auth.strategy == 'openshift' %}
+# Permission to read the OAuthClient for this Kiali instance
+- apiGroups: ["oauth.openshift.io"]
+  resources:
+  - oauthclients
+  resourceNames:
+  - {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}
+  verbs:
+  - get
+{% endif %}
+{% if kiali_vars.deployment.tls_config.source == 'auto' %}
+# Permission to read OpenShift TLSSecurityProfile for tls_config.source=auto
+- apiGroups: ["config.openshift.io"]
+  resources:
+  - apiservers
+  verbs:
+  - get
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/clusterrolebinding-openshift.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/clusterrolebinding-openshift.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}-openshift
+  labels: {{ kiali_resource_metadata_labels }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}-openshift
+subjects:
+- kind: ServiceAccount
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
+  namespace: "{{ kiali_vars.deployment.namespace }}"

--- a/roles/v2.27/kiali-deploy/templates/openshift/configmap.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+{% if kiali_vars.deployment.configmap_annotations is defined and kiali_vars.deployment.configmap_annotations|length > 0 %}
+  annotations:
+    {{ kiali_vars.deployment.configmap_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% endif %}
+data:
+  config.yaml: |
+    {{ kiali_vars | to_nice_yaml(indent=0) | trim | indent(4) }}

--- a/roles/v2.27/kiali-deploy/templates/openshift/console-links.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/console-links.yaml
@@ -1,0 +1,16 @@
+{% for namespace in namespaces %}
+---
+apiVersion: console.openshift.io/v1
+kind: ConsoleLink
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-namespace-{{ namespace }}
+  labels: {{ kiali_resource_metadata_labels | combine({ kiali_instance_label_name: kiali_instance_label_value }) }}
+spec:
+  href: {{ kiali_route_url }}{{ '/' if kiali_vars.server.web_root == '/' else (kiali_vars.server.web_root + '/') }}console/graph/namespaces?namespaces={{ namespace }}
+  location: NamespaceDashboard
+  text: Kiali
+  text: {{ ('Kiali [' + kiali_vars.deployment.instance_name + ']') if kiali_vars.deployment.instance_name != 'kiali' else 'Kiali' }}
+  namespaceDashboard:
+    namespaces:
+    - "{{ namespace }}"
+{% endfor %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/deployment.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/deployment.yaml
@@ -1,0 +1,275 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+{% if kiali_vars.deployment.hpa.spec | length == 0 %}
+  replicas: {{ kiali_vars.deployment.replicas }}
+{% endif %}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  strategy:
+{% if kiali_vars.deployment.strategy | length > 0 %}
+    {{ kiali_vars.deployment.strategy | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% else %}
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+{% endif %}
+  template:
+    metadata:
+      name: {{ kiali_vars.deployment.instance_name }}
+      labels: {{ kiali_resource_metadata_labels | combine(kiali_vars.deployment.pod_labels) }}
+      annotations:
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ kiali_vars.server.observability.metrics.port }}"
+        prometheus.io/scheme: "{{ 'http' if kiali_vars.identity.cert_file == '' else 'https' }}"
+{% else %}
+        prometheus.io/scrape: "false"
+        prometheus.io/port: null
+        prometheus.io/scheme: null
+{% endif %}
+        kiali.io/dashboards: go,kiali
+        operator.kiali.io/last-updated: "{{ deployment_last_updated }}"
+{% if kiali_vars.deployment.pod_annotations|length > 0 %}
+        {{ kiali_vars.deployment.pod_annotations | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+    spec:
+      serviceAccount: {{ kiali_vars.deployment.instance_name }}-service-account
+{% if kiali_vars.deployment.priority_class_name != "" %}
+      priorityClassName: "{{ kiali_vars.deployment.priority_class_name }}"
+{% endif %}
+{% if kiali_vars.deployment.image_pull_secrets | default([]) | length > 0 %}
+      imagePullSecrets:
+{% for n in kiali_vars.deployment.image_pull_secrets %}
+      - name: {{ n }}
+{% endfor %}
+{% endif %}
+{% if kiali_vars.deployment.host_aliases|length > 0 %}
+      hostAliases:
+        {{ kiali_vars.deployment.host_aliases | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+{% if kiali_vars.deployment.dns | length > 0 %}
+{% if kiali_vars.deployment.dns.policy | length > 0 %}
+      dnsPolicy: "{{ kiali_vars.deployment.dns.policy }}"
+{% endif %}
+{% if kiali_vars.deployment.dns.config | length > 0 %}
+      dnsConfig:
+        {{ kiali_vars.deployment.dns.config | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endif %}
+{% endif %}
+{% if kiali_vars.deployment.additional_pod_init_containers_yaml|length > 0 %}
+      initContainers:
+{% for container in kiali_vars.deployment.additional_pod_init_containers_yaml %}
+      - {{ container | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endfor %}
+{% endif %}
+      containers:
+{% for container in kiali_vars.deployment.additional_pod_containers_yaml %}
+      - {{ container | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% endfor %}
+      - image: {{ kiali_vars.deployment.image_name }}{{ '@' + kiali_vars.deployment.image_digest if kiali_vars.deployment.image_digest != '' else '' }}:{{ kiali_vars.deployment.image_version }}
+        imagePullPolicy: {{ kiali_vars.deployment.image_pull_policy }}
+        name: kiali
+        command:
+        - "/opt/kiali/kiali"
+        - "-config"
+        - "/kiali-configuration/config.yaml"
+        terminationMessagePolicy: FallbackToLogsOnError
+        securityContext:
+{% if kiali_vars.deployment.security_context|length > 0 %}
+          {{ kiali_vars.deployment.security_context | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% endif %}
+{% if kiali_vars.deployment.security_context|length == 0 or lookup('env', 'ALLOW_SECURITY_CONTEXT_OVERRIDE') != "true" %}
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+            - ALL
+{% endif %}
+        ports:
+          - name: api-port
+            containerPort: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+          - name: http-metrics
+            containerPort: {{ kiali_vars.server.observability.metrics.port }}
+{% endif %}
+        readinessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: {{ kiali_vars.deployment.probes.readiness.initial_delay_seconds|int }}
+          periodSeconds: {{ kiali_vars.deployment.probes.readiness.period_seconds|int }}
+        livenessProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          initialDelaySeconds: {{ kiali_vars.deployment.probes.liveness.initial_delay_seconds|int }}
+          periodSeconds: {{ kiali_vars.deployment.probes.liveness.period_seconds|int }}
+        startupProbe:
+          httpGet:
+            path: {{ kiali_vars.server.web_root | regex_replace('\\/$', '') }}/healthz
+            port: api-port
+            scheme:  {{ 'HTTP' if kiali_vars.identity.cert_file == "" else 'HTTPS' }}
+          failureThreshold: {{ kiali_vars.deployment.probes.startup.failure_threshold|int }}
+          initialDelaySeconds: {{ kiali_vars.deployment.probes.startup.initial_delay_seconds|int }}
+          periodSeconds: {{ kiali_vars.deployment.probes.startup.period_seconds|int }}
+        env:
+        - name: ACTIVE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOG_FORMAT
+          value: "{{ kiali_vars.deployment.logger.log_format }}"
+        - name: LOG_LEVEL
+          value: "{{ kiali_vars.deployment.logger.log_level }}"
+        - name: LOG_SAMPLER_RATE
+          value: "{{ kiali_vars.deployment.logger.sampler_rate }}"
+        - name: LOG_TIME_FIELD_FORMAT
+          value: "{{ kiali_vars.deployment.logger.time_field_format }}"
+{% for env in kiali_vars.deployment.custom_envs %}
+        - name: "{{ env.name }}"
+          value: "{{ env.value }}"
+{% endfor %}
+        volumeMounts:
+        - name: kiali-configuration
+          mountPath: "/kiali-configuration"
+{% if kiali_vars.identity.cert_file == "/kiali-cert/tls.crt" %}
+        - name: kiali-cert
+          mountPath: "/kiali-cert"
+{% endif %}
+        - name: kiali-secret
+          mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
+{% for sec in kiali_deployment_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-override-secrets/{{ sec }}"
+          readOnly: true
+{% endfor %}
+{% for secret in kiali_vars.deployment.custom_secrets %}
+        - name: {{ secret.name }}
+          mountPath: "{{ secret.mount }}"
+{% endfor %}
+        - name: "kiali-multi-cluster-secret"
+          mountPath: "/kiali-remote-cluster-secrets/kiali-multi-cluster-secret"
+          readOnly: true
+{% for sec in kiali_deployment_remote_cluster_secret_volumes %}
+        - name: {{ sec }}
+          mountPath: "/kiali-remote-cluster-secrets/{{ kiali_deployment_remote_cluster_secret_volumes[sec].secret_name }}"
+          readOnly: true
+{% endfor %}
+{% if kiali_vars.deployment.resources|length > 0 %}
+        resources:
+          {{ kiali_vars.deployment.resources | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        resources: null
+{% endif %}
+      volumes:
+      - name: kiali-configuration
+        configMap:
+          name: {{ kiali_vars.deployment.instance_name }}
+{% if kiali_vars.identity.cert_file == "/kiali-cert/tls.crt" %}
+      - name: kiali-cert
+        secret:
+          secretName: {{ kiali_vars.deployment.instance_name }}-cert-secret
+{% endif %}
+      - name: kiali-secret
+        secret:
+          secretName: {{ kiali_vars.deployment.secret_name }}
+          optional: true
+      - name: kiali-cabundle
+        projected:
+          sources:
+          - configMap:
+              name: {{ kiali_vars.deployment.instance_name }}-cabundle-openshift
+          - configMap:
+              name: {{ kiali_vars.deployment.instance_name }}-cabundle
+              optional: true
+          - configMap:
+              name: {{ kiali_vars.deployment.instance_name }}-oauth-cabundle
+              optional: true
+{% for sec in kiali_deployment_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_secret_volumes[sec].secret_name }}
+          items:
+          - key: {{ kiali_deployment_secret_volumes[sec].secret_key }}
+            path: {{ kiali_deployment_secret_volumes[sec].path | default('value.txt') }}
+          optional: false
+{% endfor %}
+{% for secret in kiali_vars.deployment.custom_secrets %}
+      - name: {{ secret.name }}
+{% if secret.csi is defined %}
+        csi:
+          {{ secret.csi | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        secret:
+          secretName: {{ secret.name }}
+{% if secret.optional is defined %}
+          optional: {{ secret.optional }}
+{% endif %}
+{% endif %}
+{% endfor %}
+      - name: "kiali-multi-cluster-secret"
+        secret:
+          secretName: "kiali-multi-cluster-secret"
+          optional: true
+{% for sec in kiali_deployment_remote_cluster_secret_volumes %}
+      - name: {{ sec }}
+        secret:
+          secretName: {{ kiali_deployment_remote_cluster_secret_volumes[sec].secret_name }}
+{% endfor %}
+{% if kiali_vars.deployment.affinity.node|length > 0 or kiali_vars.deployment.affinity.pod|length > 0 or kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+      affinity:
+{% if kiali_vars.deployment.affinity.node|length > 0 %}
+        nodeAffinity:
+          {{ kiali_vars.deployment.affinity.node | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        nodeAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod|length > 0 %}
+        podAffinity:
+          {{ kiali_vars.deployment.affinity.pod | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAffinity: null
+{% endif %}
+{% if kiali_vars.deployment.affinity.pod_anti|length > 0 %}
+        podAntiAffinity:
+          {{ kiali_vars.deployment.affinity.pod_anti | to_nice_yaml(indent=0) | trim | indent(10) }}
+{% else %}
+        podAntiAffinity: null
+{% endif %}
+{% else %}
+      affinity: null
+{% endif %}
+{% if kiali_vars.deployment.tolerations|length > 0 %}
+      tolerations:
+      {{ kiali_vars.deployment.tolerations | to_nice_yaml(indent=0) | trim | indent(6) }}
+{% else %}
+      tolerations: null
+{% endif %}
+{% if kiali_vars.deployment.node_selector|length > 0 %}
+      nodeSelector:
+        {{ kiali_vars.deployment.node_selector | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% else %}
+      nodeSelector: null
+{% endif %}
+{% if kiali_vars.deployment.topology_spread_constraints|length > 0 %}
+      topologySpreadConstraints:
+        {{ kiali_vars.deployment.topology_spread_constraints | to_nice_yaml(indent=0) | trim | indent(8) }}
+{% else %}
+      topologySpreadConstraints: null
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/hpa.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/hpa.yaml
@@ -1,0 +1,14 @@
+{% if kiali_vars.deployment.hpa.spec | length > 0 %}
+apiVersion: {{ kiali_vars.deployment.hpa.api_version }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ kiali_vars.deployment.instance_name }}
+  {{ kiali_vars.deployment.hpa.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/networkpolicy.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/networkpolicy.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: {{ kiali_vars.server.port }}
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+    - protocol: TCP
+      port: {{ kiali_vars.server.observability.metrics.port }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/oauth.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/oauth.yaml
@@ -1,0 +1,23 @@
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-{{ kiali_vars.deployment.namespace }}
+  labels: {{ kiali_resource_metadata_labels }}
+redirectURIs:
+{% if kiali_vars.auth.openshift.redirect_uris | default([]) | length > 0 %}
+{% for uri in kiali_vars.auth.openshift.redirect_uris %}
+- "{{ uri }}"
+{% endfor %}
+{% else %}
+- {{ kiali_route_url }}/api/auth/callback
+{% if kiali_vars.server.web_port | length > 0 %}
+- {{ kiali_route_url }}:{{ kiali_vars.server.web_port }}/api/auth/callback
+{% endif %}
+{% endif %}
+grantMethod: auto
+{% if kiali_vars.auth.openshift.token_inactivity_timeout is defined %}
+accessTokenInactivityTimeoutSeconds: {{ kiali_vars.auth.openshift.token_inactivity_timeout }}
+{% endif %}
+{% if kiali_vars.auth.openshift.token_max_age is defined %}
+accessTokenMaxAgeSeconds: {{ kiali_vars.auth.openshift.token_max_age }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/pdb.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/pdb.yaml
@@ -1,0 +1,14 @@
+{% if kiali_vars.deployment.pod_disruption_budget.spec | length > 0 %}
+apiVersion: {{ kiali_vars.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  {{ kiali_vars.deployment.pod_disruption_budget.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -1,0 +1,91 @@
+{% for namespace in role_namespaces %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-viewer
+  namespace: "{{ namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+{% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
+  - pods/log
+{% endif %}
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io
+  - inference.networking.k8s.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+{% endfor %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/role.yaml
@@ -1,0 +1,98 @@
+{% for namespace in role_namespaces %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_kind }}
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+{% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
+  - pods/log
+{% endif %}
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io
+  - inference.networking.k8s.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+{% endfor %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/rolebinding.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/rolebinding.yaml
@@ -1,0 +1,17 @@
+{% for namespace in role_namespaces %}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ role_binding_kind }}
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ role_kind }}
+  name: {{ (kiali_vars.deployment.instance_name + '-viewer') if ((kiali_vars.deployment.view_only_mode|bool == True) or (kiali_vars.auth.strategy != 'anonymous')) else kiali_vars.deployment.instance_name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+{% endfor %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/route.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/route.yaml
@@ -1,0 +1,22 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_vars.deployment.ingress.additional_labels | combine(kiali_resource_metadata_labels) }}
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.metadata is defined and kiali_vars.deployment.ingress.override_yaml.metadata.annotations is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.metadata | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% endif %}
+spec:
+{% if kiali_vars.deployment.ingress.override_yaml is defined and kiali_vars.deployment.ingress.override_yaml.spec is defined %}
+  {{ kiali_vars.deployment.ingress.override_yaml.spec | to_nice_yaml(indent=0) | trim | indent(2) }}
+{% else %}
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect
+  to:
+    kind: Service
+    name: {{ kiali_vars.deployment.instance_name }}
+  port:
+    targetPort: {{ kiali_vars.server.port }}
+{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/service.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/service.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: {{ kiali_vars.deployment.instance_name }}-cert-secret
+{% if kiali_vars.deployment.service_annotations|length > 0 %}
+    {{ kiali_vars.deployment.service_annotations | to_nice_yaml(indent=0) | trim | indent(4) }}
+{% endif %}
+spec:
+{% if kiali_vars.deployment.service_type is defined %}
+  type: {{ kiali_vars.deployment.service_type }}
+{% endif %}
+  ports:
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}
+    protocol: TCP
+{% if k8s_version is defined and k8s_version is version('1.20', '>=') %}
+    appProtocol: {{ 'http' if kiali_vars.identity.cert_file == "" else 'https' }}
+{% endif %}
+    port: {{ kiali_vars.server.port }}
+{% if kiali_vars.deployment.service_type is defined and kiali_vars.deployment.service_type == "NodePort" and kiali_vars.server.node_port is defined %}
+    nodePort: {{ kiali_vars.server.node_port }}
+{% endif %}
+{% if kiali_vars.server.observability.metrics.enabled|bool == True %}
+  - name: {{ 'http' if kiali_vars.identity.cert_file == "" else 'tcp' }}-metrics
+    protocol: TCP
+{% if k8s_version is defined and k8s_version is version('1.20', '>=') %}
+    appProtocol: {{ 'http' if kiali_vars.identity.cert_file == "" else 'https' }}
+{% endif %}
+    port: {{ kiali_vars.server.observability.metrics.port }}
+{% endif %}
+  selector:
+{% if query(k8s_plugin, kind='Service', resource_name=kiali_vars.deployment.instance_name, namespace=kiali_vars.deployment.namespace) | length > 0 %}
+    app: null
+    version: null
+{% endif %}
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: {{ kiali_vars.deployment.instance_name }}
+  {% if kiali_vars.deployment.additional_service_yaml is defined %}{{ kiali_vars.deployment.additional_service_yaml | to_nice_yaml(indent=0) | trim | indent(2) }}{% endif %}

--- a/roles/v2.27/kiali-deploy/templates/openshift/serviceaccount.yaml
+++ b/roles/v2.27/kiali-deploy/templates/openshift/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ kiali_vars.deployment.instance_name }}-service-account
+  namespace: "{{ kiali_vars.deployment.namespace }}"
+  labels: {{ kiali_resource_metadata_labels }}

--- a/roles/v2.27/kiali-deploy/vars/main.yml
+++ b/roles/v2.27/kiali-deploy/vars/main.yml
@@ -1,0 +1,129 @@
+# These are the actual variables used by the role. You will notice it is
+# one big dictionary (key="kiali_vars") whose child dictionaries mimic those
+# as defined in defaults/main.yml.
+# The child dictionaries below will have values that are a combination of the default values
+# (as found in defaults/main.yaml) and user-supplied values.
+# Without this magic, a user supplying only one key/value pair in a child dictionary will
+# clear out (make undefined) all the rest of the key/value pairs in that child dictionary.
+# This is not what we want. We want the rest of the dictionary to keep the defaults,
+# thus allowing the user to override only a subset of key/values in a dictionary.
+#
+# I found this trick at https://groups.google.com/forum/#!topic/Ansible-project/pGbRYZyqxZ4
+# I tweeked that solution a little bit because I did not want to require the user to supply
+# everything under a main "kiali_vars" dictionary.
+
+kiali_vars:
+  installation_tag: "{{ installation_tag | default(kiali_defaults.installation_tag) }}"
+  version: "{{ version | default(kiali_defaults.version) }}"
+
+  additional_display_details: |
+    {%- if additional_display_details is defined and additional_display_details is iterable -%}
+    {{ additional_display_details }}
+    {%- else -%}
+    {{ kiali_defaults.additional_display_details }}
+    {%- endif -%}
+
+  auth: |
+    {%- if auth is defined and auth is iterable -%}
+    {{ kiali_defaults.auth | combine((auth | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.auth }}
+    {%- endif -%}
+
+  chat_ai: |
+    {%- if chat_ai is defined and chat_ai is iterable -%}
+    {{ kiali_defaults.chat_ai | combine((chat_ai | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.chat_ai }}
+    {%- endif -%}
+
+  clustering: |
+    {%- if clustering is defined and clustering is iterable -%}
+    {{ kiali_defaults.clustering | combine((clustering | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.clustering }}
+    {%- endif -%}
+
+  custom_dashboards: |
+    {%- if custom_dashboards is defined and custom_dashboards is iterable -%}
+    {{ custom_dashboards }}
+    {%- else -%}
+    {{ kiali_defaults.custom_dashboards }}
+    {%- endif -%}
+
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ kiali_defaults.deployment | combine((deployment | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.deployment }}
+    {%- endif -%}
+
+  extensions: |
+    {%- if extensions is defined and extensions is iterable -%}
+    {{ extensions }}
+    {%- else -%}
+    {{ kiali_defaults.extensions }}
+    {%- endif -%}
+
+  external_services: |
+    {%- if external_services is defined and external_services is iterable -%}
+    {{ kiali_defaults.external_services | combine((external_services | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.external_services }}
+    {%- endif -%}
+
+  health_config: |
+    {%- if health_config is defined and health_config is iterable -%}
+    {{ kiali_defaults.health_config | combine((health_config | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.health_config }}
+    {%- endif -%}
+
+  identity: |
+    {%- if identity is defined and identity is iterable -%}
+    {{ kiali_defaults.identity | combine((identity | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.identity }}
+    {%- endif -%}
+
+  istio_labels: |
+    {%- if istio_labels is defined and istio_labels is iterable -%}
+    {{ kiali_defaults.istio_labels | combine((istio_labels | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.istio_labels }}
+    {%- endif -%}
+
+  kiali_feature_flags: |
+    {%- if kiali_feature_flags is defined and kiali_feature_flags is iterable -%}
+    {{ kiali_defaults.kiali_feature_flags | combine((kiali_feature_flags | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.kiali_feature_flags }}
+    {%- endif -%}
+
+  kiali_internal: |
+    {%- if kiali_internal is defined and kiali_internal is iterable -%}
+    {{ kiali_defaults.kiali_internal | combine((kiali_internal | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.kiali_internal }}
+    {%- endif -%}
+
+  kubernetes_config: |
+    {%- if kubernetes_config is defined and kubernetes_config is iterable -%}
+    {{ kiali_defaults.kubernetes_config | combine((kubernetes_config | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.kubernetes_config }}
+    {%- endif -%}
+
+  login_token: |
+    {%- if login_token is defined and login_token is iterable -%}
+    {{ kiali_defaults.login_token | combine((login_token | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.login_token }}
+    {%- endif -%}
+
+  server: |
+    {%- if server is defined and server is iterable -%}
+    {{ kiali_defaults.server | combine((server | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults.server }}
+    {%- endif -%}

--- a/roles/v2.27/kiali-remove/defaults/main.yml
+++ b/roles/v2.27/kiali-remove/defaults/main.yml
@@ -1,0 +1,12 @@
+kiali_defaults_remove:
+  deployment:
+    cluster_wide_access: true
+    hpa:
+      api_version: ""
+    instance_name: "kiali"
+    pod_disruption_budget:
+      api_version: ""
+
+# Will be auto-detected, but for debugging purposes you can force one of these to true
+is_k8s: false
+is_openshift: false

--- a/roles/v2.27/kiali-remove/filter_plugins/stripnone.py
+++ b/roles/v2.27/kiali-remove/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/roles/v2.27/kiali-remove/meta/main.yml
+++ b/roles/v2.27/kiali-remove/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+- kubernetes.core

--- a/roles/v2.27/kiali-remove/tasks/clusterroles-to-remove.yml
+++ b/roles/v2.27/kiali-remove/tasks/clusterroles-to-remove.yml
@@ -1,0 +1,25 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars_remove.deployment.instance_name }}-viewer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ kiali_vars_remove.deployment.instance_name }}-{{ kiali_vars_remove.deployment.namespace }}-openshift
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ kiali_vars_remove.deployment.instance_name }}-{{ kiali_vars_remove.deployment.namespace }}-openshift

--- a/roles/v2.27/kiali-remove/tasks/get-api-versions.yaml
+++ b/roles/v2.27/kiali-remove/tasks/get-api-versions.yaml
@@ -1,0 +1,14 @@
+# We want to avoid using k8s_cluster_info because it is resource intensive. So just look for the API versions we are interested in.
+
+### AUTOSCALING API
+
+- name: See if autoscaling/v2 HorizontalPodAutoscaler is available
+  k8s_info:
+    api_version: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+  register: api_check_autoscaling_v2
+  ignore_errors: true
+
+- name: Set autoscaling_api_version based on whether autoscaling/v2 is supported or not
+  set_fact:
+    autoscaling_api_version: "{{ 'autoscaling/v2' if (api_check_autoscaling_v2 is defined and api_check_autoscaling_v2.api_found is defined and api_check_autoscaling_v2.api_found) else 'autoscaling/v2beta2' }}"

--- a/roles/v2.27/kiali-remove/tasks/main.yml
+++ b/roles/v2.27/kiali-remove/tasks/main.yml
@@ -1,0 +1,239 @@
+# These tasks remove all Kiali resources such that no remnants of Kiali will remain.
+#
+# Note that we ignore_errors everywhere - we do not want these tasks to ever abort with a failure.
+# This is because these are run within a finalizer and if a failure aborts any task here
+# the user will never be able to delete the Kiali CR - in fact, the delete will hang indefinitely
+# and the user will need to do an ugly hack to fix it.
+
+- ignore_errors: yes
+  set_fact:
+    k8s_plugin: kubernetes.core.k8s
+
+- name: Get the original CR that was deleted
+  ignore_errors: yes
+  set_fact:
+    current_cr: "{{ _kiali_io_kiali }}"
+
+- name: Get api group information from the cluster
+  ignore_errors: yes
+  set_fact:
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+- name: Get api versions from the cluster
+  ignore_errors: yes
+  include_tasks: get-api-versions.yaml
+
+- name: Determine the cluster type
+  ignore_errors: yes
+  set_fact:
+    is_openshift: "{{ True if 'route.openshift.io' in api_groups else False }}"
+    is_k8s: "{{ False if 'route.openshift.io' in api_groups else True }}"
+  when:
+  - is_openshift == False
+  - is_k8s == False
+
+# Indicate what kind of cluster we are in (OpenShift or Kubernetes).
+- ignore_errors: yes
+  debug:
+    msg: "CLUSTER TYPE: is_openshift={{ is_openshift }}; is_k8s={{ is_k8s }}"
+
+- name: Print some debug information
+  ignore_errors: yes
+  vars:
+    msg: |
+        Kiali Variables:
+        --------------------------------
+        {{ kiali_vars_remove | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: Set default HPA api_version
+  ignore_errors: yes
+  set_fact:
+    kiali_vars_remove: "{{ kiali_vars_remove | combine({'deployment': {'hpa': {'api_version': autoscaling_api_version }}}, recursive=True) }}"
+  when:
+  - kiali_vars_remove.deployment.hpa.api_version == ""
+
+- name: Set default PDB api_version
+  ignore_errors: yes
+  set_fact:
+    kiali_vars_remove: "{{ kiali_vars_remove | combine({'deployment': {'pod_disruption_budget': {'api_version': 'policy/v1'}}}, recursive=True) }}"
+  when:
+  - kiali_vars_remove.deployment.pod_disruption_budget.api_version == ""
+
+# There is an edge case where a user installed Kiali with one instance name, then changed the instance name in the CR.
+# This is not allowed. When this happens, the operator will abort with an error message telling the user to uninstall Kiali.
+# The user will do this by deleting the Kiali CR, at which time this ansible role is executed.
+# In this case we must use the instance name stored in the status not the spec because the spec will have the bad name
+# and the status will have the correct name that was used to initially install Kiali.
+- name: Ensure the correct instance_name is used
+  ignore_errors: yes
+  set_fact:
+    kiali_vars_remove: "{{ kiali_vars_remove | combine({'deployment': {'instance_name': current_cr.status.deployment.instanceName}}, recursive=True) }}"
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.instanceName is defined
+  - current_cr.status.deployment.instanceName != kiali_vars_remove.deployment.instance_name
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  ignore_errors: yes
+  set_fact:
+    kiali_vars_remove: "{{ kiali_vars_remove | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - kiali_vars_remove.deployment.namespace is not defined or kiali_vars_remove.deployment.namespace == ""
+
+- name: Define the expected label for the namespaces and signing key secret
+  set_fact:
+    kiali_instance_label_name: "{{ 'kiali.io/' + kiali_vars_remove.deployment.instance_name + '.home' }}"
+    kiali_instance_label_value: "{{ kiali_vars_remove.deployment.namespace }}"
+
+- name: Get namespaces that have Kiali roles in them
+  ignore_errors: yes
+  set_fact:
+    namespaces_with_kiali_roles: "{{ query(k8s_plugin, label_selector=(kiali_instance_label_name + '=' + kiali_instance_label_value), kind='Namespace', errors='ignore') | default ([]) | map(attribute='metadata.name') | list }}"
+  when:
+  - kiali_vars_remove.deployment.cluster_wide_access == False
+
+- name: Delete Kiali roles
+  ignore_errors: yes
+  k8s:
+    state: absent
+    definition: |
+      {% for namespace in namespaces_with_kiali_roles %}
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
+      metadata:
+        name: "{{ kiali_vars_remove.deployment.instance_name }}"
+        namespace: "{{ namespace }}"
+      ...
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: "{{ kiali_vars_remove.deployment.instance_name }}"
+        namespace: "{{ namespace }}"
+      ...
+      ---
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
+      metadata:
+        name: "{{ kiali_vars_remove.deployment.instance_name }}-viewer"
+        namespace: "{{ namespace }}"
+      ...
+      {% endfor %}
+  when:
+  - namespaces_with_kiali_roles is defined
+  - namespaces_with_kiali_roles | length > 0
+
+- name: Remove Kiali label from namespaces that are currently accessible
+  ignore_errors: yes
+  k8s:
+    state: patched
+    definition: |
+      {% for namespace in namespaces_with_kiali_roles %}
+      ---
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ namespace }}"
+        labels:
+         {{ kiali_instance_label_name }}: null
+      ...
+      {% endfor %}
+  when:
+  - namespaces_with_kiali_roles is defined
+  - namespaces_with_kiali_roles | length > 0
+
+- name: Delete Kiali cluster roles
+  ignore_errors: yes
+  k8s:
+    state: absent
+    continue_on_error: false
+    template:
+    - clusterroles-to-remove.yml
+  retries: 6
+  delay: 10
+
+- name: Delete Kiali resources
+  ignore_errors: yes
+  k8s:
+    state: absent
+    continue_on_error: false
+    template:
+    - resources-to-remove.yml
+  retries: 6
+  delay: 10
+
+- name: Unlabel the signing key secret if it exists to indicate this Kiali instance no longer uses it
+  ignore_errors: yes
+  k8s:
+    state: patched
+    definition: |
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "kiali-signing-key"
+        namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+        labels:
+          {{ kiali_instance_label_name }}: null
+
+- name: Delete the signing key secret if no other Kiali installation is using it
+  ignore_errors: yes
+  vars:
+    signing_key_secret_labels: "{{ lookup(k8s_plugin, namespace=kiali_vars_remove.deployment.namespace, kind='Secret', resource_name='kiali-signing-key', api_version='v1') | default({}) | json_query('metadata.labels') }}"
+  k8s:
+    state: absent
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: kiali-signing-key
+        namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  when:
+  - (signing_key_secret_labels is not defined) or (signing_key_secret_labels | length == 0) or (signing_key_secret_labels | dict2items | selectattr('key', 'match', 'kiali.io/.*\.home') | list | length == 0)
+
+- name: Delete OpenShift-specific Kiali resources
+  ignore_errors: yes
+  k8s:
+    state: absent
+    continue_on_error: false
+    template:
+    - os-resources-to-remove.yml
+  retries: 6
+  delay: 10
+  when:
+  - is_openshift == True
+
+# If it is Removed, the web console is disabled.
+# See: https://docs.openshift.com/container-platform/4.13/web_console/disabling-web-console.html
+- name: Determine if OpenShift Console is installed and enabled
+  ignore_errors: yes
+  vars:
+    console_res: "{{ query(k8s_plugin, resource_name='cluster', api_version='operator.openshift.io/v1', kind='Console', errors='ignore') }}"
+  set_fact:
+    has_openshift_console: "{{ console_res | length > 0 and console_res[0].spec.managementState != 'Removed' }}"
+  when:
+  - is_openshift == True
+
+- name: Delete OpenShift-specific Kiali ConsoleLinks
+  ignore_errors: yes
+  k8s:
+    state: absent
+    definition: |
+      {% for cl in query(k8s_plugin, kind='ConsoleLink', label_selector=(kiali_instance_label_name + '=' + kiali_instance_label_value)) %}
+      ---
+      apiVersion: "{{ cl.apiVersion }}"
+      kind: "{{ cl.kind }}"
+      metadata:
+        name: "{{ cl.metadata.name }}"
+      ...
+      {% endfor %}
+  when:
+  - is_openshift == True
+  - has_openshift_console is defined
+  - has_openshift_console == True

--- a/roles/v2.27/kiali-remove/tasks/os-resources-to-remove.yml
+++ b/roles/v2.27/kiali-remove/tasks/os-resources-to-remove.yml
@@ -1,0 +1,17 @@
+---
+apiVersion: oauth.openshift.io/v1
+kind: OAuthClient
+metadata:
+  name: {{ kiali_vars_remove.deployment.instance_name + '-' + kiali_vars_remove.deployment.namespace }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}-cabundle-openshift

--- a/roles/v2.27/kiali-remove/tasks/resources-to-remove.yml
+++ b/roles/v2.27/kiali-remove/tasks/resources-to-remove.yml
@@ -1,0 +1,79 @@
+---
+apiVersion: {{ kiali_vars_remove.deployment.hpa.api_version }}
+kind: HorizontalPodAutoscaler
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: {{ kiali_vars_remove.deployment.pod_disruption_budget.api_version }}
+kind: PodDisruptionBudget
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: networking.k8s.io/{{ 'v1' if (lookup(k8s_plugin, kind='Ingress', api_version='networking.k8s.io/v1', errors='ignore') is iterable) else 'v1beta1' }}
+kind: Ingress
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: v1
+kind: ReplicaSet
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}-service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}-viewer
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
+  name: {{ kiali_vars_remove.deployment.instance_name }}
+---

--- a/roles/v2.27/kiali-remove/vars/main.yml
+++ b/roles/v2.27/kiali-remove/vars/main.yml
@@ -1,0 +1,7 @@
+kiali_vars_remove:
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ kiali_defaults_remove.deployment | combine((deployment | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ kiali_defaults_remove.deployment }}
+    {%- endif -%}

--- a/roles/v2.27/ossmconsole-deploy/defaults/main.yml
+++ b/roles/v2.27/ossmconsole-deploy/defaults/main.yml
@@ -1,0 +1,24 @@
+# Defaults for all user-facing OSSM Console settings.
+#
+# Note that these are under the main dictionary group "ossmconsole_defaults".
+# The actual vars used by the role are found in the vars/ directory.
+# These defaults (the dictionaries under "ossmconsole_defaults") are merged into the vars such that the values
+# below (e.g. deployment) are merged in rather than completely replaced by user-supplied values.
+#
+# If new groups are added to these defaults, you must remember to add the merge code to vars/main.yml.
+
+ossmconsole_defaults:
+  version: "default"
+
+  deployment:
+    imageDigest: ""
+    imageName: ""
+    imagePullPolicy: "IfNotPresent"
+    imagePullSecrets: []
+    imageVersion: ""
+    namespace: ""
+
+  kiali:
+    serviceName: ""
+    serviceNamespace: ""
+    servicePort: 0

--- a/roles/v2.27/ossmconsole-deploy/filter_plugins/stripnone.py
+++ b/roles/v2.27/ossmconsole-deploy/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/roles/v2.27/ossmconsole-deploy/meta/main.yml
+++ b/roles/v2.27/ossmconsole-deploy/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+- kubernetes.core

--- a/roles/v2.27/ossmconsole-deploy/tasks/main.yml
+++ b/roles/v2.27/ossmconsole-deploy/tasks/main.yml
@@ -1,0 +1,413 @@
+- set_fact:
+    k8s_plugin: kubernetes.core.k8s
+
+- name: Get the original CR as-is
+  set_fact:
+    current_cr: "{{ _kiali_io_ossmconsole }}"
+
+- name: Find oldest CR
+  vars:
+    crs: "{{ query(k8s_plugin, kind=current_cr.kind, api_version=current_cr.apiVersion) | sort(attribute='metadata.creationTimestamp') }}"
+  set_fact:
+    oldest_ossmconsole_cr: "{{ crs[0] }}"
+  when:
+  - crs | length > 0
+
+- block:
+  - debug:
+      msg: "Ignoring this CR [{{ current_cr.metadata.namespace }}/{{ current_cr.metadata.name }}]. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - include_tasks: update-status-progress.yml
+    vars:
+      status_progress_message: "Ignoring this CR. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - meta: end_play
+  when:
+  - oldest_ossmconsole_cr is defined
+  - oldest_ossmconsole_cr.metadata.name != current_cr.metadata.name or oldest_ossmconsole_cr.metadata.namespace != current_cr.metadata.namespace
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Initializing"
+    status_vars:
+      specVersion: "{{ ossmconsole_vars.version }}"
+      deployment:
+        namespace: null
+      kiali:
+        serviceName: null
+        serviceNamespace: null
+        servicePort: null
+
+# There are three possible values for the console managementState: Managed, Unmanaged, and Removed.
+# If it is Removed, the web console is disabled and thus we cannot install OSSMC so abort immediately.
+# See: https://docs.openshift.com/container-platform/4.13/web_console/disabling-web-console.html
+- name: Ensure OpenShift Console is installed and enabled
+  vars:
+    console_res: "{{ query(k8s_plugin, resource_name='cluster', api_version='operator.openshift.io/v1', kind='Console', errors='ignore') }}"
+  fail:
+    msg: "The OpenShift Console is not installed and enabled. Cannot install OSSMC."
+  when:
+  - console_res | length == 0 or console_res[0].spec.managementState == "Removed"
+
+- name: Get information about the cluster
+  set_fact:
+    api_groups: "{{ lookup(k8s_plugin, cluster_info='api_groups') }}"
+
+- name: Determine the Kubernetes version
+  set_fact:
+    k8s_version: "{{ lookup(k8s_plugin, cluster_info='version').kubernetes.gitVersion | regex_replace('^v', '') }}"
+  ignore_errors: yes
+
+- name: Determine the OpenShift version
+  vars:
+    kube_apiserver_cluster_op_raw: "{{ lookup(k8s_plugin, api_version='config.openshift.io/v1', kind='ClusterOperator', resource_name='kube-apiserver') | default({}) }}"
+    ri_query: "status.versions[?name == 'raw-internal'].version"
+  set_fact:
+    openshift_version: "{{ kube_apiserver_cluster_op_raw | json_query(ri_query) | join }}"
+
+- name: Get information about the operator
+  k8s_info:
+    api_version: v1
+    kind: Pod
+    namespace: "{{ lookup('env', 'POD_NAMESPACE') }}"
+    name: "{{ lookup('env', 'POD_NAME') }}"
+  register: operator_pod_raw
+  ignore_errors: yes
+- name: Determine the version of the operator based on the version label
+  set_fact:
+    operator_version: "{{ operator_pod_raw.resources[0].metadata.labels.version }}"
+  when:
+  - operator_pod_raw is defined
+  - operator_pod_raw.resources[0] is defined
+  - operator_pod_raw.resources[0].metadata is defined
+  - operator_pod_raw.resources[0].metadata.labels is defined
+  - operator_pod_raw.resources[0].metadata.labels.version is defined
+- set_fact:
+    operator_version: "unknown"
+  when:
+  - operator_version is not defined
+- debug:
+    msg: "OPERATOR VERSION: [{{ operator_version }}]"
+
+- name: Print some debug information
+  vars:
+    msg: |
+      OSSM Console Variables:
+      --------------------------------
+      {{ ossmconsole_vars | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.deployment.namespace is not defined or ossmconsole_vars.deployment.namespace == ""
+
+- name: Do not support installing in any namespace other than where the CR lives
+  fail:
+    msg: "The operator currently does not support installing the plugin in any namespace other than the namespace where the CR was created."
+  when:
+  - ossmconsole_vars.deployment.namespace != current_cr.metadata.namespace
+
+# Never allow deployment.namespace to change to avoid leaking resources - to uninstall resources you must delete the OSSMConsole CR
+- name: Ensure the deployment.namespace has not changed
+  fail:
+    msg: "The deployment.namespace cannot be changed to a different value. It was [{{ current_cr.status.deployment.namespace }}] but is now [{{ ossmconsole_vars.deployment.namespace }}]. In order to install OSSM Console with a different deployment.namespace, please uninstall OSSM Console first."
+  when:
+  - current_cr.status is defined
+  - current_cr.status.deployment is defined
+  - current_cr.status.deployment.namespace is defined
+  - current_cr.status.deployment.namespace != ossmconsole_vars.deployment.namespace
+
+# If we need to auto-discover some things that require the Kiali Route, get the route now - first look in the CR's namespace then anywhere else. If Kiali is not found, abort.
+- name: Auto-discover the Kiali Route - preference goes to a Kiali installed in the same namespace as the CR
+  vars:
+    kiali_in_namespace: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route', namespace=current_cr.metadata.namespace) }}"
+    kiali_anywhere: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route') }}"
+  set_fact:
+    kiali_route: "{{ kiali_in_namespace[0] if kiali_in_namespace | length > 0 else (kiali_anywhere[0] if kiali_anywhere | length > 0 else '') }}"
+  when:
+  - ossmconsole_vars.kiali.serviceName == "" or ossmconsole_vars.kiali.serviceNamespace == "" or ossmconsole_vars.kiali.servicePort|int == 0
+  ignore_errors: yes
+
+- fail:
+    msg: "Failed to auto-discover the Kiali Route. Make sure Kiali is installed. You can specify the full 'kiali' section in the CR if there is a Kiali installed but cannot be auto-discovered by this operator."
+  when:
+  - kiali_route is defined
+  - kiali_route == ""
+
+- name: Auto-discover the Kiali Service Name
+  set_fact:
+    kiali_service_name: "{{ kiali_route.spec.to.name }}"
+  when:
+  - ossmconsole_vars.kiali.serviceName == ""
+  ignore_errors: yes
+
+- name: Auto-discover the Kiali Service Namespace
+  set_fact:
+    kiali_service_namespace: "{{ kiali_route.metadata.namespace }}"
+  when:
+  - ossmconsole_vars.kiali.serviceNamespace == ""
+  ignore_errors: yes
+
+- name: Auto-discover the Kiali Service Port
+  set_fact:
+    kiali_service_port: "{{ kiali_route.spec.port.targetPort }}"
+  when:
+  - ossmconsole_vars.kiali.servicePort|int == 0
+  ignore_errors: yes
+
+- fail:
+    msg: "Failed to auto-discover the Kiali Service Name. Make sure Kiali is installed. You can specify 'kiali.serviceName' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
+  when:
+  - ossmconsole_vars.kiali.serviceName == ""
+  - kiali_service_name is not defined or kiali_service_name == ""
+
+- fail:
+    msg: "Failed to auto-discover the Kiali Service Namespace. Make sure Kiali is installed. You can specify 'kiali.serviceNamespace' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
+  when:
+  - ossmconsole_vars.kiali.serviceNamespace == ""
+  - kiali_service_namespace is not defined or kiali_service_namespace == ""
+
+- fail:
+    msg: "Failed to auto-discover the Kiali Service Port. Make sure Kiali is installed. You can specify 'kiali.servicePort' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
+  when:
+  - ossmconsole_vars.kiali.servicePort|int == 0
+  - kiali_service_port is not defined or kiali_service_port == ""
+
+# Set the auto-discovered values that we found
+- set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'serviceName': kiali_service_name}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.kiali.serviceName == ""
+- set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'serviceNamespace': kiali_service_namespace}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.kiali.serviceNamespace == ""
+- set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'servicePort': kiali_service_port}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.kiali.servicePort|int == 0
+
+- name: Ask Kiali for information about itself
+  vars:
+    version_url: "{{ 'https://' + ossmconsole_vars.kiali.serviceName + '.' + ossmconsole_vars.kiali.serviceNamespace + '.svc.cluster.local:' + ossmconsole_vars.kiali.servicePort|string + '/api' }}"
+  uri:
+    url: "{{ version_url }}"
+    status_code: 200
+    validate_certs: false
+    return_content: true
+  register: kiali_info_results
+  until:
+  - kiali_info_results is defined
+  - kiali_info_results.status is defined
+  - kiali_info_results.status == 200
+  retries: 60
+  delay: 5
+  ignore_errors: yes
+
+- name: Determine Kiali version
+  vars:
+    q: status."Kiali version"
+  set_fact:
+    kiali_version: "{{ kiali_info_results.json | json_query(q) }}"
+  when:
+  - kiali_info_results is defined
+  - kiali_info_results.json is defined
+  ignore_errors: yes
+
+- name: "Determine environment to store in status"
+  set_fact:
+    status_environment: "{{ status_environment | default({}) | combine({item.0: item.1}) }}"
+  loop: "{{ data[0] | zip(data[1]) | list }}"
+  vars:
+    data:
+    - ['kialiVersion', 'kubernetesVersion', 'openshiftVersion', 'operatorVersion']
+    - ["{{kiali_version|default('unknown')}}", "{{k8s_version|default('')}}", "{{openshift_version|default('')}}", "{{operator_version}}"]
+  when:
+  - item.1 != ""
+  - item.1 != "false"
+  - item.1 != False
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Setting up configuration"
+    status_vars:
+      environment: "{{ status_environment | default({}) }}"
+      deployment:
+        namespace: "{{ ossmconsole_vars.deployment.namespace }}"
+      kiali:
+        serviceName: "{{ ossmconsole_vars.kiali.serviceName }}"
+        serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
+        servicePort: "{{ ossmconsole_vars.kiali.servicePort|int }}"
+
+# The OSSMC plugin must talk to a Kiali of the same version.
+# We asked the Kiali Server what version it is, so we already have that.
+# To know the OSSMC version, we assume even if the user overrides the imageName/imageVersion, that that image must
+# support the same major.minor version of the playbook (i.e. spec.version). We look up the version of the playbook
+# in original_supported_ossmconsole_images (which contains the actual imageVersion strings, even if they were overridden
+# by the RELATED_IMAGES environment variables - we assume all RELATED_IMAGES are fixed hashs of the original imageVersion
+# numbers) and obtain the imageVersion that that playbook supports and assume that is the version
+# of OSSMC that is being installed - so that is the version we compare with the Kiali version. Note that if imageVersion
+# is the string "operator_version", the supported OSSMC version is the same version as the operator itself.
+# Note that we ignore any "v" prefix that may be in front of the version numbers; always just compare major.minor (v or no-v).
+# If, for some reason, the user runs into an edge case where OSSMC needs to be installed even if the versions don't match,
+# set the env var OSSMC_SKIP_VERSION_CHECK=true in the operator.
+- name: Ensure Kiali major.minor version is supported by the version of OSSMC being installed
+  vars:
+    kiali_version_to_match: "{{ kiali_version | default('') | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+    ossmc_version_expected: "{{ original_supported_ossmconsole_images[ossmconsole_vars.version].imageVersion | default ('') }}"
+    ossmc_version_to_match: "{{ ((operator_version | default('')) if ossmc_version_expected == 'operator_version' else ossmc_version_expected) | regex_replace('^[v]?([0-9]+.[0-9]+).*', '\\1') }}"
+  fail:
+    msg: "The version of the Kiali Server [{{ kiali_version_to_match }}] does not match the OSSMC version [{{ ossmc_version_to_match }}]. OSSMC will not be installed. To skip this check and allow for the install to continue, set the operator environment variable OSSMC_SKIP_VERSION_CHECK to 'true'."
+  when:
+  - kiali_version_to_match != ossmc_version_to_match
+  - lookup('env', 'OSSMC_SKIP_VERSION_CHECK') | default('false', True) != "true"
+
+- name: Only allow ad-hoc OSSM Console image when appropriate
+  fail:
+    msg: "The operator is forbidden from accepting an OSSMConsole CR that defines an ad hoc OSSM Console image [{{ ossmconsole_vars.deployment.imageName }}{{ '@' + ossmconsole_vars.deployment.imageDigest if ossmconsole_vars.deployment.imageDigest != '' else '' }}:{{ ossmconsole_vars.deployment.imageVersion }}]. Remove spec.deployment.imageName, spec.deployment.imageVersion, and spec.deployment.imageDigest from the OSSMConsole CR."
+  when:
+  - ossmconsole_vars.deployment.imageName != "" or ossmconsole_vars.deployment.imageVersion != "" or ossmconsole_vars.deployment.imageDigest != ""
+  - lookup('env', 'ALLOW_AD_HOC_OSSMCONSOLE_IMAGE') | default('false', True) != "true"
+
+- name: Default the image name to a known supported image.
+  set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'deployment': {'imageName': supported_ossmconsole_images[ossmconsole_vars.version].imageName}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.deployment.imageName == ""
+- name: Default the image version to a known supported image.
+  set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'deployment': {'imageVersion': ('latest' if operator_version == 'master' else operator_version) if supported_ossmconsole_images[ossmconsole_vars.version].imageVersion == 'operator_version' else supported_ossmconsole_images[ossmconsole_vars.version].imageVersion}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.deployment.imageVersion == ""
+
+- name: If image version is latest then we will want to always pull
+  set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'deployment': {'imagePullPolicy': 'Always'}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.deployment.imageVersion == "latest"
+
+- name: Confirm the cluster can access github.com when it needs to determine the last release of Kiali
+  uri:
+    url: https://api.github.com/repos/kiali/openshift-servicemesh-plugin/releases
+  when:
+  - ossmconsole_vars.deployment.imageVersion == "lastrelease"
+- name: Determine image version when last release is to be installed
+  shell: echo -n $(curl -s https://api.github.com/repos/kiali/openshift-servicemesh-plugin/releases 2> /dev/null | grep "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//' | grep -v "snapshot" | sort -t "." -k 1.2g,1 -k 2g,2 -k 3g | tail -n 1)
+  register: github_lastrelease
+  when:
+  - ossmconsole_vars.deployment.imageVersion == "lastrelease"
+- set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'deployment': {'imageVersion': github_lastrelease.stdout}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.deployment.imageVersion == "lastrelease"
+
+- name: Determine image version when it explicitly was configured as the operator_version
+  set_fact:
+    ossmconsole_vars: "{{ ossmconsole_vars | combine({'deployment': {'imageVersion': 'latest' if operator_version == 'master' else operator_version}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars.deployment.imageVersion == "operator_version"
+
+- fail:
+    msg: "Could not determine what the image version should be. Set deployment.imageVersion to a valid value"
+  when:
+  - ossmconsole_vars.deployment.imageVersion == "" or ossmconsole_vars.deployment.imageVersion == "unknown"
+
+# Indicate which image we are going to use.
+- debug:
+    msg: "IMAGE_NAME={{ ossmconsole_vars.deployment.imageName }}; IMAGE VERSION={{ ossmconsole_vars.deployment.imageVersion }}"
+
+- name: Determine what metadata labels to apply to all created resources
+  vars:
+    version_label: "{{ (ossmconsole_vars.deployment.imageVersion) if (ossmconsole_vars.deployment.imageVersion | length <= 63) else (ossmconsole_vars.deployment.imageVersion[:60] + 'XXX') }}"
+  set_fact:
+    ossmconsole_resource_metadata_labels:
+      app: ossmconsole
+      version: "{{ version_label }}"
+      app.kubernetes.io/name: ossmconsole
+      app.kubernetes.io/version: "{{ version_label }}"
+      app.kubernetes.io/instance: ossmconsole
+      app.kubernetes.io/part-of: ossmconsole
+
+- name: Delete OSSM Console deployment if image is changing - this uninstalls any old version of OSSM Console that might be running
+  k8s:
+    state: absent
+    api_version: apps/v1
+    kind: Deployment
+    namespace: "{{ ossmconsole_vars.deployment.namespace }}"
+    name: ossmconsole
+  when:
+  - current_image_name is defined and current_image_version is defined
+  - (current_image_name != ossmconsole_vars.deployment.imageName) or (current_image_version != ossmconsole_vars.deployment.imageVersion)
+
+# Get the deployment's custom annotation we set that tells us when we last updated the Deployment.
+# We need this to ensure the Deployment we update retains this same timestamp unless changes are made
+# that requires a pod restart - in which case we update this timestamp.
+- name: Find current deployment, if it exists
+  set_fact:
+    current_deployment: "{{ lookup(k8s_plugin, resource_name='ossmconsole', namespace=ossmconsole_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') }}"
+
+- name: Get current deployment last-updated annotation timestamp from existing deployment
+  set_fact:
+    current_deployment_last_updated: "{{ current_deployment.spec.template.metadata.annotations['ossmconsole.kiali.io/last-updated'] if current_deployment.spec.template.metadata.annotations['ossmconsole.kiali.io/last-updated'] is defined else lookup('pipe','date') }}"
+    deployment_is_new: false
+  when:
+  - current_deployment is defined
+  - current_deployment.spec is defined
+  - current_deployment.spec.template is defined
+  - current_deployment.spec.template.metadata is defined
+  - current_deployment.spec.template.metadata.annotations is defined
+
+- name: Set current deployment last-updated annotation timestamp for new deployments
+  set_fact:
+    current_deployment_last_updated: "{{ lookup('pipe','date') }}"
+    deployment_is_new: true
+  when:
+  - current_deployment_last_updated is not defined
+
+# Now deploy all resources for the specific cluster environment
+
+- name: Execute for OpenShift environment
+  include_tasks: openshift/os-main.yml
+  vars:
+    deployment_last_updated: "{{ current_deployment_last_updated }}"
+
+# If something changed that can only be picked up when the OSSM Console pod starts up, then restart the pod using a rolling restart
+# We do this by checking the processed_resources_dict created by process-resources.yml task. If there is a map key
+# with the kind (ConfigMap) with the name of our config map appended to it ("-plugin-conf") see if that config map changed.
+# If it did, we need to restart the pod so it can re-read the new config.
+- name: Force the OSSM Console pod to restart if necessary
+  vars:
+    keyname: "{{ 'ConfigMap-plugin-conf' }}"
+    updated_deployment: "{{ lookup(k8s_plugin, resource_name='ossmconsole', namespace=ossmconsole_vars.deployment.namespace, api_version='apps/v1', kind='Deployment') | combine({'spec': {'template': {'metadata': {'annotations': {'ossmconsole.kiali.io/last-updated': lookup('pipe','date') }}}}}, recursive=True) }}"
+  k8s:
+    state: "present"
+    definition: "{{ updated_deployment }}"
+  when:
+  - deployment_is_new == False
+  - processed_resources_dict is defined
+  - processed_resources_dict[keyname] is defined
+  - processed_resources_dict[keyname].changed == True
+  - processed_resources_dict[keyname].method == "patch"
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Enabling plugin"
+    status_vars: {}
+
+- name: Enable plugin by ensuring the OSSM Console is in the Console list of plugins
+  vars:
+    existing_plugins: "{{ lookup(k8s_plugin, resource_name='cluster', api_version='operator.openshift.io/v1', kind='Console').spec.plugins | default([]) }}"
+  k8s:
+    state: patched
+    api_version: operator.openshift.io/v1
+    kind: Console
+    name: cluster
+    definition:
+      spec:
+        plugins: "{{ (existing_plugins | difference(['ossmconsole'])) + ['ossmconsole'] }}"
+
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Finished"
+    status_vars: {}

--- a/roles/v2.27/ossmconsole-deploy/tasks/openshift/os-main.yml
+++ b/roles/v2.27/ossmconsole-deploy/tasks/openshift/os-main.yml
@@ -1,0 +1,13 @@
+- include_tasks: update-status-progress.yml
+  vars:
+    status_progress_message: "Creating core resources"
+
+- name: Create OSSM Console objects on OpenShift
+  include_tasks: process-resource.yml
+  vars:
+    process_resource_templates:
+    - "templates/openshift/configmap-nginx.yaml"
+    - "templates/openshift/configmap-plugin.yaml"
+    - "templates/openshift/deployment.yaml"
+    - "templates/openshift/service.yaml"
+    - "templates/openshift/consoleplugin.yaml"

--- a/roles/v2.27/ossmconsole-deploy/tasks/process-resource.yml
+++ b/roles/v2.27/ossmconsole-deploy/tasks/process-resource.yml
@@ -1,0 +1,31 @@
+# process all template names found in process_resource_templates - any empty strings in the list are ignored.
+# This will keep a running tally of all processed resources in "processed_resources_dict".
+- name: "Create OSSMConsole resources from templates"
+  k8s:
+    state: "present"
+    continue_on_error: false
+    template: "{{ process_resource_templates | select() | list }}"
+  register: process_resource_templates_result
+  retries: 6
+  delay: 10
+
+# Store the results of the processed resource so they can be examined later (e.g. to know if something changed or stayed the same)
+- vars:
+    kinds: "{{ process_resource_templates_result.result.results | map(attribute='result.kind') | list }}"
+    names: "{{ process_resource_templates_result.result.results | map(attribute='result.metadata.name') | list }}"
+    changed: "{{ process_resource_templates_result.result.results | map(attribute='changed') | list }}"
+    method: "{{ process_resource_templates_result.result.results | map(attribute='method') | list }}"
+    thedict: "{{ processed_resources_dict | default({}) }}"
+  set_fact:
+    processed_resources_dict: |
+      {% for kind in kinds %}
+      {%   set _ = thedict.update({ (kind + '-' + names[loop.index0]): {'name': names[loop.index0], 'changed': changed[loop.index0], 'method': method[loop.index0]}}) %}
+      {% endfor %}
+      {{ thedict }}
+  when:
+  - process_resource_templates_result is defined
+  - process_resource_templates_result | length > 0
+
+- name: "Resource creation results"
+  debug:
+    msg: "{{ processed_resources_dict }}"

--- a/roles/v2.27/ossmconsole-deploy/tasks/update-status-progress.yml
+++ b/roles/v2.27/ossmconsole-deploy/tasks/update-status-progress.yml
@@ -1,0 +1,16 @@
+- name: Prepare status progress facts
+  ignore_errors: yes
+  set_fact:
+    status_progress_step: "{{ 1 if status_progress_step is not defined else (status_progress_step|int + 1) }}"
+    status_progress_start: "{{ ('%Y-%m-%d %H:%M:%S' | strftime) if status_progress_start is not defined else (status_progress_start) }}"
+
+- name: Update CR status progress field with any additional status fields
+  ignore_errors: yes
+  vars:
+    duration: "{{ ('%Y-%m-%d %H:%M:%S' | strftime | to_datetime) - (status_progress_start | to_datetime) }}"
+  operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars | default({}) | combine({'progress':{'message': status_progress_step + '. ' + status_progress_message, 'duration': duration }}, recursive=True) }}"

--- a/roles/v2.27/ossmconsole-deploy/tasks/update-status.yml
+++ b/roles/v2.27/ossmconsole-deploy/tasks/update-status.yml
@@ -1,0 +1,8 @@
+- name: Update CR status field
+  ignore_errors: yes
+  operator_sdk.util.k8s_status:
+    api_version: "{{ current_cr.apiVersion }}"
+    kind: "{{ current_cr.kind }}"
+    name: "{{ current_cr.metadata.name }}"
+    namespace: "{{ current_cr.metadata.namespace }}"
+    status: "{{ status_vars }}"

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
+  labels: {{ ossmconsole_resource_metadata_labels }}
+data:
+  nginx.conf: |
+    error_log /dev/stdout;
+    events {}
+    http {
+      access_log         /dev/stdout;
+      include            /etc/nginx/mime.types;
+      default_type       application/octet-stream;
+      keepalive_timeout  65;
+      server {
+        listen              9443 ssl;
+        listen              [::]:9443 ssl;
+        ssl_certificate     /var/serving-cert/tls.crt;
+        ssl_certificate_key /var/serving-cert/tls.key;
+        # Only TLS client is the OCP Console backend (Go 1.24+), so TLS 1.2 is unnecessary
+        ssl_protocols       TLSv1.3;
+        # PQC hybrid groups for ML-KEM; requires OpenSSL >= 3.5
+        ssl_ecdh_curve      x25519mlkem768:SecP256r1MLKEM768:x25519:prime256v1:secp384r1;
+
+        add_header oauth_token "$http_Authorization";
+
+        location / {
+          root                /usr/share/nginx/html;
+        }
+      }
+    }

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: plugin-conf
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
+  labels: {{ ossmconsole_resource_metadata_labels }}
+data:
+  plugin-config.json: |
+    {
+    }

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -1,0 +1,25 @@
+apiVersion: console.openshift.io/v1
+kind: ConsolePlugin
+metadata:
+  name: ossmconsole
+  labels: {{ ossmconsole_resource_metadata_labels }}
+spec:
+  displayName: "OpenShift Service Mesh Console"
+  i18n:
+    loadType: Preload
+  backend:
+    service:
+      name: ossmconsole
+      namespace: "{{ ossmconsole_vars.deployment.namespace }}"
+      port: 9443
+      basePath: "/"
+    type: Service
+  proxy:
+  - alias: kiali
+    authorization: UserToken
+    endpoint:
+      service:
+        name: {{ ossmconsole_vars.kiali.serviceName }}
+        namespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
+        port: {{ ossmconsole_vars.kiali.servicePort | int }}
+      type: Service

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/deployment.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ossmconsole
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
+  labels: {{ ossmconsole_resource_metadata_labels }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ossmconsole
+      app.kubernetes.io/instance: ossmconsole
+  template:
+    metadata:
+      name: ossmconsole
+      labels: {{ ossmconsole_resource_metadata_labels }}
+      annotations:
+        ossmconsole.kiali.io/last-updated: "{{ deployment_last_updated }}"
+    spec:
+{% if ossmconsole_vars.deployment.imagePullSecrets | default([]) | length > 0 %}
+      imagePullSecrets:
+{% for n in ossmconsole_vars.deployment.imagePullSecrets %}
+      - name: {{ n }}
+{% endfor %}
+{% endif %}
+      containers:
+      - name: ossmconsole
+        image: {{ ossmconsole_vars.deployment.imageName }}{{ '@' + ossmconsole_vars.deployment.imageDigest if ossmconsole_vars.deployment.imageDigest != '' else '' }}:{{ ossmconsole_vars.deployment.imageVersion }}
+        imagePullPolicy: {{ ossmconsole_vars.deployment.imagePullPolicy }}
+        ports:
+        - containerPort: 9443
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: ossmconsole-cert-secret
+          readOnly: true
+          mountPath: /var/serving-cert
+        - name: nginx-conf
+          readOnly: true
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+        - name: plugin-conf
+          readOnly: true
+          mountPath: /usr/share/nginx/html/plugin-config.json
+          subPath: plugin-config.json
+      volumes:
+      - name: ossmconsole-cert-secret
+        secret:
+          secretName: ossmconsole-cert-secret
+          defaultMode: 420
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+          defaultMode: 420
+      - name: plugin-conf
+        configMap:
+          name: plugin-conf
+          defaultMode: 420
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "25%"
+      maxSurge: "25%"

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/service.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ossmconsole
+  namespace: "{{ ossmconsole_vars.deployment.namespace }}"
+  labels: {{ ossmconsole_resource_metadata_labels }}
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: ossmconsole-cert-secret
+spec:
+  ports:
+  - name: 9443-tcp
+    protocol: TCP
+    port: 9443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: ossmconsole
+    app.kubernetes.io/instance: ossmconsole
+  type: ClusterIP
+  sessionAffinity: None

--- a/roles/v2.27/ossmconsole-deploy/vars/main.yml
+++ b/roles/v2.27/ossmconsole-deploy/vars/main.yml
@@ -1,0 +1,30 @@
+# These are the actual variables used by the role. You will notice it is
+# one big dictionary (key="ossmconsole_vars") whose child dictionaries mimic those
+# as defined in defaults/main.yml.
+# The child dictionaries below will have values that are a combination of the default values
+# (as found in defaults/main.yaml) and user-supplied values.
+# Without this magic, a user supplying only one key/value pair in a child dictionary will
+# clear out (make undefined) all the rest of the key/value pairs in that child dictionary.
+# This is not what we want. We want the rest of the dictionary to keep the defaults,
+# thus allowing the user to override only a subset of key/values in a dictionary.
+#
+# I found this trick at https://groups.google.com/forum/#!topic/Ansible-project/pGbRYZyqxZ4
+# I tweeked that solution a little bit because I did not want to require the user to supply
+# everything under a main "ossmconsole_vars" dictionary.
+
+ossmconsole_vars:
+  version: "{{ version | default(ossmconsole_defaults.version) }}"
+
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ ossmconsole_defaults.deployment | combine((deployment | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmconsole_defaults.deployment }}
+    {%- endif -%}
+
+  kiali: |
+    {%- if kiali is defined and kiali is iterable -%}
+    {{ ossmconsole_defaults.kiali | combine((kiali | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmconsole_defaults.kiali }}
+    {%- endif -%}

--- a/roles/v2.27/ossmconsole-remove/defaults/main.yml
+++ b/roles/v2.27/ossmconsole-remove/defaults/main.yml
@@ -1,0 +1,3 @@
+ossmconsole_defaults:
+  deployment:
+    namespace: ""

--- a/roles/v2.27/ossmconsole-remove/filter_plugins/stripnone.py
+++ b/roles/v2.27/ossmconsole-remove/filter_plugins/stripnone.py
@@ -1,0 +1,28 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+  'metadata_version': '1.1',
+  'status': ['preview'],
+  'supported_by': 'community'
+}
+
+# Process recursively the given value if it is a dict and remove all keys that have a None value
+def strip_none(value):
+  if isinstance(value, dict):
+    dicts = {}
+    for k,v in value.items():
+      if isinstance(v, dict):
+        dicts[k] = strip_none(v)
+      elif v is not None:
+        dicts[k] = v
+    return dicts
+  else:
+    return value
+
+# ---- Ansible filters ----
+class FilterModule(object):
+  def filters(self):
+    return {
+      'stripnone': strip_none
+    }

--- a/roles/v2.27/ossmconsole-remove/meta/main.yml
+++ b/roles/v2.27/ossmconsole-remove/meta/main.yml
@@ -1,0 +1,2 @@
+collections:
+- kubernetes.core

--- a/roles/v2.27/ossmconsole-remove/tasks/main.yml
+++ b/roles/v2.27/ossmconsole-remove/tasks/main.yml
@@ -1,0 +1,72 @@
+# These tasks remove all resources such that no remnants of OSSM Console will remain.
+#
+# Note that we ignore_errors everywhere - we do not want these tasks to ever abort with a failure.
+# This is because these are run within a finalizer and if a failure aborts any task here
+# the user will never be able to delete the OSSMConsole CR - in fact, the delete will hang indefinitely
+# and the user will need to do an ugly hack to fix it.
+
+- ignore_errors: yes
+  set_fact:
+    k8s_plugin: kubernetes.core.k8s
+
+- name: Get the original CR that was deleted
+  ignore_errors: yes
+  set_fact:
+    current_cr: "{{ _kiali_io_ossmconsole }}"
+
+- name: Find oldest CR
+  vars:
+    crs: "{{ query(k8s_plugin, kind=current_cr.kind, api_version=current_cr.apiVersion) | sort(attribute='metadata.creationTimestamp') }}"
+  set_fact:
+    oldest_ossmconsole_cr: "{{ crs[0] }}"
+  when:
+  - crs | length > 0
+
+- block:
+  - debug:
+      msg: "Ignoring this CR [{{ current_cr.metadata.namespace }}/{{ current_cr.metadata.name }}]. The CR in control of OSSMC is [{{ oldest_ossmconsole_cr.metadata.namespace }}/{{ oldest_ossmconsole_cr.metadata.name }}]."
+  - meta: end_play
+  when:
+  - oldest_ossmconsole_cr is defined
+  - oldest_ossmconsole_cr.metadata.name != current_cr.metadata.name or oldest_ossmconsole_cr.metadata.namespace != current_cr.metadata.namespace
+
+- name: Print some debug information
+  ignore_errors: yes
+  vars:
+    msg: |
+        OSSM Console Variables:
+        --------------------------------
+        {{ ossmconsole_vars_remove | to_nice_yaml }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: Set default deployment namespace to the same namespace where the CR lives
+  ignore_errors: yes
+  set_fact:
+    ossmconsole_vars_remove: "{{ ossmconsole_vars_remove | combine({'deployment': {'namespace': current_cr.metadata.namespace}}, recursive=True) }}"
+  when:
+  - ossmconsole_vars_remove.deployment.namespace is not defined or ossmconsole_vars_remove.deployment.namespace == ""
+
+- name: Disable plugin by ensuring the OSSM Console is removed from the Console list of plugins
+  ignore_errors: yes
+  vars:
+    existing_plugins: "{{ lookup(k8s_plugin, resource_name='cluster', api_version='operator.openshift.io/v1', kind='Console').spec.plugins | default([]) }}"
+  k8s:
+    state: patched
+    api_version: operator.openshift.io/v1
+    kind: Console
+    name: cluster
+    definition:
+      spec:
+        plugins: "{{ existing_plugins | difference(['ossmconsole']) }}"
+
+- name: Delete OSSM Console resources
+  ignore_errors: yes
+  k8s:
+    state: absent
+    namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
+    continue_on_error: false
+    template:
+    - resources-to-remove.yml
+  retries: 6
+  delay: 10

--- a/roles/v2.27/ossmconsole-remove/tasks/resources-to-remove.yml
+++ b/roles/v2.27/ossmconsole-remove/tasks/resources-to-remove.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
+  name: nginx-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
+  name: plugin-config
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
+  name: ossmconsole
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: "{{ ossmconsole_vars_remove.deployment.namespace }}"
+  name: ossmconsole
+---
+apiVersion: console.openshift.io/v1alpha1
+kind: ConsolePlugin
+metadata:
+  name: ossmconsole

--- a/roles/v2.27/ossmconsole-remove/vars/main.yml
+++ b/roles/v2.27/ossmconsole-remove/vars/main.yml
@@ -1,0 +1,7 @@
+ossmconsole_vars_remove:
+  deployment: |
+    {%- if deployment is defined and deployment is iterable -%}
+    {{ ossmconsole_defaults.deployment | combine((deployment | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmconsole_defaults.deployment }}
+    {%- endif -%}


### PR DESCRIPTION
## Summary
Backport of https://github.com/kiali/kiali-operator/pull/1047 to v2.27 branch.

- Add new version-specific Ansible role `v2.27` (copied from `default`)
- Register v2.27 in supported images for both kiali and ossmconsole
- Update kiali-ossm CSV with RELATED_IMAGE references and relatedImages entries for v2.27

## Test plan
- [ ] Verify operator builds successfully with the new role
- [ ] Test deploying Kiali CR with `spec.version: v2.27`
- [ ] Test deploying OSSMConsole CR with `spec.version: v2.27`


Made with [Cursor](https://cursor.com)