### PR TITLE
Increase retry count for set_kiali_cr to handle longer reconciliation

### DIFF
--- a/molecule/common/set_kiali_cr.yml
+++ b/molecule/common/set_kiali_cr.yml
@@ -2,7 +2,7 @@
   k8s:
     namespace: '{{ cr_namespace }}'
     definition: "{{ new_kiali_cr }}"
-  retries: 10
+  retries: 60
   delay: 5
   register: kiali_cr_patch_result
   until: kiali_cr_patch_result is succeeded


### PR DESCRIPTION
The existing retry logic (10 retries × 5s = 50s) was insufficient when the operator's reconciliation takes longer, causing os-console-links-test to fail with 409 Conflict errors.

This commit increases retries from 10 to 60 (5 minutes total) to allow enough time for the operator to complete reconciliation before the patch succeeds.

Fixes: 409 Conflict error 'Operation cannot be fulfilled on kialis.kiali.io'