### PR TITLE
Implement OIDC RP-Initiated Logout

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_kiali.yaml
@@ -33,10 +33,12 @@ spec:
       https_proxy: ""
       insecure_skip_verify_tls: false
       issuer_uri: ""
+      post_logout_redirect_uri: ""
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
       discovery_override:
         authorization_endpoint: ""
+        end_session_endpoint: ""
         jwks_uri: ""
         token_endpoint: ""
         userinfo_endpoint: ""

--- a/crd-docs/crd/kiali.io_kialis.yaml
+++ b/crd-docs/crd/kiali.io_kialis.yaml
@@ -185,6 +185,9 @@ spec:
                           authorization_endpoint:
                             type: string
                             description: "The URL of the provider's authorization endpoint."
+                          end_session_endpoint:
+                            type: string
+                            description: "The URL of the provider's RP-Initiated Logout endpoint. If set, logout will terminate both the local Kiali session and the IdP session. If not set, logout will only clear the local Kiali session."
                           jwks_uri:
                             type: string
                             description: "The URL of the provider's JWK Set document."
@@ -194,6 +197,9 @@ spec:
                           userinfo_endpoint:
                             type: string
                             description: "The URL of the provider's UserInfo endpoint."
+                      post_logout_redirect_uri:
+                        type: string
+                        description: "The URL to redirect the browser to after the IdP terminates the session during RP-Initiated Logout. Must be registered in the IdP's client configuration. If not set, defaults to the Kiali root URL."
                       username_claim:
                         type: string
                         default: "sub"

--- a/manifests/kiali-ossm/manifests/kiali.crd.yaml
+++ b/manifests/kiali-ossm/manifests/kiali.crd.yaml
@@ -185,6 +185,9 @@ spec:
                           authorization_endpoint:
                             type: string
                             description: "The URL of the provider's authorization endpoint."
+                          end_session_endpoint:
+                            type: string
+                            description: "The URL of the provider's RP-Initiated Logout endpoint. If set, logout will terminate both the local Kiali session and the IdP session. If not set, logout will only clear the local Kiali session."
                           jwks_uri:
                             type: string
                             description: "The URL of the provider's JWK Set document."
@@ -194,6 +197,9 @@ spec:
                           userinfo_endpoint:
                             type: string
                             description: "The URL of the provider's UserInfo endpoint."
+                      post_logout_redirect_uri:
+                        type: string
+                        description: "The URL to redirect the browser to after the IdP terminates the session during RP-Initiated Logout. Must be registered in the IdP's client configuration. If not set, defaults to the Kiali root URL."
                       username_claim:
                         type: string
                         default: "sub"

--- a/manifests/kiali-upstream/2.31.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.31.0/manifests/kiali.crd.yaml
@@ -185,6 +185,9 @@ spec:
                           authorization_endpoint:
                             type: string
                             description: "The URL of the provider's authorization endpoint."
+                          end_session_endpoint:
+                            type: string
+                            description: "The URL of the provider's RP-Initiated Logout endpoint. If set, logout will terminate both the local Kiali session and the IdP session. If not set, logout will only clear the local Kiali session."
                           jwks_uri:
                             type: string
                             description: "The URL of the provider's JWK Set document."
@@ -194,6 +197,9 @@ spec:
                           userinfo_endpoint:
                             type: string
                             description: "The URL of the provider's UserInfo endpoint."
+                      post_logout_redirect_uri:
+                        type: string
+                        description: "The URL to redirect the browser to after the IdP terminates the session during RP-Initiated Logout. Must be registered in the IdP's client configuration. If not set, defaults to the Kiali root URL."
                       username_claim:
                         type: string
                         default: "sub"

--- a/molecule/config-values-test/kiali-cr-all-yaml
+++ b/molecule/config-values-test/kiali-cr-all-yaml
@@ -24,9 +24,11 @@ spec:
     openid:
       discovery_override:
         authorization_endpoint: ""
+        end_session_endpoint: ""
         jwks_uri: ""
         token_endpoint: ""
         userinfo_endpoint: ""
+      post_logout_redirect_uri: ""
     openshift:
       impersonation:
         allowed_groups: []
@@ -37,12 +39,15 @@ spec:
   chat_ai:
     default_provider: ""
     enabled: false
+    max_tool_iterations: 5
     providers: []
     store_config:
       enabled: true
+      inactivity_timeout: "30m"
       max_cache_memory_mb: 1024
       reduce_threshold: 15
       reduce_with_ai: false
+    tools: {}
 
   installation_tag: "config-values-test-installation"
 
@@ -71,6 +76,10 @@ spec:
         metricName: "request_rate"
         dataType: "raw"
 
+  identity:
+    cert_file: ""
+    private_key_file: ""
+
   deployment:
     cluster_wide_access: {{ kiali.cluster_wide_access|bool }}
     image_digest: ""
@@ -80,7 +89,10 @@ spec:
     ingress:
       enabled: true
     logger:
+      log_format: "text"
       log_level: info
+      sampler_rate: "1"
+      time_field_format: "2006-01-02T15:04:05Z07:00"
     namespace: {{ kiali.install_namespace }}
     network_policy:
       enabled: true
@@ -253,6 +265,8 @@ spec:
     version_label_name: "app.kubernetes.io/version"
 
   kiali_feature_flags:
+    authz:
+      require_namespace_get: false
     custom_workload_types:
     - group: "argoproj.io"
       version: "v1alpha1"
@@ -316,6 +330,10 @@ spec:
     excluded_workloads: ["CronJob", "DeploymentConfig", "Job", "ReplicationController"]
     qps: 175
 
+  login_token:
+    expiration_seconds: 86400
+    signing_key: ""
+
   server:
     address: "0.0.0.0"
     audit_log: true
@@ -325,6 +343,9 @@ spec:
     observability:
       metrics:
         enabled: true
+        health_status:
+          enabled: false
+          max_consecutive_na: 3
         port: 9090
       tracing:
         collector_type: "otel"

--- a/molecule/openid-test/converge.yml
+++ b/molecule/openid-test/converge.yml
@@ -49,6 +49,7 @@
     assert:
       that:
       - kiali_configmap.auth.openid.discovery_override.authorization_endpoint == ""
+      - kiali_configmap.auth.openid.discovery_override.end_session_endpoint == ""
       - kiali_configmap.auth.openid.discovery_override.token_endpoint == ""
       - kiali_configmap.auth.openid.discovery_override.userinfo_endpoint == ""
       - kiali_configmap.auth.openid.discovery_override.jwks_uri == ""
@@ -170,7 +171,7 @@
 
   - name: "Update: Build new Kiali CR with discovery_override configuration"
     set_fact:
-      new_kiali_cr_with_discovery: "{{ current_kiali_cr | combine({'spec': {'auth': {'openid': {'discovery_override': {'authorization_endpoint': openid.discovery_override.authorization_endpoint, 'jwks_uri': openid.discovery_override.jwks_uri, 'token_endpoint': openid.discovery_override.token_endpoint, 'userinfo_endpoint': openid.discovery_override.userinfo_endpoint}}}}}, recursive=True) }}"
+      new_kiali_cr_with_discovery: "{{ current_kiali_cr | combine({'spec': {'auth': {'openid': {'discovery_override': {'authorization_endpoint': openid.discovery_override.authorization_endpoint, 'end_session_endpoint': openid.discovery_override.end_session_endpoint, 'jwks_uri': openid.discovery_override.jwks_uri, 'token_endpoint': openid.discovery_override.token_endpoint, 'userinfo_endpoint': openid.discovery_override.userinfo_endpoint}}}}}, recursive=True) }}"
 
   - name: "Update: Apply updated Kiali CR with discovery_override"
     import_tasks: ../common/set_kiali_cr.yml
@@ -190,6 +191,8 @@
       - kiali_configmap.auth.openid.discovery_override is defined
       - kiali_configmap.auth.openid.discovery_override.authorization_endpoint is defined
       - kiali_configmap.auth.openid.discovery_override.authorization_endpoint != ""
+      - kiali_configmap.auth.openid.discovery_override.end_session_endpoint is defined
+      - kiali_configmap.auth.openid.discovery_override.end_session_endpoint != ""
       - kiali_configmap.auth.openid.discovery_override.jwks_uri is defined
       - kiali_configmap.auth.openid.discovery_override.jwks_uri != ""
       - kiali_configmap.auth.openid.discovery_override.token_endpoint is defined
@@ -204,6 +207,8 @@
       that:
       - kiali_configmap.auth.openid.discovery_override.authorization_endpoint is search(nip_io_base_url)
       - kiali_configmap.auth.openid.discovery_override.authorization_endpoint is search("/oauth2/auth")
+      - kiali_configmap.auth.openid.discovery_override.end_session_endpoint is search(nip_io_base_url)
+      - kiali_configmap.auth.openid.discovery_override.end_session_endpoint is search("/oauth2/sessions/logout")
       - kiali_configmap.auth.openid.discovery_override.jwks_uri is search(nip_io_base_url)
       - kiali_configmap.auth.openid.discovery_override.jwks_uri is search("jwks.json")
       - kiali_configmap.auth.openid.discovery_override.token_endpoint is search(nip_io_base_url)

--- a/molecule/openid-test/kiali-cr.yaml
+++ b/molecule/openid-test/kiali-cr.yaml
@@ -10,6 +10,7 @@ spec:
       client_id: {{ openid.client_id }}
       insecure_skip_verify_tls: true
       issuer_uri: {{ openid.issuer_uri }}
+      post_logout_redirect_uri: "http://{{ nip_io_base_url }}:32080/kiali/"
       username_claim: {{ openid.username_claim }}
   deployment:
     ingress:

--- a/molecule/openid-test/molecule.yml
+++ b/molecule/openid-test/molecule.yml
@@ -36,6 +36,7 @@ provisioner:
           client_id: kiali-app
           discovery_override:
             authorization_endpoint: "https://{{ nip_io_base_url }}:{{ hydra.public_port }}/oauth2/auth"
+            end_session_endpoint: "https://{{ nip_io_base_url }}:{{ hydra.public_port }}/oauth2/sessions/logout"
             jwks_uri: "https://{{ nip_io_base_url }}:{{ hydra.public_port }}/.well-known/jwks.json"
             token_endpoint: "https://{{ nip_io_base_url }}:{{ hydra.public_port }}/oauth2/token"
             userinfo_endpoint: "https://{{ nip_io_base_url }}:{{ hydra.public_port }}/userinfo"

--- a/molecule/openid-test/oidc-handshaking.yml
+++ b/molecule/openid-test/oidc-handshaking.yml
@@ -24,6 +24,12 @@
     step8_response: ""
     step9_response: ""
     step10_response: ""
+    step11_response: ""
+    step12_response: ""
+    step13_response: ""
+    step14_kiali_redirect: ""
+    step14_hydra_response: ""
+    logout_redirect_url: ""
 
 - name: "Step 1: Send request to Kiali auth info endpoint and expect OpenID strategy configuration"
   uri:
@@ -382,3 +388,136 @@
   assert:
     that:
     - step10_response.json | length > 0
+
+# =============================================================================
+# OIDC RP-INITIATED LOGOUT (Steps 11-14)
+# Verifies that Kiali's logout terminates both the local session and the IdP session.
+# =============================================================================
+
+- name: "Step 11: Call Kiali logout API and expect redirect URL to IdP end_session_endpoint"
+  uri:
+    url: "{{ kiali_base_url }}/api/logout"
+    headers:
+      Cookie: "{{ kiali_cookies }}"
+    return_content: yes
+    validate_certs: false
+    status_code: 200
+  register: step11_response
+
+- name: "Step 11: DEBUG: Log logout API request and response"
+  vars:
+    msg: |
+      === Call Kiali logout API and expect redirect URL to IdP end_session_endpoint ===
+      Request URL: {{ kiali_base_url }}/api/logout
+      Request cookies sent: {{ kiali_cookies }}
+      Response status code: {{ step11_response.status }}
+      Response content: {{ step11_response.json }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: "Step 11: Assert logout response contains redirect_url with expected parameters"
+  assert:
+    that:
+    - step11_response.json.redirect_url is defined
+    - step11_response.json.redirect_url != ""
+    - step11_response.json.redirect_url is search("/oauth2/sessions/logout")
+    - step11_response.json.redirect_url is search("id_token_hint=")
+    - step11_response.json.redirect_url is search("post_logout_redirect_uri=")
+    fail_msg: "Logout response should contain redirect_url pointing to Hydra's end_session_endpoint with id_token_hint and post_logout_redirect_uri"
+    success_msg: "Logout response contains valid redirect_url for RP-Initiated Logout"
+
+- name: "Step 11: Extract the logout redirect URL for later use"
+  set_fact:
+    logout_redirect_url: "{{ step11_response.json.redirect_url }}"
+
+- name: "Step 12: Verify logout response cleared session cookies"
+  assert:
+    that:
+    - step11_response.set_cookie is defined
+    - step11_response.set_cookie is search("kiali-token-[^=]+=;") or step11_response.set_cookie is search("Max-Age=0")
+    fail_msg: "Logout response should include Set-Cookie headers that clear the session cookies"
+    success_msg: "Logout response correctly clears session cookies"
+
+- name: "Step 12: Verify request without cookies returns 401"
+  uri:
+    url: "{{ kiali_base_url }}/api/namespaces"
+    validate_certs: false
+    status_code: 401
+  register: step12_response
+
+- name: "Step 12: DEBUG: Log session invalidation check"
+  vars:
+    msg: |
+      === Verify request without session cookies is rejected ===
+      Request URL: {{ kiali_base_url }}/api/namespaces
+      Request cookies sent: None
+      Response status code: {{ step12_response.status }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: "Step 13: Follow the logout redirect URL to Hydra to terminate the IdP session"
+  uri:
+    url: "{{ logout_redirect_url }}"
+    headers:
+      Cookie: "{{ hydra_cookies }}"
+    validate_certs: false
+    follow_redirects: none
+    status_code: [302, 303]
+  register: step13_response
+
+- name: "Step 13: DEBUG: Log Hydra logout redirect"
+  vars:
+    msg: |
+      === Follow the logout redirect URL to Hydra ===
+      Request URL: {{ logout_redirect_url }}
+      Request cookies sent: {{ hydra_cookies }}
+      Response status code: {{ step13_response.status }}
+      Response location: {{ step13_response.location if step13_response.location is defined else 'None' }}
+      Response cookies received: {{ step13_response.set_cookie if step13_response.set_cookie is defined else 'None' }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: "Step 13: Assert Hydra accepted the logout and redirected"
+  assert:
+    that:
+    - step13_response.status in [302, 303]
+    - step13_response.location is defined
+    fail_msg: "Hydra should accept the RP-Initiated Logout and redirect to post_logout_redirect_uri"
+    success_msg: "Hydra accepted the logout and redirected as expected"
+
+- name: "Step 14: Verify IdP session is terminated by re-initiating auth flow and checking for login prompt"
+  get_all_cookies:
+    url: "{{ auth_endpoint }}"
+    validate_certs: false
+  register: step14_kiali_redirect
+
+- name: "Step 14: Follow redirect to Hydra authorization endpoint"
+  vars:
+    step14_hydra_url: "{{ step14_kiali_redirect.location | regex_replace('hydra.*\\.ory\\.svc\\.cluster\\.local:4444', nip_io_base_url + ':' + hydra.public_port|string) }}"
+  uri:
+    url: "{{ step14_hydra_url }}"
+    headers:
+      Cookie: "{{ hydra_cookies }}"
+    return_content: yes
+    validate_certs: false
+    follow_redirects: none
+    status_code: 302
+  register: step14_hydra_response
+
+- name: "Step 14: DEBUG: Log re-authentication attempt"
+  vars:
+    msg: |
+      === Verify IdP session is terminated ===
+      Kiali redirect location: {{ step14_kiali_redirect.location }}
+      Hydra response status: {{ step14_hydra_response.status }}
+      Hydra response location: {{ step14_hydra_response.location if step14_hydra_response.location is defined else 'None' }}
+  debug:
+    msg: "{{ msg.split('\n') }}"
+
+- name: "Step 14: Assert that Hydra requires re-authentication (login prompt)"
+  assert:
+    that:
+    - step14_hydra_response.location is defined
+    - step14_hydra_response.location is search("login_challenge=")
+    fail_msg: "After IdP logout, Hydra should present a login challenge instead of auto-authenticating. This means the IdP session was NOT terminated."
+    success_msg: "IdP session was correctly terminated - Hydra requires re-authentication"

--- a/roles/default/kiali-deploy/defaults/main.yml
+++ b/roles/default/kiali-deploy/defaults/main.yml
@@ -31,10 +31,12 @@ kiali_defaults:
       https_proxy: ""
       insecure_skip_verify_tls: false
       issuer_uri: ""
+      post_logout_redirect_uri: ""
       scopes: ["openid", "profile", "email"]
       username_claim: "sub"
       discovery_override:
         authorization_endpoint: ""
+        end_session_endpoint: ""
         jwks_uri: ""
         token_endpoint: ""
         userinfo_endpoint: ""


### PR DESCRIPTION
Add support for redirecting users to the OpenID provider's end_session_endpoint during logout, ensuring both the Kiali session and the IdP session are properly terminated. Includes new end_session_endpoint and post_logout_redirect_uri configuration options, frontend redirect handling, and end-to-end molecule test coverage.

Fixes: https://github.com/kiali/kiali/issues/10095

Generated-by: Cursor