### PR TITLE
Test fix for K8s Gateway wizard Create button disabled after RBAC permission cleanup

### DIFF
--- a/molecule/api-test/api-endpoint-tests.yml
+++ b/molecule/api-test/api-endpoint-tests.yml
@@ -78,7 +78,7 @@
   - { name: "Workload details", path: "/api/namespaces/api-test/workloads/api-test-app" }
   - { name: "Service details", path: "/api/namespaces/api-test/services/api-test-app" }
   - { name: "App details", path: "/api/namespaces/api-test/apps/api-test-app" }
-  - { name: "Istio config details (VirtualService)", path: "/api/namespaces/api-test/istio/networking.istio.io/v1/virtualservices/api-test-app" }
+  - { name: "Istio config details (VirtualService)", path: "/api/namespaces/api-test/istio/networking.istio.io/v1/VirtualService/api-test-app" }
   - { name: "Service metrics", path: "/api/namespaces/api-test/services/api-test-app/metrics" }
   - { name: "Workload metrics", path: "/api/namespaces/api-test/workloads/api-test-app/metrics" }
   - { name: "App metrics", path: "/api/namespaces/api-test/apps/api-test-app/metrics" }

--- a/molecule/api-test/api-write-tests.yml
+++ b/molecule/api-test/api-write-tests.yml
@@ -115,7 +115,21 @@
   register: result
   failed_when: result.status >= 500
 
-# 8. Delete the K8s Gateway we just created
+# 8. Verify K8s Gateway detail page returns correct write permissions
+#    This exercises the single-object getPermissions() code path which uses
+#    SSAR with the plural resource name (not Kind).
+- name: "Write test: Verify K8s Gateway detail permissions"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/gateways/api-test-gw"
+    validate_certs: false
+  register: gw_detail
+  failed_when: >-
+    gw_detail.status >= 500 or
+    gw_detail.json.permissions.create != true or
+    gw_detail.json.permissions.update != true or
+    gw_detail.json.permissions.delete != true
+
+# 9. Delete the K8s Gateway we just created
 - name: "Write test: Delete K8s Gateway"
   uri:
     url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/gateways/api-test-gw"
@@ -124,8 +138,9 @@
   register: result
   failed_when: result.status >= 500
 
-# 9. Validate istio permissions endpoint reports correct K8s Gateway create permission
-- name: "Write test: Verify K8s Gateway create permission is granted"
+# 10. Validate istio permissions endpoint reports correct K8s Gateway create permission
+#     This exercises the bulk GetIstioConfigPermissions() code path.
+- name: "Write test: Verify K8s Gateway bulk create permission is granted"
   uri:
     url: "{{ kiali_base_url }}/api/istio/permissions?namespaces=api-test"
     validate_certs: false

--- a/molecule/api-test/api-write-tests.yml
+++ b/molecule/api-test/api-write-tests.yml
@@ -121,16 +121,21 @@
 
 # 8. Verify K8s Gateway detail page returns correct write permissions.
 #    Exercises the single-object getPermissions() code path.
-- name: "Write test: Verify K8s Gateway detail permissions"
+- name: "Write test: Get K8s Gateway detail"
   uri:
     url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/Gateway/api-test-gw"
     validate_certs: false
+    return_content: true
   register: gw_detail
-  failed_when: >-
-    gw_detail.status < 200 or gw_detail.status >= 300 or
-    gw_detail.json.permissions.create != True or
-    gw_detail.json.permissions.update != True or
-    gw_detail.json.permissions.delete != True
+  failed_when: gw_detail.status < 200 or gw_detail.status >= 300
+
+- name: "Write test: Verify K8s Gateway detail has write permissions"
+  assert:
+    that:
+    - gw_detail.json.permissions.create
+    - gw_detail.json.permissions.update
+    - gw_detail.json.permissions.delete
+    fail_msg: "K8s Gateway detail permissions are wrong: {{ gw_detail.json.permissions }}"
 
 # 9. Delete the K8s Gateway we just created
 - name: "Write test: Delete K8s Gateway"
@@ -150,4 +155,4 @@
   register: perms_result
   failed_when: >-
     perms_result.status < 200 or perms_result.status >= 300 or
-    perms_result.json['api-test']['gateway.networking.k8s.io/v1, Kind=Gateway'].create != True
+    not (perms_result.json['api-test']['gateway.networking.k8s.io/v1, Kind=Gateway'].create | bool)

--- a/molecule/api-test/api-write-tests.yml
+++ b/molecule/api-test/api-write-tests.yml
@@ -3,11 +3,15 @@
 # are only granted by role.yaml, not role-viewer.yaml.
 # All resources are created in the api-test namespace so they are cleaned
 # up by the destroy phase if the test fails mid-way.
+#
+# URL format: /api/namespaces/{ns}/istio/{group}/{version}/{Kind}[/{name}]
+# The {Kind} must be PascalCase Kubernetes Kind (e.g., DestinationRule, Gateway)
+# matching how the Kiali frontend constructs these URLs.
 
 # 1. Create a DestinationRule via Kiali API
 - name: "Write test: Create DestinationRule"
   uri:
-    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/destinationrules"
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/DestinationRule"
     method: POST
     body_format: json
     body:
@@ -25,12 +29,12 @@
     validate_certs: false
     status_code: [200, 201]
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
 # 2. Patch the existing VirtualService via Kiali API
 - name: "Write test: Patch VirtualService"
   uri:
-    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/virtualservices/api-test-app"
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/VirtualService/api-test-app"
     method: PATCH
     body_format: json
     body:
@@ -39,16 +43,16 @@
           api-test-write: patched
     validate_certs: false
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
 # 3. Delete the DestinationRule we just created
 - name: "Write test: Delete DestinationRule"
   uri:
-    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/destinationrules/api-test-dr"
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/networking.istio.io/v1/DestinationRule/api-test-dr"
     method: DELETE
     validate_certs: false
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
 # 4. Patch the workload via Kiali API
 - name: "Write test: Patch workload"
@@ -62,7 +66,7 @@
           api-test-write: patched
     validate_certs: false
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
 # 5. Patch the service via Kiali API
 - name: "Write test: Patch service"
@@ -76,7 +80,7 @@
           api-test-write: patched
     validate_certs: false
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
 # 6. Patch the namespace via Kiali API
 - name: "Write test: Patch namespace"
@@ -90,12 +94,12 @@
           api-test-write: patched
     validate_certs: false
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
 # 7. Create a K8s Gateway via Kiali API (exercises gateway.networking.k8s.io create permission)
 - name: "Write test: Create K8s Gateway"
   uri:
-    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/gateways"
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/Gateway"
     method: POST
     body_format: json
     body:
@@ -113,38 +117,37 @@
     validate_certs: false
     status_code: [200, 201]
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
-# 8. Verify K8s Gateway detail page returns correct write permissions
-#    This exercises the single-object getPermissions() code path which uses
-#    SSAR with the plural resource name (not Kind).
+# 8. Verify K8s Gateway detail page returns correct write permissions.
+#    Exercises the single-object getPermissions() code path.
 - name: "Write test: Verify K8s Gateway detail permissions"
   uri:
-    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/gateways/api-test-gw"
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/Gateway/api-test-gw"
     validate_certs: false
   register: gw_detail
   failed_when: >-
-    gw_detail.status >= 500 or
-    gw_detail.json.permissions.create != true or
-    gw_detail.json.permissions.update != true or
-    gw_detail.json.permissions.delete != true
+    gw_detail.status < 200 or gw_detail.status >= 300 or
+    gw_detail.json.permissions.create != True or
+    gw_detail.json.permissions.update != True or
+    gw_detail.json.permissions.delete != True
 
 # 9. Delete the K8s Gateway we just created
 - name: "Write test: Delete K8s Gateway"
   uri:
-    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/gateways/api-test-gw"
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/Gateway/api-test-gw"
     method: DELETE
     validate_certs: false
   register: result
-  failed_when: result.status >= 500
+  failed_when: result.status < 200 or result.status >= 300
 
-# 10. Validate istio permissions endpoint reports correct K8s Gateway create permission
-#     This exercises the bulk GetIstioConfigPermissions() code path.
+# 10. Validate istio permissions endpoint reports correct K8s Gateway create permission.
+#     Exercises the bulk GetIstioConfigPermissions() code path.
 - name: "Write test: Verify K8s Gateway bulk create permission is granted"
   uri:
     url: "{{ kiali_base_url }}/api/istio/permissions?namespaces=api-test"
     validate_certs: false
   register: perms_result
   failed_when: >-
-    perms_result.status >= 500 or
-    perms_result.json['api-test']['gateway.networking.k8s.io/v1, Kind=Gateway'].create != true
+    perms_result.status < 200 or perms_result.status >= 300 or
+    perms_result.json['api-test']['gateway.networking.k8s.io/v1, Kind=Gateway'].create != True

--- a/molecule/api-test/api-write-tests.yml
+++ b/molecule/api-test/api-write-tests.yml
@@ -91,3 +91,45 @@
     validate_certs: false
   register: result
   failed_when: result.status >= 500
+
+# 7. Create a K8s Gateway via Kiali API (exercises gateway.networking.k8s.io create permission)
+- name: "Write test: Create K8s Gateway"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/gateways"
+    method: POST
+    body_format: json
+    body:
+      apiVersion: gateway.networking.k8s.io/v1
+      kind: Gateway
+      metadata:
+        name: api-test-gw
+        namespace: api-test
+      spec:
+        gatewayClassName: istio
+        listeners:
+        - name: http
+          port: 80
+          protocol: HTTP
+    validate_certs: false
+    status_code: [200, 201]
+  register: result
+  failed_when: result.status >= 500
+
+# 8. Delete the K8s Gateway we just created
+- name: "Write test: Delete K8s Gateway"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces/api-test/istio/gateway.networking.k8s.io/v1/gateways/api-test-gw"
+    method: DELETE
+    validate_certs: false
+  register: result
+  failed_when: result.status >= 500
+
+# 9. Validate istio permissions endpoint reports correct K8s Gateway create permission
+- name: "Write test: Verify K8s Gateway create permission is granted"
+  uri:
+    url: "{{ kiali_base_url }}/api/istio/permissions?namespaces=api-test"
+    validate_certs: false
+  register: perms_result
+  failed_when: >-
+    perms_result.status >= 500 or
+    perms_result.json['api-test']['gateway.networking.k8s.io/v1, Kind=Gateway'].create != true

--- a/molecule/api-test/converge.yml
+++ b/molecule/api-test/converge.yml
@@ -66,6 +66,6 @@
     debug:
       msg: |
         API endpoint test completed:
-        - Pass 1 (view_only_mode=false): ~45 read endpoints + ~9 write endpoints passed (role.yaml)
-        - Pass 2 (view_only_mode=true): ~45 read endpoints passed (role-viewer.yaml)
+        - Pass 1 (view_only_mode=false): read and write endpoint tests passed (role.yaml)
+        - Pass 2 (view_only_mode=true): read-only endpoint tests passed (role-viewer.yaml)
         - No 5xx errors detected — RBAC permissions are sufficient for both roles

--- a/molecule/api-test/converge.yml
+++ b/molecule/api-test/converge.yml
@@ -66,6 +66,6 @@
     debug:
       msg: |
         API endpoint test completed:
-        - Pass 1 (view_only_mode=false): ~45 read endpoints + ~6 write endpoints passed (role.yaml)
+        - Pass 1 (view_only_mode=false): ~45 read endpoints + ~9 write endpoints passed (role.yaml)
         - Pass 2 (view_only_mode=true): ~45 read endpoints passed (role-viewer.yaml)
         - No 5xx errors detected — RBAC permissions are sufficient for both roles


### PR DESCRIPTION
test for https://github.com/kiali/kiali/pull/9881

part of: https://github.com/kiali/kiali/issues/9880

Generated-by: Cursor