### PR TITLE
Fix permissions for bump_version reusable workflow call

### DIFF
--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -50,6 +50,8 @@ jobs:
         fi
 
   bump_version:
+    permissions:
+      contents: write
     name: Bump to Next Version
     needs: [release_tag]
     uses: ./.github/workflows/bump-release-version.yml


### PR DESCRIPTION
## Summary
- The `bump_version` job in `tag-release-creator.yml` calls the reusable workflow `bump-release-version.yml`, which needs `contents: write` to push commits and tags.
- Without explicit permissions on the calling job, it inherits the workflow-level `permissions: read-all`, causing GitHub to reject the nested job's write request with: *"The nested job 'bump_version' is requesting 'contents: write', but is only allowed 'contents: read'"*.
- Added `permissions: contents: write` to the `bump_version` calling job, matching what the `release_tag` job already has.

Same fix as https://github.com/kiali/kiali/pull/9894.

## Test plan
- [ ] Verify the workflow file passes GitHub Actions validation
- [ ] Run the `Release Tag Creator` workflow on a test branch

Made with [Cursor](https://cursor.com)