### PR TITLE
Remove ssl_ecdh_curve to support FIPS-enabled clusters

### DIFF
--- a/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -18,10 +18,8 @@ data:
         listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
-        # Only TLS client is the OCP Console backend (Go 1.24+), so TLS 1.2 is unnecessary
+        # Only TLS client is the OCP Console backend, which supports TLS 1.3
         ssl_protocols       TLSv1.3;
-        # PQC hybrid groups for ML-KEM; requires OpenSSL >= 3.5
-        ssl_ecdh_curve      x25519mlkem768:SecP256r1MLKEM768:x25519:prime256v1:secp384r1;
 
         add_header oauth_token "$http_Authorization";
 

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -18,10 +18,8 @@ data:
         listen              [::]:9443 ssl;
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
-        # Only TLS client is the OCP Console backend (Go 1.24+), so TLS 1.2 is unnecessary
+        # Only TLS client is the OCP Console backend, which supports TLS 1.3
         ssl_protocols       TLSv1.3;
-        # PQC hybrid groups for ML-KEM; requires OpenSSL >= 3.5
-        ssl_ecdh_curve      x25519mlkem768:SecP256r1MLKEM768:x25519:prime256v1:secp384r1;
 
         add_header oauth_token "$http_Authorization";
 


### PR DESCRIPTION
## Summary
- Removes the `ssl_ecdh_curve` nginx directive from OSSMC ConfigMap templates (`roles/default/` and `roles/v2.27/`)
- The hardcoded curve list includes non-FIPS-approved algorithms (`x25519mlkem768`, `SecP256r1MLKEM768`, `x25519`) that cause nginx to crash on FIPS-enabled clusters (e.g. ARO): `SSL_CTX_set1_curves_list(...) failed`
- Without the directive, OpenSSL selects curves based on its runtime config: FIPS-approved curves in FIPS mode, PQC hybrid groups by default on OpenSSL 3.5+
- Companion PR: https://github.com/kiali/openshift-servicemesh-plugin/pull/696

## Test plan
- [ ] Deploy OSSMC via the operator on a FIPS-enabled cluster (e.g. ARO) and verify nginx starts successfully
- [ ] Deploy OSSMC via the operator on a non-FIPS cluster and verify TLS 1.3 still works


Made with [Cursor](https://cursor.com)