### PR TITLE
Remove changes that leaked into the already-released 2.29.0 bundle

### DIFF
--- a/manifests/kiali-upstream/2.29.0/manifests/kiali.crd.yaml
+++ b/manifests/kiali-upstream/2.29.0/manifests/kiali.crd.yaml
@@ -232,10 +232,6 @@ spec:
                     description: "Enable or disable the ChatAI feature."
                     type: boolean
                     default: false
-                  max_tool_iterations:
-                    description: "Maximum number of tool-call iterations (LLM call + tool execution round) allowed per request before the loop is force-aborted. Must be between 1 and 20."
-                    type: integer
-                    default: 5
                   providers:
                     description: "A list of providers that can be used for the ChatAI feature. This is the list of providers that will be available to the user to choose from."
                     type: array

--- a/manifests/kiali-upstream/2.29.0/manifests/kiali.v2.29.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.29.0/manifests/kiali.v2.29.0.clusterserviceversion.yaml
@@ -492,7 +492,6 @@ spec:
           resources:
           - tcproutes
           - tlsroutes
-          - udproutes
           verbs:
           - get
           - list


### PR DESCRIPTION
The max_tool_iterations CRD field (#1074) and the udproutes RBAC rule (#1076) were both meant only for 2.30.0, but got merged into the already-released manifests/kiali-upstream/2.29.0 by mistake:

- #1074 merged while main was still missing 2.30.0 (the prior "prepare for next version" PR that would have created it, e82dfe14, was never merged and only lives on the abandoned origin/kiali-operator-release-281-main branch).
- #1076 manually edited the 2.29.0 CSV instead of 2.30.0's, and the follow-up fix (#1080) only added the missing permission to 2.30.0 without removing it from 2.29.0.

2.30.0 already has both changes correctly, so this only removes the stray content from 2.29.0.

We need this fix so future releases of the operator to OperatorHub.io keep older releases intact.