### PR TITLE
[CI] Fix race condition in set_kiali_cr task

### DIFF
--- a/molecule/common/set_kiali_cr.yml
+++ b/molecule/common/set_kiali_cr.yml
@@ -2,3 +2,7 @@
   k8s:
     namespace: '{{ cr_namespace }}'
     definition: "{{ new_kiali_cr }}"
+  retries: 10
+  delay: 5
+  register: kiali_cr_patch_result
+  until: kiali_cr_patch_result is succeeded


### PR DESCRIPTION
Add retry logic with 10 retries and 5 second delay to handle resource conflict errors (HTTP 409) when patching Kiali CR.

The operator can modify the CR between read and update operations, causing 'the object has been modified' errors. This retry mechanism resolves the race condition.

Fixes os-console-links-test intermittent failures.