### PR TITLE
Strip resourceVersion from set_kiali_cr to fix 409 Conflict race

### DIFF
--- a/molecule/common/set_kiali_cr.yml
+++ b/molecule/common/set_kiali_cr.yml
@@ -1,8 +1,13 @@
+# Callers build new_kiali_cr from a previously-read CR that includes a stale
+# metadata.resourceVersion. Stripping it lets the patch apply unconditionally
+# instead of racing with the operator reconciler (409 Conflict).
 - name: Change Kiali CR with new Kiali CR
+  vars:
+    cr_metadata_clean: "{{ new_kiali_cr.metadata | dict2items | rejectattr('key', 'equalto', 'resourceVersion') | list | items2dict }}"
   k8s:
     namespace: '{{ cr_namespace }}'
-    definition: "{{ new_kiali_cr }}"
-  retries: 60
+    definition: "{{ new_kiali_cr | combine({'metadata': cr_metadata_clean}) }}"
+  retries: 10
   delay: 5
   register: kiali_cr_patch_result
   until: kiali_cr_patch_result is succeeded


### PR DESCRIPTION
## Summary

- Strip `metadata.resourceVersion` from `new_kiali_cr` before patching in `molecule/common/set_kiali_cr.yml`
- Prevents 409 Conflict when the operator reconciler modifies the CR between read and patch
- Reduces retries from 60 to 10 (409 was the sole reason for high retry count)

## Root cause

Callers build `new_kiali_cr` via `kiali_cr | combine(...)` where `kiali_cr` was read earlier and carries a stale `resourceVersion`. The `k8s` module sends this version on every retry attempt, and Kubernetes rejects all of them with 409 because the operator's reconciler continuously advances the version.

Prior fix attempts (PR #1073, #1075) added retries but didn't address the core issue — retrying the same stale version can never succeed while the reconciler is active.

## Fix

Strip `resourceVersion` from metadata before patching. Without it, Kubernetes applies the patch unconditionally (no optimistic locking). This is safe for test automation where the test owns the desired spec state.

Fixes https://github.com/kiali/kiali/issues/10030

## Test plan

- [ ] Verify `external-auth-rotation-test` passes on Jenkins nightly
- [ ] Verify `os-console-links-test` passes on Jenkins nightly
- [ ] Confirm no regressions in other molecule tests that use `set_kiali_cr.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)