### PR TITLE
Add opt-in OpenShift impersonation mode for multi-cluster auth

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -42,6 +42,8 @@ spec:
         userinfo_endpoint: ""
     openshift:
       impersonation:
+        allowed_groups: []
+        allowed_users: []
         enabled: false
       #redirect_uris:
       #token_inactivity_timeout:

--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -41,6 +41,8 @@ spec:
         token_endpoint: ""
         userinfo_endpoint: ""
     openshift:
+      impersonation:
+        enabled: false
       #redirect_uris:
       #token_inactivity_timeout:
       #token_max_age:

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -211,6 +211,16 @@ spec:
                         description: "Settings for Kubernetes API impersonation. When enabled, users authenticate once to the home cluster and Kiali uses its service account to impersonate the user on all clusters (including home)."
                         type: object
                         properties:
+                          allowed_groups:
+                            description: "When set, only these groups will be included in impersonation headers (in addition to system:authenticated and system:authenticated:oauth which are always included). If empty, all of the user's groups are impersonated. This also restricts the Kiali SA's ClusterRole via resourceNames. Must not contain system: prefixed groups. For full RBAC defense-in-depth, configure both allowed_users and allowed_groups."
+                            type: array
+                            items:
+                              type: string
+                          allowed_users:
+                            description: "When set, only users in this list are permitted to use Kiali with impersonation. Users not in this list will be denied access (HTTP 403). This also restricts the Kiali SA's ClusterRole via resourceNames, limiting which identities the SA can impersonate even at the Kubernetes RBAC level. Must not contain system: prefixed identities. For full RBAC defense-in-depth, configure both allowed_users and allowed_groups."
+                            type: array
+                            items:
+                              type: string
                           enabled:
                             description: "When true, Kiali will use Kubernetes API impersonation for accessing all clusters instead of requiring per-cluster OAuth login. The user logs in once to the home cluster, and Kiali uses its service account credentials with impersonation headers carrying the user's identity. Requires the Kiali service account on each cluster to have ClusterRole permissions to impersonate users and groups. SECURITY NOTE: Enabling this grants the Kiali service account the ability to impersonate any user. Protect the service account token accordingly."
                             type: boolean

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -207,6 +207,14 @@ spec:
                       client_id_prefix:
                         description: "DEPRECATED AFTER v1.73: A prefix that will be applied to the OpenShift OAuth client identifier."
                         type: string
+                      impersonation:
+                        description: "Settings for Kubernetes API impersonation. When enabled, users authenticate once to the home cluster and Kiali uses its service account to impersonate the user on all clusters (including home)."
+                        type: object
+                        properties:
+                          enabled:
+                            description: "When true, Kiali will use Kubernetes API impersonation for accessing all clusters instead of requiring per-cluster OAuth login. The user logs in once to the home cluster, and Kiali uses its service account credentials with impersonation headers carrying the user's identity. Requires the Kiali service account on each cluster to have ClusterRole permissions to impersonate users and groups. SECURITY NOTE: Enabling this grants the Kiali service account the ability to impersonate any user. Protect the service account token accordingly."
+                            type: boolean
+                            default: false
                       insecure_skip_verify_tls:
                         description: "Set true to skip verifying certificate validity when Kiali contacts OpenShift over https."
                         type: boolean

--- a/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.clusterserviceversion.yaml
@@ -720,6 +720,12 @@ spec:
           - tokenreviews
           verbs:
           - create
+        - apiGroups: [""]
+          resources:
+          - groups
+          - users
+          verbs:
+          - impersonate
         - apiGroups: ["admissionregistration.k8s.io"]
           resources:
           - mutatingwebhookconfigurations

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -211,6 +211,16 @@ spec:
                         description: "Settings for Kubernetes API impersonation. When enabled, users authenticate once to the home cluster and Kiali uses its service account to impersonate the user on all clusters (including home)."
                         type: object
                         properties:
+                          allowed_groups:
+                            description: "When set, only these groups will be included in impersonation headers (in addition to system:authenticated and system:authenticated:oauth which are always included). If empty, all of the user's groups are impersonated. This also restricts the Kiali SA's ClusterRole via resourceNames. Must not contain system: prefixed groups. For full RBAC defense-in-depth, configure both allowed_users and allowed_groups."
+                            type: array
+                            items:
+                              type: string
+                          allowed_users:
+                            description: "When set, only users in this list are permitted to use Kiali with impersonation. Users not in this list will be denied access (HTTP 403). This also restricts the Kiali SA's ClusterRole via resourceNames, limiting which identities the SA can impersonate even at the Kubernetes RBAC level. Must not contain system: prefixed identities. For full RBAC defense-in-depth, configure both allowed_users and allowed_groups."
+                            type: array
+                            items:
+                              type: string
                           enabled:
                             description: "When true, Kiali will use Kubernetes API impersonation for accessing all clusters instead of requiring per-cluster OAuth login. The user logs in once to the home cluster, and Kiali uses its service account credentials with impersonation headers carrying the user's identity. Requires the Kiali service account on each cluster to have ClusterRole permissions to impersonate users and groups. SECURITY NOTE: Enabling this grants the Kiali service account the ability to impersonate any user. Protect the service account token accordingly."
                             type: boolean

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -207,6 +207,14 @@ spec:
                       client_id_prefix:
                         description: "DEPRECATED AFTER v1.73: A prefix that will be applied to the OpenShift OAuth client identifier."
                         type: string
+                      impersonation:
+                        description: "Settings for Kubernetes API impersonation. When enabled, users authenticate once to the home cluster and Kiali uses its service account to impersonate the user on all clusters (including home)."
+                        type: object
+                        properties:
+                          enabled:
+                            description: "When true, Kiali will use Kubernetes API impersonation for accessing all clusters instead of requiring per-cluster OAuth login. The user logs in once to the home cluster, and Kiali uses its service account credentials with impersonation headers carrying the user's identity. Requires the Kiali service account on each cluster to have ClusterRole permissions to impersonate users and groups. SECURITY NOTE: Enabling this grants the Kiali service account the ability to impersonate any user. Protect the service account token accordingly."
+                            type: boolean
+                            default: false
                       insecure_skip_verify_tls:
                         description: "Set true to skip verifying certificate validity when Kiali contacts OpenShift over https."
                         type: boolean

--- a/manifests/kiali-upstream/2.30.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.30.0/manifests/kiali.crd.yaml
@@ -211,6 +211,16 @@ spec:
                         description: "Settings for Kubernetes API impersonation. When enabled, users authenticate once to the home cluster and Kiali uses its service account to impersonate the user on all clusters (including home)."
                         type: object
                         properties:
+                          allowed_groups:
+                            description: "When set, only these groups will be included in impersonation headers (in addition to system:authenticated and system:authenticated:oauth which are always included). If empty, all of the user's groups are impersonated. This also restricts the Kiali SA's ClusterRole via resourceNames. Must not contain system: prefixed groups. For full RBAC defense-in-depth, configure both allowed_users and allowed_groups."
+                            type: array
+                            items:
+                              type: string
+                          allowed_users:
+                            description: "When set, only users in this list are permitted to use Kiali with impersonation. Users not in this list will be denied access (HTTP 403). This also restricts the Kiali SA's ClusterRole via resourceNames, limiting which identities the SA can impersonate even at the Kubernetes RBAC level. Must not contain system: prefixed identities. For full RBAC defense-in-depth, configure both allowed_users and allowed_groups."
+                            type: array
+                            items:
+                              type: string
                           enabled:
                             description: "When true, Kiali will use Kubernetes API impersonation for accessing all clusters instead of requiring per-cluster OAuth login. The user logs in once to the home cluster, and Kiali uses its service account credentials with impersonation headers carrying the user's identity. Requires the Kiali service account on each cluster to have ClusterRole permissions to impersonate users and groups. SECURITY NOTE: Enabling this grants the Kiali service account the ability to impersonate any user. Protect the service account token accordingly."
                             type: boolean

--- a/manifests/kiali-upstream/2.30.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.30.0/manifests/kiali.crd.yaml
@@ -207,6 +207,14 @@ spec:
                       client_id_prefix:
                         description: "DEPRECATED AFTER v1.73: A prefix that will be applied to the OpenShift OAuth client identifier."
                         type: string
+                      impersonation:
+                        description: "Settings for Kubernetes API impersonation. When enabled, users authenticate once to the home cluster and Kiali uses its service account to impersonate the user on all clusters (including home)."
+                        type: object
+                        properties:
+                          enabled:
+                            description: "When true, Kiali will use Kubernetes API impersonation for accessing all clusters instead of requiring per-cluster OAuth login. The user logs in once to the home cluster, and Kiali uses its service account credentials with impersonation headers carrying the user's identity. Requires the Kiali service account on each cluster to have ClusterRole permissions to impersonate users and groups. SECURITY NOTE: Enabling this grants the Kiali service account the ability to impersonate any user. Protect the service account token accordingly."
+                            type: boolean
+                            default: false
                       insecure_skip_verify_tls:
                         description: "Set true to skip verifying certificate validity when Kiali contacts OpenShift over https."
                         type: boolean

--- a/manifests/kiali-upstream/2.30.0/manifests/kiali.v2.30.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.30.0/manifests/kiali.v2.30.0.clusterserviceversion.yaml
@@ -511,6 +511,12 @@ spec:
           - tokenreviews
           verbs:
           - create
+        - apiGroups: [""]
+          resources:
+          - groups
+          - users
+          verbs:
+          - impersonate
         - apiGroups: ["admissionregistration.k8s.io"]
           resources:
           - mutatingwebhookconfigurations

--- a/manifests/kiali-upstream/2.30.0/manifests/kiali.v2.30.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.30.0/manifests/kiali.v2.30.0.clusterserviceversion.yaml
@@ -511,12 +511,6 @@ spec:
           - tokenreviews
           verbs:
           - create
-        - apiGroups: [""]
-          resources:
-          - groups
-          - users
-          verbs:
-          - impersonate
         - apiGroups: ["admissionregistration.k8s.io"]
           resources:
           - mutatingwebhookconfigurations

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -27,6 +27,9 @@ spec:
         jwks_uri: ""
         token_endpoint: ""
         userinfo_endpoint: ""
+    openshift:
+      impersonation:
+        enabled: false
     strategy: "anonymous"
 
   chat_ai:

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -29,6 +29,8 @@ spec:
         userinfo_endpoint: ""
     openshift:
       impersonation:
+        allowed_groups: []
+        allowed_users: []
         enabled: false
     strategy: "anonymous"
 

--- a/molecule/remote-cluster-resources-test/converge.yml
+++ b/molecule/remote-cluster-resources-test/converge.yml
@@ -287,6 +287,105 @@
       - oauthclient.redirectURIs[0] == 'http://one-redirect-uri'
       - oauthclient.redirectURIs[1] == 'http://two-redirect-uri'
 
+  # IMPERSONATION TESTS
+  # At this point: remote_cluster_resources_only=true, auth.strategy=openshift, redirect_uris are set, OAuthClient exists.
+  # Enable impersonation and verify: OAuthClient is removed by the operator, impersonate ClusterRole rule is added.
+  # Note: redirect_uris remain set from the prior step — this verifies that stale redirect_uris
+  # don't cause OAuthClient creation when impersonation is enabled.
+
+  - debug: msg="Enable impersonation - OAuthClient should be removed and impersonate ClusterRole rule should be added"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'openshift': {'impersonation': {'enabled': true }}}}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  - name: "Impersonation enabled: make sure we only have the resources that are expected (no OAuthClient)"
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 0
+
+  - name: "Impersonation enabled: verify ConfigMap has impersonation.enabled set to true"
+    assert:
+      that:
+      - kiali_configmap.auth.openshift.impersonation.enabled == True
+
+  - name: "Impersonation enabled: get the OpenShift ClusterRole"
+    vars:
+      instance_name: "{{ kiali.instance_name | default('kiali') }}"
+    k8s_info:
+      api_version: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      name: "{{ instance_name }}-{{ kiali.install_namespace }}-openshift"
+    register: openshift_clusterrole_result
+
+  - name: "Impersonation enabled: verify OpenShift ClusterRole exists"
+    assert:
+      that:
+      - openshift_clusterrole_result.resources | length == 1
+
+  - name: "Impersonation enabled: verify OpenShift ClusterRole contains impersonate rule for users and groups"
+    vars:
+      impersonate_rules: "{{ openshift_clusterrole_result.resources[0].rules | selectattr('verbs', 'contains', 'impersonate') | list }}"
+    assert:
+      that:
+      - impersonate_rules | length > 0
+      - "'users' in (impersonate_rules | map(attribute='resources') | flatten)"
+      - "'groups' in (impersonate_rules | map(attribute='resources') | flatten)"
+
+  # Now disable impersonation and add redirect_uris so OAuthClient is created.
+  - debug: msg="Disable impersonation with redirect_uris - OAuthClient should be created, impersonate ClusterRole rule should be removed"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'openshift': {'impersonation': {'enabled': false }, 'redirect_uris': ['http://one-redirect-uri'] }}}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  - name: "Impersonation disabled: make sure we only have the resources that are expected (OAuthClient is back)"
+    assert:
+      that:
+      - query('k8s', kind='ConfigMap',      namespace=queryNamespace, api_version=apiCMap, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Deployment',     namespace=queryNamespace, api_version=apiDepl, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Pod',            namespace=queryNamespace, api_version=apiPod,  label_selector=querySelector) | length == 0
+      - query('k8s', kind='Secret',         namespace=queryNamespace, api_version=apiSecr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Service',        namespace=queryNamespace, api_version=apiServ, label_selector=querySelector) | length == 0
+      - query('k8s', kind='ServiceAccount', namespace=queryNamespace, api_version=apiSvcA, label_selector=querySelector) | length == 1
+      - query('k8s', kind='Ingress',        namespace=queryNamespace, api_version=apiIngr, label_selector=querySelector) | length == 0
+      - query('k8s', kind='Route',          namespace=queryNamespace, api_version=apiRout, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='ConsoleLink',                              api_version=apiCoLn, label_selector=querySelector, errors='warn') | length == 0
+      - query('k8s', kind='OAuthClient',                              api_version=apiOAut, label_selector=querySelector, errors='warn') | length == 1
+
+  - name: "Impersonation disabled: verify ConfigMap has impersonation.enabled set to false"
+    assert:
+      that:
+      - kiali_configmap.auth.openshift.impersonation.enabled == False
+
+  - name: "Impersonation disabled: get the OpenShift ClusterRole"
+    vars:
+      instance_name: "{{ kiali.instance_name | default('kiali') }}"
+    k8s_info:
+      api_version: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      name: "{{ instance_name }}-{{ kiali.install_namespace }}-openshift"
+    register: openshift_clusterrole_result
+
+  - name: "Impersonation disabled: verify OpenShift ClusterRole exists but does NOT contain impersonate rule"
+    vars:
+      impersonate_rules: "{{ openshift_clusterrole_result.resources[0].rules | selectattr('verbs', 'contains', 'impersonate') | list }}"
+    assert:
+      that:
+      - openshift_clusterrole_result.resources | length == 1
+      - impersonate_rules | length == 0
+
   - debug: msg="Change auth strategy back to anonymous to see OAuthClient resource gets removed"
   - include_tasks: ../common/set_kiali_cr.yml
     vars:

--- a/molecule/remote-cluster-resources-test/converge.yml
+++ b/molecule/remote-cluster-resources-test/converge.yml
@@ -342,6 +342,90 @@
       - "'users' in (impersonate_rules | map(attribute='resources') | flatten)"
       - "'groups' in (impersonate_rules | map(attribute='resources') | flatten)"
 
+  # ALLOWLIST TESTS
+  # At this point: impersonation is enabled, no allowlists set, ClusterRole has impersonate without resourceNames.
+
+  - debug: msg="Set allowed_users and allowed_groups - verify resourceNames appear in ClusterRole and ConfigMap"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'openshift': {'impersonation': {'enabled': true, 'allowed_users': ['alice@example.com', 'bob@example.com'], 'allowed_groups': ['developers', 'sre-team'] }}}}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  - name: "Allowlists set: verify ConfigMap contains allowed_users"
+    assert:
+      that:
+      - kiali_configmap.auth.openshift.impersonation.allowed_users is defined
+      - kiali_configmap.auth.openshift.impersonation.allowed_users | length == 2
+      - "'alice@example.com' in kiali_configmap.auth.openshift.impersonation.allowed_users"
+      - "'bob@example.com' in kiali_configmap.auth.openshift.impersonation.allowed_users"
+
+  - name: "Allowlists set: verify ConfigMap contains allowed_groups"
+    assert:
+      that:
+      - kiali_configmap.auth.openshift.impersonation.allowed_groups is defined
+      - kiali_configmap.auth.openshift.impersonation.allowed_groups | length == 2
+      - "'developers' in kiali_configmap.auth.openshift.impersonation.allowed_groups"
+      - "'sre-team' in kiali_configmap.auth.openshift.impersonation.allowed_groups"
+
+  - name: "Allowlists set: get the OpenShift ClusterRole"
+    vars:
+      instance_name: "{{ kiali.instance_name | default('kiali') }}"
+    k8s_info:
+      api_version: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      name: "{{ instance_name }}-{{ kiali.install_namespace }}-openshift"
+    register: openshift_clusterrole_result
+
+  - name: "Allowlists set: verify users impersonate rule has resourceNames"
+    vars:
+      users_rules: "{{ openshift_clusterrole_result.resources[0].rules | selectattr('verbs', 'contains', 'impersonate') | selectattr('resources', 'contains', 'users') | list }}"
+    assert:
+      that:
+      - users_rules | length == 1
+      - users_rules[0].resourceNames is defined
+      - users_rules[0].resourceNames | length == 2
+      - "'alice@example.com' in users_rules[0].resourceNames"
+      - "'bob@example.com' in users_rules[0].resourceNames"
+
+  - name: "Allowlists set: verify groups impersonate rule has resourceNames including system groups"
+    vars:
+      groups_rules: "{{ openshift_clusterrole_result.resources[0].rules | selectattr('verbs', 'contains', 'impersonate') | selectattr('resources', 'contains', 'groups') | list }}"
+    assert:
+      that:
+      - groups_rules | length == 1
+      - groups_rules[0].resourceNames is defined
+      - groups_rules[0].resourceNames | length == 4
+      - "'system:authenticated' in groups_rules[0].resourceNames"
+      - "'system:authenticated:oauth' in groups_rules[0].resourceNames"
+      - "'developers' in groups_rules[0].resourceNames"
+      - "'sre-team' in groups_rules[0].resourceNames"
+
+  - debug: msg="Remove allowlists - verify resourceNames disappear from ClusterRole"
+  - include_tasks: ../common/set_kiali_cr.yml
+    vars:
+      new_kiali_cr: "{{ kiali_cr_list.resources[0] | combine({'spec': {'auth': {'openshift': {'impersonation': {'enabled': true, 'allowed_users': [], 'allowed_groups': [] }}}}}, recursive=True) }}"
+  - include_tasks: ../common/wait_for_kiali_cr_changes.yml
+  - include_tasks: ../common/tasks.yml
+
+  - name: "Allowlists removed: get the OpenShift ClusterRole"
+    vars:
+      instance_name: "{{ kiali.instance_name | default('kiali') }}"
+    k8s_info:
+      api_version: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      name: "{{ instance_name }}-{{ kiali.install_namespace }}-openshift"
+    register: openshift_clusterrole_result
+
+  - name: "Allowlists removed: verify impersonate rules have NO resourceNames"
+    vars:
+      impersonate_rules: "{{ openshift_clusterrole_result.resources[0].rules | selectattr('verbs', 'contains', 'impersonate') | list }}"
+    assert:
+      that:
+      - impersonate_rules | length == 2
+      - impersonate_rules[0].resourceNames is not defined
+      - impersonate_rules[1].resourceNames is not defined
+
   # Now disable impersonation and add redirect_uris so OAuthClient is created.
   - debug: msg="Disable impersonation with redirect_uris - OAuthClient should be created, impersonate ClusterRole rule should be removed"
   - include_tasks: ../common/set_kiali_cr.yml

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -40,6 +40,8 @@ kiali_defaults:
         userinfo_endpoint: ""
     openshift:
       impersonation:
+        allowed_groups: []
+        allowed_users: []
         enabled: false
       insecure_skip_verify_tls: false
       #redirect_uris:

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -39,6 +39,8 @@ kiali_defaults:
         token_endpoint: ""
         userinfo_endpoint: ""
     openshift:
+      impersonation:
+        enabled: false
       insecure_skip_verify_tls: false
       #redirect_uris:
       #token_inactivity_timeout:

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -103,7 +103,7 @@
   when:
   - is_openshift == True
 
-- name: Delete OAuthClient on OpenShift if not using auth.strategy openshift
+- name: Delete OAuthClient on OpenShift if not needed
   k8s:
     state: absent
     api_version: "oauth.openshift.io/v1"
@@ -112,7 +112,7 @@
     - "app.kubernetes.io/instance = {{ kiali_vars.deployment.instance_name }}"
   when:
   - is_openshift == True
-  - kiali_vars.auth.strategy != "openshift"
+  - kiali_vars.auth.strategy != "openshift" or (kiali_vars.deployment.remote_cluster_resources_only|bool == True and kiali_vars.auth.openshift.impersonation.enabled|bool == True)
   # Ignore errors because OAuthClient API may not exist when OpenShift uses external OIDC authentication
   ignore_errors: true
 

--- a/roles/default/kiali-deploy/tasks/openshift/os-main.yml
+++ b/roles/default/kiali-deploy/tasks/openshift/os-main.yml
@@ -140,21 +140,22 @@
 
 # For now, when creating remote cluster resources only, we are going to assume there is no way for us to determine what the redirect URIs are
 # going to be other than having the user explicitly configure them. So fail immediately if the user did not tell us what redirect URI[s] to use.
-# Note that this only comes into play when auth.strategy is "openshift".
+# Note that this only comes into play when auth.strategy is "openshift" and impersonation is disabled.
 - name: Fail if creating remote cluster resources with auth strategy of openshift, but the Kiali redirect URIs are not defined
   fail:
     msg: "Redirect URIs for the Kiali Server OAuthClient are not specified via auth.openshift.redirect_uris; this is required when creating remote cluster resources with auth.strategy of openshift."
   when:
   - kiali_vars.deployment.remote_cluster_resources_only|bool == True
   - kiali_vars.auth.strategy == 'openshift'
+  - kiali_vars.auth.openshift.impersonation.enabled|bool == False
   - kiali_vars.auth.openshift.redirect_uris | default([]) | length == 0
 
 # We only need to auto-discover the Kiali route if (a) we know it will exist and (b) we know we need it.
 # We know it will exist if we are creating the Kiali Server itself (i.e. remote_cluster_resources_only == False).
 # We know we need it for ConsoleLinks (and those are only created when we are creating the Kiali Server itself).
 # We know we need it for OAuthClient, too. That is also created when we are creating the Kiali Server itself. But it is also
-# created when creating only remote cluster resources - however, in that case, we are going to require the user to tell us
-# what redirect URIs to use (see the above fail task to ensure the user does that).
+# created when creating only remote cluster resources (unless impersonation is enabled, which skips OAuthClient entirely) -
+# however, in that case, we are going to require the user to tell us what redirect URIs to use (see the above fail task).
 # All of this is to say: we only need to auto-discover the route when we are creating the Kiali Server itself (we do not
 # auto-discover the route when we are creating only the remote cluster resources).
 # We also don't expect the Route if it was disabled (which also disables other features like OAuthClient -- see https://github.com/kiali/kiali/issues/8023)
@@ -172,6 +173,7 @@
   - is_openshift == True
   - kiali_vars.deployment.ingress.enabled|bool == True
   - kiali_vars.auth.strategy == "openshift"
+  - kiali_vars.deployment.remote_cluster_resources_only|bool == False or kiali_vars.auth.openshift.impersonation.enabled|bool == False
 
 - name: Delete all ConsoleLinks for namespaces that are no longer accessible
   k8s:

--- a/roles/default/kiali-deploy/templates/openshift/clusterrole-openshift.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/clusterrole-openshift.yaml
@@ -14,6 +14,14 @@ rules:
   verbs:
   - get
 {% endif %}
+{% if kiali_vars.auth.openshift.impersonation.enabled | default(false) | bool %}
+- apiGroups: [""]
+  resources:
+  - groups
+  - users
+  verbs:
+  - impersonate
+{% endif %}
 {% if kiali_vars.deployment.tls_config.source == 'auto' %}
 # Permission to read OpenShift TLSSecurityProfile for tls_config.source=auto
 - apiGroups: ["config.openshift.io"]

--- a/roles/default/kiali-deploy/templates/openshift/clusterrole-openshift.yaml
+++ b/roles/default/kiali-deploy/templates/openshift/clusterrole-openshift.yaml
@@ -17,10 +17,28 @@ rules:
 {% if kiali_vars.auth.openshift.impersonation.enabled | default(false) | bool %}
 - apiGroups: [""]
   resources:
-  - groups
   - users
   verbs:
   - impersonate
+{% if kiali_vars.auth.openshift.impersonation.allowed_users | default([]) | length > 0 %}
+  resourceNames:
+{% for user in kiali_vars.auth.openshift.impersonation.allowed_users %}
+  - "{{ user }}"
+{% endfor %}
+{% endif %}
+- apiGroups: [""]
+  resources:
+  - groups
+  verbs:
+  - impersonate
+{% if kiali_vars.auth.openshift.impersonation.allowed_groups | default([]) | length > 0 %}
+  resourceNames:
+  - "system:authenticated"
+  - "system:authenticated:oauth"
+{% for group in kiali_vars.auth.openshift.impersonation.allowed_groups %}
+  - "{{ group }}"
+{% endfor %}
+{% endif %}
 {% endif %}
 {% if kiali_vars.deployment.tls_config.source == 'auto' %}
 # Permission to read OpenShift TLSSecurityProfile for tls_config.source=auto


### PR DESCRIPTION
Fixes: https://github.com/kiali/kiali/issues/10038

When spec.auth.openshift.impersonation.enabled is true, users authenticate once to the home cluster and Kiali uses its SA credentials with Kubernetes impersonation headers for all cluster API calls. This eliminates the need for per-cluster OAuth login flows that don't scale beyond a few clusters.

Generated-by: Cursor