### PR TITLE
Use KIALI_BOT_TOKEN for release workflow push to protected branches

### DIFF
--- a/.github/workflows/bump-release-version.yml
+++ b/.github/workflows/bump-release-version.yml
@@ -16,8 +16,6 @@ on:
         default: v2.22
         type: string
 
-permissions: read-all
-
 jobs:
   bump_version:
     permissions:
@@ -28,6 +26,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.tag_branch }}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
 
     - name: Prepare scripts
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.inputs.release_branch || github.ref_name }}
+        token: ${{ secrets.KIALI_BOT_TOKEN }}
 
     - name: Set version to release
       run: sed -i -r "s/^VERSION \?= (.*)/VERSION \?= $RELEASE_VERSION/" Makefile

--- a/.github/workflows/tag-release-creator.yml
+++ b/.github/workflows/tag-release-creator.yml
@@ -57,3 +57,4 @@ jobs:
     uses: ./.github/workflows/bump-release-version.yml
     with:
       tag_branch: ${{ inputs.tag_branch }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Follow-up to #1063. The previous fix resolved the permissions: read-all conflict, but the workflow still fails because GITHUB_TOKEN cannot push to protected release branches.
- Use KIALI_BOT_TOKEN in the checkout step of bump-release-version.yml so git push authenticates as kiali-bot, which has bypass permissions on protected branches.
- Pass secrets to the reusable workflow via secrets: inherit in tag-release-creator.yml.

Same fix as https://github.com/kiali/kiali/pull/9899.

## Test plan
- [ ] Trigger the Release Tag Creator workflow and verify bump_version can push to a protected branch