### PR TITLE
Apply principle of least privilege to operator RBAC permissions

### DIFF
--- a/hack/verify-kiali-server-permissions.sh
+++ b/hack/verify-kiali-server-permissions.sh
@@ -373,7 +373,8 @@ main() {
             compare_permissions "${combined_kiali_perms}" "${ossm_csv_perms}" "Kiali-Server" "OSSM-CSV"
         fi
         if [[ -n "${kiali_upstream_csv}" ]]; then
-            compare_permissions "${combined_kiali_perms}" "${upstream_csv_perms}" "Kiali-Server" "Upstream-CSV"
+            # Upstream CSV is non-OpenShift-only, so only check against kubernetes role template
+            compare_permissions "${kiali_k8s_perms}" "${upstream_csv_perms}" "Kiali-Server" "Upstream-CSV"
         fi
     fi
 

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -657,7 +657,6 @@ spec:
           - security.istio.io
           - extensions.istio.io
           - telemetry.istio.io
-          - gateway.networking.k8s.io
           - inference.networking.k8s.io
           resources: ["*"]
           verbs:
@@ -667,6 +666,36 @@ spec:
           - create
           - delete
           - patch
+        - apiGroups: ["gateway.networking.k8s.io"]
+          resources:
+          - gateways
+          - grpcroutes
+          - httproutes
+          - referencegrants
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["gateway.networking.k8s.io"]
+          resources:
+          - tcproutes
+          - tlsroutes
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - patch
+        - apiGroups: ["gateway.networking.k8s.io"]
+          resources:
+          - gatewayclasses
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups: ["apps.openshift.io"]
           resources:
           - deploymentconfigs

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -405,11 +405,8 @@ spec:
         - apiGroups: [""]
           resources:
           - configmaps
-          - endpoints
-          - pods
           - serviceaccounts
           - services
-          - services/finalizers
           verbs:
           - create
           - delete
@@ -418,6 +415,11 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: [""]
+          resources:
+          - pods
+          verbs:
+          - get
         - apiGroups: [""]
           resources:
           - namespaces
@@ -465,7 +467,6 @@ spec:
         - apiGroups: ["apps"]
           resources:
           - deployments
-          - replicasets
           verbs:
           - create
           - delete
@@ -496,19 +497,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: ["monitoring.coreos.com"]
-          resources:
-          - servicemonitors
-          verbs:
-          - create
-          - get
-        - apiGroups: ["apps"]
-          resourceNames:
-          - kiali-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
         - apiGroups: ["kiali.io"]
           resources:
           - '*'
@@ -524,7 +512,7 @@ spec:
           resources:
           - selfsubjectaccessreviews
           verbs:
-          - list
+          - create
         - apiGroups: ["rbac.authorization.k8s.io"]
           resources:
           - clusterrolebindings
@@ -539,14 +527,7 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: ["apiextensions.k8s.io"]
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups: ["extensions", "networking.k8s.io"]
+        - apiGroups: ["networking.k8s.io"]
           resources:
           - ingresses
           - networkpolicies
@@ -630,7 +611,6 @@ spec:
         - apiGroups: [""]
           resources:
           - configmaps
-          - endpoints
           - pods/log
           verbs:
           - get
@@ -652,8 +632,7 @@ spec:
           - pods/portforward
           verbs:
           - create
-          - post
-        - apiGroups: ["extensions", "apps"]
+        - apiGroups: ["apps"]
           resources:
           - daemonsets
           - deployments
@@ -674,10 +653,7 @@ spec:
           - watch
           - patch
         - apiGroups:
-          - config.istio.io
           - networking.istio.io
-          - authentication.istio.io
-          - rbac.istio.io
           - security.istio.io
           - extensions.istio.io
           - telemetry.istio.io
@@ -718,7 +694,5 @@ spec:
           resources:
           - mutatingwebhookconfigurations
           verbs:
-          - get
           - list
-          - watch
         serviceAccountName: kiali-operator

--- a/manifests/kiali-upstream/2.28.0/manifests/kiali.v2.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.28.0/manifests/kiali.v2.28.0.clusterserviceversion.yaml
@@ -291,11 +291,8 @@ spec:
         - apiGroups: [""]
           resources:
           - configmaps
-          - endpoints
-          - pods
           - serviceaccounts
           - services
-          - services/finalizers
           verbs:
           - create
           - delete
@@ -304,6 +301,11 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups: [""]
+          resources:
+          - pods
+          verbs:
+          - get
         - apiGroups: [""]
           resources:
           - namespaces
@@ -342,7 +344,6 @@ spec:
         - apiGroups: ["apps"]
           resources:
           - deployments
-          - replicasets
           verbs:
           - create
           - delete
@@ -373,19 +374,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: ["monitoring.coreos.com"]
-          resources:
-          - servicemonitors
-          verbs:
-          - create
-          - get
-        - apiGroups: ["apps"]
-          resourceNames:
-          - kiali-operator
-          resources:
-          - deployments/finalizers
-          verbs:
-          - update
         - apiGroups: ["kiali.io"]
           resources:
           - '*'
@@ -401,7 +389,7 @@ spec:
           resources:
           - selfsubjectaccessreviews
           verbs:
-          - list
+          - create
         - apiGroups: ["rbac.authorization.k8s.io"]
           resources:
           - clusterrolebindings
@@ -416,64 +404,10 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups: ["apiextensions.k8s.io"]
-          resources:
-          - customresourcedefinitions
-          verbs:
-          - get
-          - list
-          - watch
-        - apiGroups: ["extensions", "networking.k8s.io"]
+        - apiGroups: ["networking.k8s.io"]
           resources:
           - ingresses
           - networkpolicies
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups: ["route.openshift.io"]
-          resources:
-          - routes
-          - routes/custom-host
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups: ["oauth.openshift.io"]
-          resources:
-          - oauthclients
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups: ["config.openshift.io"]
-          resources:
-          - clusteroperators
-          verbs:
-          - list
-          - watch
-        - apiGroups: ["config.openshift.io"]
-          resourceNames:
-          - kube-apiserver
-          resources:
-          - clusteroperators
-          verbs:
-          - get
-        - apiGroups: ["console.openshift.io"]
-          resources:
-          - consolelinks
           verbs:
           - create
           - delete
@@ -486,7 +420,6 @@ spec:
         - apiGroups: [""]
           resources:
           - configmaps
-          - endpoints
           - pods/log
           verbs:
           - get
@@ -508,8 +441,7 @@ spec:
           - pods/portforward
           verbs:
           - create
-          - post
-        - apiGroups: ["extensions", "apps"]
+        - apiGroups: ["apps"]
           resources:
           - daemonsets
           - deployments
@@ -530,15 +462,12 @@ spec:
           - watch
           - patch
         - apiGroups:
-          - config.istio.io
-          - networking.istio.io
-          - authentication.istio.io
-          - rbac.istio.io
-          - security.istio.io
           - extensions.istio.io
-          - telemetry.istio.io
           - gateway.networking.k8s.io
           - inference.networking.k8s.io
+          - networking.istio.io
+          - security.istio.io
+          - telemetry.istio.io
           resources: ["*"]
           verbs:
           - get
@@ -546,14 +475,6 @@ spec:
           - watch
           - create
           - delete
-          - patch
-        - apiGroups: ["apps.openshift.io"]
-          resources:
-          - deploymentconfigs
-          verbs:
-          - get
-          - list
-          - watch
           - patch
         - apiGroups: ["authentication.k8s.io"]
           resources:
@@ -564,7 +485,5 @@ spec:
           resources:
           - mutatingwebhookconfigurations
           verbs:
-          - get
           - list
-          - watch
         serviceAccountName: kiali-operator

--- a/manifests/kiali-upstream/2.28.0/manifests/kiali.v2.28.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.28.0/manifests/kiali.v2.28.0.clusterserviceversion.yaml
@@ -463,7 +463,6 @@ spec:
           - patch
         - apiGroups:
           - extensions.istio.io
-          - gateway.networking.k8s.io
           - inference.networking.k8s.io
           - networking.istio.io
           - security.istio.io
@@ -476,6 +475,36 @@ spec:
           - create
           - delete
           - patch
+        - apiGroups: ["gateway.networking.k8s.io"]
+          resources:
+          - gateways
+          - grpcroutes
+          - httproutes
+          - referencegrants
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - patch
+        - apiGroups: ["gateway.networking.k8s.io"]
+          resources:
+          - tcproutes
+          - tlsroutes
+          verbs:
+          - get
+          - list
+          - watch
+          - delete
+          - patch
+        - apiGroups: ["gateway.networking.k8s.io"]
+          resources:
+          - gatewayclasses
+          verbs:
+          - get
+          - list
+          - watch
         - apiGroups: ["authentication.k8s.io"]
           resources:
           - tokenreviews

--- a/molecule/api-test/api-endpoint-tests.yml
+++ b/molecule/api-test/api-endpoint-tests.yml
@@ -1,0 +1,123 @@
+# Read-only API endpoint tests.
+# Imported twice from converge.yml: once with view_only_mode=false (role.yaml)
+# and once with view_only_mode=true (role-viewer.yaml).
+# Expects `kiali_base_url` and `api_test_pod` to be set before import.
+
+# Group A: Global endpoints (no path params)
+- name: "Test global API endpoints"
+  uri:
+    url: "{{ kiali_base_url }}{{ item.path }}"
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+  loop:
+  - { name: "Root API", path: "/api" }
+  - { name: "Status", path: "/api/status" }
+  - { name: "Config", path: "/api/config" }
+  - { name: "Disabled features", path: "/api/config/disabled" }
+  - { name: "Auth info", path: "/api/auth/info" }
+  - { name: "Namespaces", path: "/api/namespaces" }
+  - { name: "Istio status", path: "/api/istio/status" }
+  - { name: "Istio config (all)", path: "/api/istio/config" }
+  - { name: "Istio validations (all)", path: "/api/istio/validations" }
+  - { name: "Istio permissions", path: "/api/istio/permissions" }
+  - { name: "Mesh TLS", path: "/api/mesh/tls" }
+  - { name: "Mesh graph", path: "/api/mesh/graph" }
+  - { name: "Mesh control planes", path: "/api/mesh/controlplanes" }
+  - { name: "Clusters health", path: "/api/clusters/health" }
+  - { name: "Clusters services", path: "/api/clusters/services" }
+  - { name: "Clusters workloads", path: "/api/clusters/workloads" }
+  - { name: "Clusters apps", path: "/api/clusters/apps" }
+  - { name: "Clusters TLS", path: "/api/clusters/tls" }
+  - { name: "Clusters metrics", path: "/api/clusters/metrics" }
+  - { name: "Tracing info", path: "/api/tracing" }
+  - { name: "Overview service latency", path: "/api/overview/metrics/services/latency" }
+  - { name: "Overview service rates", path: "/api/overview/metrics/services/rates" }
+  - { name: "Overview service throughput", path: "/api/overview/metrics/services/throughput" }
+  - { name: "Overview app rates", path: "/api/overview/metrics/apps/rates" }
+  loop_control:
+    label: "{{ item.name }}"
+
+# Integration info endpoints that return 503 when backends aren't configured.
+# These don't exercise unique K8s permissions; we just verify the server handles them.
+- name: "Test integration info endpoints (503 expected when unconfigured)"
+  uri:
+    url: "{{ kiali_base_url }}{{ item.path }}"
+    validate_certs: false
+    status_code: [200, 204, 503]
+  loop:
+  - { name: "Grafana info", path: "/api/grafana" }
+  - { name: "Perses info", path: "/api/perses" }
+  loop_control:
+    label: "{{ item.name }}"
+
+# Group B: Namespace-scoped endpoints
+- name: "Test namespace-scoped API endpoints"
+  uri:
+    url: "{{ kiali_base_url }}{{ item.path }}"
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+  loop:
+  - { name: "Namespace info", path: "/api/namespaces/api-test/info" }
+  - { name: "Namespace Istio config", path: "/api/namespaces/api-test/istio" }
+  - { name: "Namespace validations", path: "/api/namespaces/api-test/validations" }
+  - { name: "Namespace TLS", path: "/api/namespaces/api-test/tls" }
+  - { name: "Namespace metrics", path: "/api/namespaces/api-test/metrics" }
+  loop_control:
+    label: "{{ item.name }}"
+
+# Group C: Resource-specific endpoints
+- name: "Test resource-specific API endpoints"
+  uri:
+    url: "{{ kiali_base_url }}{{ item.path }}"
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+  loop:
+  - { name: "Workload details", path: "/api/namespaces/api-test/workloads/api-test-app" }
+  - { name: "Service details", path: "/api/namespaces/api-test/services/api-test-app" }
+  - { name: "App details", path: "/api/namespaces/api-test/apps/api-test-app" }
+  - { name: "Istio config details (VirtualService)", path: "/api/namespaces/api-test/istio/networking.istio.io/v1/virtualservices/api-test-app" }
+  - { name: "Service metrics", path: "/api/namespaces/api-test/services/api-test-app/metrics" }
+  - { name: "Workload metrics", path: "/api/namespaces/api-test/workloads/api-test-app/metrics" }
+  - { name: "App metrics", path: "/api/namespaces/api-test/apps/api-test-app/metrics" }
+  loop_control:
+    label: "{{ item.name }}"
+
+# Group D: Pod-specific endpoints (use dynamically discovered pod name)
+- name: "Test pod details"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/pods/{{ api_test_pod }}"
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+- name: "Test pod logs"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/pods/{{ api_test_pod }}/logs?container=nginx"
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+- name: "Test pod config dump (exercises pods/portforward)"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/pods/{{ api_test_pod }}/config_dump"
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+# Group E: Graph endpoints
+- name: "Test graph API endpoints"
+  uri:
+    url: "{{ kiali_base_url }}{{ item.path }}"
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+  loop:
+  - { name: "Namespace graph", path: "/api/namespaces/graph?namespaces=api-test&duration=60s" }
+  - { name: "Service graph", path: "/api/namespaces/api-test/services/api-test-app/graph" }
+  - { name: "Workload graph", path: "/api/namespaces/api-test/workloads/api-test-app/graph" }
+  - { name: "App graph", path: "/api/namespaces/api-test/applications/api-test-app/graph" }
+  loop_control:
+    label: "{{ item.name }}"

--- a/molecule/api-test/api-write-tests.yml
+++ b/molecule/api-test/api-write-tests.yml
@@ -1,0 +1,93 @@
+# Write API endpoint tests (create, patch, delete).
+# Only imported during pass 1 (view_only_mode=false) since these verbs
+# are only granted by role.yaml, not role-viewer.yaml.
+# All resources are created in the api-test namespace so they are cleaned
+# up by the destroy phase if the test fails mid-way.
+
+# 1. Create a DestinationRule via Kiali API
+- name: "Write test: Create DestinationRule"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/destinationrules"
+    method: POST
+    body_format: json
+    body:
+      apiVersion: networking.istio.io/v1
+      kind: DestinationRule
+      metadata:
+        name: api-test-dr
+        namespace: api-test
+      spec:
+        host: api-test-app
+        trafficPolicy:
+          connectionPool:
+            tcp:
+              maxConnections: 100
+    validate_certs: false
+    status_code: [200, 201]
+  register: result
+  failed_when: result.status >= 500
+
+# 2. Patch the existing VirtualService via Kiali API
+- name: "Write test: Patch VirtualService"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/virtualservices/api-test-app"
+    method: PATCH
+    body_format: json
+    body:
+      metadata:
+        annotations:
+          api-test-write: patched
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+# 3. Delete the DestinationRule we just created
+- name: "Write test: Delete DestinationRule"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/destinationrules/api-test-dr"
+    method: DELETE
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+# 4. Patch the workload via Kiali API
+- name: "Write test: Patch workload"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/workloads/api-test-app?gvk=apps/v1/Deployment"
+    method: PATCH
+    body_format: json
+    body:
+      metadata:
+        annotations:
+          api-test-write: patched
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+# 5. Patch the service via Kiali API
+- name: "Write test: Patch service"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/services/api-test-app"
+    method: PATCH
+    body_format: json
+    body:
+      metadata:
+        annotations:
+          api-test-write: patched
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+# 6. Patch the namespace via Kiali API
+- name: "Write test: Patch namespace"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test"
+    method: PATCH
+    body_format: json
+    body:
+      metadata:
+        labels:
+          api-test-write: patched
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500

--- a/molecule/api-test/converge.yml
+++ b/molecule/api-test/converge.yml
@@ -1,0 +1,71 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  vars:
+    custom_resource: "{{ lookup('template', cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # Wait for the fixture pod to be fully ready including the Istio sidecar,
+  # which is needed for the config_dump endpoint test (port-forward to Envoy admin).
+  - name: Wait for test pod to be running with all containers ready
+    k8s_info:
+      kind: Pod
+      namespace: api-test
+      label_selectors:
+      - "app=api-test-app"
+    register: test_pods
+    until:
+    - test_pods.resources | length > 0
+    - test_pods.resources[0].status.phase == "Running"
+    - test_pods.resources[0].status.containerStatuses is defined
+    - (test_pods.resources[0].status.containerStatuses | selectattr('ready', 'equalto', true) | list | length) == (test_pods.resources[0].status.containerStatuses | length)
+    retries: 60
+    delay: 5
+
+  - name: Set test pod name
+    set_fact:
+      api_test_pod: "{{ test_pods.resources[0].metadata.name }}"
+
+  # ==========================================================================
+  # Pass 1: view_only_mode=false — validates role.yaml (full access)
+  # ==========================================================================
+
+  - name: "=== Pass 1: Testing with view_only_mode=false (role.yaml) ==="
+    debug:
+      msg: "Running read and write API endpoint tests against full-access role"
+
+  - import_tasks: api-endpoint-tests.yml
+  - import_tasks: api-write-tests.yml
+
+  # ==========================================================================
+  # Switch to view_only_mode=true and wait for operator reconciliation
+  # ==========================================================================
+
+  - import_tasks: ../common/set_view_only_mode.yml
+  - import_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - import_tasks: ../common/wait_for_kiali_running.yml
+  - import_tasks: ../common/tasks.yml
+  - import_tasks: ../asserts/pod_asserts.yml
+
+  # ==========================================================================
+  # Pass 2: view_only_mode=true — validates role-viewer.yaml (read only)
+  # ==========================================================================
+
+  - name: "=== Pass 2: Testing with view_only_mode=true (role-viewer.yaml) ==="
+    debug:
+      msg: "Running read-only API endpoint tests against viewer role"
+
+  - import_tasks: api-endpoint-tests.yml
+
+  - name: API test completed successfully
+    debug:
+      msg: |
+        API endpoint test completed:
+        - Pass 1 (view_only_mode=false): ~45 read endpoints + ~6 write endpoints passed (role.yaml)
+        - Pass 2 (view_only_mode=true): ~45 read endpoints passed (role-viewer.yaml)
+        - No 5xx errors detected — RBAC permissions are sufficient for both roles

--- a/molecule/api-test/destroy-api-test.yml
+++ b/molecule/api-test/destroy-api-test.yml
@@ -1,0 +1,13 @@
+- name: Destroy
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+- name: Include the base destroy play to remove Kiali
+  import_playbook: ../default/destroy.yml
+
+- name: Delete the test resources
+  import_playbook: ./process-resources.yml
+  vars:
+    state: absent

--- a/molecule/api-test/kiali-cr.yaml
+++ b/molecule/api-test/kiali-cr.yaml
@@ -1,0 +1,31 @@
+apiVersion: kiali.io/v1alpha1
+kind: Kiali
+metadata:
+  name: kiali
+spec:
+  version: {{ kiali.spec_version }}
+  auth:
+    strategy: {{ kiali.auth_strategy }}
+  deployment:
+    cluster_wide_access: {{ kiali.cluster_wide_access|bool }}
+    ingress:
+      enabled: true
+    logger:
+      log_level: debug
+    namespace: {{ kiali.install_namespace }}
+    image_name: "{{ kiali.image_name }}"
+    image_pull_policy: {{ kiali.image_pull_policy }}
+    image_version: "{{ kiali.image_version }}"
+    probes:
+      liveness:
+        initial_delay_seconds: 1
+        period_seconds: 1
+      readiness:
+        initial_delay_seconds: 1
+        period_seconds: 1
+      startup:
+        failure_threshold: 60
+        initial_delay_seconds: 1
+        period_seconds: 1
+    service_type: {{ 'LoadBalancer' if is_kind else 'NodePort' }}
+    view_only_mode: false

--- a/molecule/api-test/molecule.yml
+++ b/molecule/api-test/molecule.yml
@@ -1,0 +1,46 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callbacks_enabled: junit
+  playbooks:
+    destroy: ./destroy-api-test.yml
+    prepare: ./prepare-api-test.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/api-test/kiali-cr.yaml"
+        cr_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}"
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          spec_version: "{{ lookup('env', 'MOLECULE_KIALI_CR_SPEC_VERSION') | default('default', True) }}"
+          install_namespace: istio-system
+          cluster_wide_access: true
+          auth_strategy: anonymous
+          operator_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}"
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: kiali-operator
+          operator_cluster_role_creator: "true"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali' if lookup('env', 'MOLECULE_KIALI_IMAGE_NAME') == 'dev' else ('quay.io/kiali/kiali' if ansible_env.MOLECULE_KIALI_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_KIALI_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_KIALI_IMAGE_VERSION') }}"
+          image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_IMAGE_PULL_POLICY')|default('Always', True) }}"
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+scenario:
+  name: api-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/molecule/api-test/prepare-api-test.yml
+++ b/molecule/api-test/prepare-api-test.yml
@@ -1,0 +1,13 @@
+- name: Prepare
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+- name: Create the test resources
+  import_playbook: ./process-resources.yml
+  vars:
+    state: present
+
+- name: Include the base prepare play to install Kiali
+  import_playbook: ../default/prepare.yml

--- a/molecule/api-test/process-resources.yml
+++ b/molecule/api-test/process-resources.yml
@@ -1,0 +1,84 @@
+- name: "Process API Test Resources [state={{ state }}]"
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+
+  tasks:
+  - name: "{{ 'Create' if state == 'present' else 'Delete' }} test namespace"
+    k8s:
+      state: "{{ state }}"
+      definition:
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: api-test
+          labels:
+            istio-injection: enabled
+
+  - name: "{{ 'Create' if state == 'present' else 'Delete' }} test deployment"
+    k8s:
+      state: "{{ state }}"
+      definition:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: api-test-app
+          namespace: api-test
+          labels:
+            app: api-test-app
+            version: v1
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: api-test-app
+          template:
+            metadata:
+              labels:
+                app: api-test-app
+                version: v1
+            spec:
+              containers:
+              - name: nginx
+                image: nginxinc/nginx-unprivileged:stable
+                ports:
+                - containerPort: 8080
+    when: state == 'present'
+
+  - name: "{{ 'Create' if state == 'present' else 'Delete' }} test service"
+    k8s:
+      state: "{{ state }}"
+      definition:
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: api-test-app
+          namespace: api-test
+          labels:
+            app: api-test-app
+        spec:
+          selector:
+            app: api-test-app
+          ports:
+          - port: 80
+            targetPort: 8080
+    when: state == 'present'
+
+  - name: "{{ 'Create' if state == 'present' else 'Delete' }} test VirtualService"
+    k8s:
+      state: "{{ state }}"
+      definition:
+        apiVersion: networking.istio.io/v1
+        kind: VirtualService
+        metadata:
+          name: api-test-app
+          namespace: api-test
+        spec:
+          hosts:
+          - api-test-app
+          http:
+          - route:
+            - destination:
+                host: api-test-app
+    when: state == 'present'

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -55,9 +55,21 @@ rules:
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
-  - gateway.networking.k8s.io
   - inference.networking.k8s.io
   resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gatewayclasses
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
   verbs:
   - get
   - list

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -10,7 +10,6 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
 {% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
   - pods/log
 {% endif %}
@@ -33,8 +32,7 @@ rules:
   - pods/portforward
   verbs:
   - create
-  - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -73,7 +71,5 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - watch
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -10,7 +10,6 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
 {% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
   - pods/log
 {% endif %}
@@ -34,8 +33,7 @@ rules:
   - pods/portforward
   verbs:
   - create
-  - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -60,7 +58,6 @@ rules:
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
-  - gateway.networking.k8s.io
   - inference.networking.k8s.io
   resources: ["*"]
   verbs:
@@ -70,6 +67,36 @@ rules:
   - create
   - delete
   - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - tcproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["authentication.k8s.io"]
   resources:
   - tokenreviews
@@ -79,7 +106,5 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - watch
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -55,9 +55,21 @@ rules:
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
-  - gateway.networking.k8s.io
   - inference.networking.k8s.io
   resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gatewayclasses
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  - tcproutes
+  - tlsroutes
   verbs:
   - get
   - list

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -10,7 +10,6 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
 {% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
   - pods/log
 {% endif %}
@@ -33,8 +32,7 @@ rules:
   - pods/portforward
   verbs:
   - create
-  - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -85,7 +83,5 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - watch
 {% endfor %}

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -10,7 +10,6 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
-  - endpoints
 {% if 'logs-tab' not in kiali_vars.kiali_feature_flags.disabled_features %}
   - pods/log
 {% endif %}
@@ -34,8 +33,7 @@ rules:
   - pods/portforward
   verbs:
   - create
-  - post
-- apiGroups: ["extensions", "apps"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -60,7 +58,6 @@ rules:
   - security.istio.io
   - extensions.istio.io
   - telemetry.istio.io
-  - gateway.networking.k8s.io
   - inference.networking.k8s.io
   resources: ["*"]
   verbs:
@@ -70,6 +67,36 @@ rules:
   - create
   - delete
   - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gateways
+  - grpcroutes
+  - httproutes
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - tcproutes
+  - tlsroutes
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+  - patch
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - gatewayclasses
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups: ["apps.openshift.io"]
   resources:
   - deploymentconfigs
@@ -92,7 +119,5 @@ rules:
   resources:
   - mutatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - watch
 {% endfor %}

--- a/roles/default/kiali-remove/tasks/resources-to-remove.yml
+++ b/roles/default/kiali-remove/tasks/resources-to-remove.yml
@@ -30,18 +30,6 @@ metadata:
   name: {{ kiali_vars_remove.deployment.instance_name }}
 ---
 apiVersion: v1
-kind: ReplicaSet
-metadata:
-  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
-  name: {{ kiali_vars_remove.deployment.instance_name }}
----
-apiVersion: v1
-kind: Pod
-metadata:
-  namespace: "{{ kiali_vars_remove.deployment.namespace }}"
-  name: {{ kiali_vars_remove.deployment.instance_name }}
----
-apiVersion: v1
 kind: Service
 metadata:
   namespace: "{{ kiali_vars_remove.deployment.namespace }}"


### PR DESCRIPTION
## Summary

- Remove unused, excessive, and legacy RBAC permissions from the OSSM CSV, upstream CSV, and Kiali role templates
- Remove legacy Istio API groups (`config.istio.io`, `authentication.istio.io`, `rbac.istio.io`) and deprecated `extensions` apiGroup
- Remove operator-sdk v0.x boilerplate (`services/finalizers`, `deployments/finalizers`, `servicemonitors`, `customresourcedefinitions`)
- Remove dead Pod/ReplicaSet cleanup code from `resources-to-remove.yml`
- Fix invalid `post` verb on `pods/portforward` and incorrect `list` verb on `selfsubjectaccessreviews`
- Reduce `mutatingwebhookconfigurations` to `list`-only
- Split Gateway API permissions by actual verb usage (GatewayClass read-only, TCPRoute/TLSRoute without create)
- Remove all OpenShift-specific API groups from the upstream CSV (non-OpenShift-only)
- Remove `endpoints` from both operator management and Kiali server escalation sections

## Test plan

- [x] Run molecule tests to verify operator reconciliation still works
- [x] Verify Kiali deploys and functions correctly on Kubernetes
- [x] Verify Kiali deploys and functions correctly on OpenShift (OSSM CSV)

fixes: https://github.com/kiali/kiali/issues/9836

Made with [Cursor](https://cursor.com)