### PR TITLE
Add udproutes RBAC for Gateway API 1.6 UDPRoute support

### DIFF
--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -683,6 +683,7 @@ spec:
           resources:
           - tcproutes
           - tlsroutes
+          - udproutes
           verbs:
           - get
           - list

--- a/manifests/kiali-upstream/2.29.0/manifests/kiali.v2.29.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.29.0/manifests/kiali.v2.29.0.clusterserviceversion.yaml
@@ -492,6 +492,7 @@ spec:
           resources:
           - tcproutes
           - tlsroutes
+          - udproutes
           verbs:
           - get
           - list

--- a/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role-viewer.yaml
@@ -70,6 +70,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list

--- a/roles/default/kiali-deploy/templates/kubernetes/role.yaml
+++ b/roles/default/kiali-deploy/templates/kubernetes/role.yaml
@@ -84,6 +84,7 @@ rules:
   resources:
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list

--- a/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role-viewer.yaml
@@ -70,6 +70,7 @@ rules:
   - referencegrants
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list

--- a/roles/default/kiali-deploy/templates/openshift/role.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/role.yaml
@@ -84,6 +84,7 @@ rules:
   resources:
   - tcproutes
   - tlsroutes
+  - udproutes
   verbs:
   - get
   - list


### PR DESCRIPTION
## Summary
- Add `udproutes` to Kiali server Kubernetes and OpenShift role templates (viewer and editor roles) alongside existing `tcproutes` and `tlsroutes` permissions.

## Why
Kiali #9859 adds Gateway API v1.6 `UDPRoute` support. When Gateway API 1.6 CRDs are installed, Kiali must be able to list/watch `udproutes` or listing Istio config can hang waiting on cache sync.

## Test plan
- [ ] Deploy Kiali via operator with a cluster that has Gateway API 1.6 CRDs
- [ ] Verify the Kiali service account can list `udproutes` in accessible namespaces
- [ ] Confirm MCP `manage_istio_config_read` list responds promptly

## Issue reference
Ref kiali/kiali#9859

Core PR https://github.com/kiali/kiali/pull/10018

Made with [Cursor](https://cursor.com)