### PR TITLE
[v2.27] Add FIPS-safe PQC key exchange groups to nginx TLS config

### DIFF
--- a/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -20,6 +20,8 @@ data:
         ssl_certificate_key /var/serving-cert/tls.key;
         # Only TLS client is the OCP Console backend, which supports TLS 1.3
         ssl_protocols       TLSv1.3;
+        # PQC hybrid + classical groups; ? prefix skips unavailable groups (e.g. on FIPS clusters)
+        ssl_ecdh_curve      ?X25519MLKEM768:?SecP256r1MLKEM768:?X25519:secp256r1:secp384r1;
 
         add_header oauth_token "$http_Authorization";
 

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-nginx.yaml
@@ -20,6 +20,8 @@ data:
         ssl_certificate_key /var/serving-cert/tls.key;
         # Only TLS client is the OCP Console backend, which supports TLS 1.3
         ssl_protocols       TLSv1.3;
+        # PQC hybrid + classical groups; ? prefix skips unavailable groups (e.g. on FIPS clusters)
+        ssl_ecdh_curve      ?X25519MLKEM768:?SecP256r1MLKEM768:?X25519:secp256r1:secp384r1;
 
         add_header oauth_token "$http_Authorization";
 


### PR DESCRIPTION
## Summary
- Backport to v2.27
- Restores `ssl_ecdh_curve` with OpenSSL 3.5's `?` (optional) prefix for ML-KEM hybrid and X25519 groups
- The `?` prefix makes groups optional: they are used when available (non-FIPS clusters with OpenSSL 3.5+) and silently skipped when unavailable (e.g. FIPS clusters where these algorithms are not yet approved)
- Non-FIPS clusters get PQC hybrid key exchange (X25519MLKEM768, SecP256r1MLKEM768)
- FIPS clusters gracefully fall back to secp256r1 and secp384r1
- Companion PR: https://github.com/kiali/openshift-servicemesh-plugin/pull/711

## Test plan
- [ ] Deploy OSSMC via the operator on a FIPS-enabled cluster (e.g. ARO) and verify nginx starts successfully
- [ ] Deploy OSSMC via the operator on a non-FIPS cluster and verify ML-KEM is negotiated
- [ ] Verify TLS 1.3 handshake completes on both cluster types


Made with [Cursor](https://cursor.com)