### PR TITLE
Fix release schedule base date to align with Sunday cron schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,8 @@ jobs:
         cat <<-EOF > minor.py
         import datetime
 
-        # The base date is set so that releases occur every 3 weeks starting from January 26, 2026
-        base = int(datetime.datetime.strptime("26/01/2026", "%d/%m/%Y").timestamp())
+        # The base date is set so that releases occur every 3 weeks starting from January 25, 2026
+        base = int(datetime.datetime.strptime("25/01/2026", "%d/%m/%Y").timestamp())
         now = int(datetime.datetime.now().timestamp())
 
         diff = now - base


### PR DESCRIPTION
## Summary
- Fix the release schedule base date from January 26, 2026 (Monday) to January 25, 2026 (Sunday) to match the kiali/kiali repo and align with the Sunday cron schedule (`14 7 * * SUN`).
- The misaligned base date caused the 3-week release cycle (`weeks_elapsed % 3 == 0`) to evaluate on different weeks than the kiali repo, resulting in an unintended release.

## Test plan
- Verify the base date matches the one in [kiali/kiali release.yml](https://github.com/kiali/kiali/blob/master/.github/workflows/release.yml).

Made with [Cursor](https://cursor.com)