### PR TITLE
[molecule] Fix OIDC readiness race in openid-openshift-test

### DIFF
--- a/molecule/openid-openshift-test/converge.yml
+++ b/molecule/openid-openshift-test/converge.yml
@@ -246,8 +246,29 @@
     debug:
       msg: "Testing OAuth2 authentication flow using auto-discovery (/.well-known/openid-configuration)"
 
+  # The OIDC handshaking is wrapped in block/rescue to handle a known race
+  # condition: after the kube-apiserver rolls out with OIDC config, there is a
+  # brief window where the apiserver pods report ready but the OIDC authenticator
+  # has not yet fully initialized. Retrying the real auth flow (which resets all
+  # state on each attempt) is the most reliable way to ride out this window.
   - name: "OAuth2 Auto-Discovery: Run OIDC handshaking test"
-    include_tasks: oidc-handshaking.yml
+    block:
+    - include_tasks: oidc-handshaking.yml
+    rescue:
+    - name: "OIDC handshaking attempt 1 failed - possible API server OIDC readiness race"
+      debug:
+        msg: "{{ ansible_failed_result.msg | default('OIDC handshaking failed') }} - retrying in 30s (attempt 2/3)..."
+    - pause:
+        seconds: 30
+    - block:
+      - include_tasks: oidc-handshaking.yml
+      rescue:
+      - name: "OIDC handshaking attempt 2 failed"
+        debug:
+          msg: "{{ ansible_failed_result.msg | default('OIDC handshaking failed') }} - retrying in 30s (attempt 3/3)..."
+      - pause:
+          seconds: 30
+      - include_tasks: oidc-handshaking.yml
 
   # =============================================================================
   # AUTO-DISCOVERY VALIDATION

--- a/molecule/openid-openshift-test/prepare-hydra-openshift.yml
+++ b/molecule/openid-openshift-test/prepare-hydra-openshift.yml
@@ -327,13 +327,29 @@
     delay: 10
     ignore_errors: true
 
-  # Brief pause to let API server stabilize after rollout
-  - name: "Pause for API server stabilization"
-    pause:
-      seconds: 30
-      prompt: "Waiting 30s for API server to stabilize after rollout..."
+  # Verify all kube-apiserver nodes are running the latest static pod revision.
+  # The ClusterOperator can report Available before all nodes finish rolling out,
+  # and even after the pod is running the OIDC authenticator may need a moment to
+  # initialize. Checking node revisions is a stronger "rollout complete" signal.
+  - name: "Wait for all kube-apiserver nodes to reach latest revision"
+    k8s_info:
+      api_version: operator.openshift.io/v1
+      kind: KubeAPIServer
+      name: cluster
+    register: kas_operator
+    until: >-
+      kas_operator.resources is defined and
+      kas_operator.resources | length > 0 and
+      kas_operator.resources[0].status.latestAvailableRevision is defined and
+      kas_operator.resources[0].status.nodeStatuses is defined and
+      kas_operator.resources[0].status.nodeStatuses | length > 0 and
+      (kas_operator.resources[0].status.nodeStatuses |
+       rejectattr('currentRevision', 'equalto', kas_operator.resources[0].status.latestAvailableRevision) |
+       list | length == 0)
+    retries: 180
+    delay: 10
+    ignore_errors: true
 
-  # Verify the rollout actually completed - fail if it didn't
   - name: "Verify kube-apiserver rollout completed successfully"
     k8s_info:
       api_version: config.openshift.io/v1
@@ -357,7 +373,9 @@
 
   - name: "DEBUG: API server rollout complete"
     debug:
-      msg: "API server rollout complete. OpenShift now accepts Hydra OIDC tokens."
+      msg:
+      - "API server rollout complete. OpenShift now accepts Hydra OIDC tokens."
+      - "All nodes at revision: {{ kas_operator.resources[0].status.latestAvailableRevision | default('unknown') }}"
 
   # =============================================================================
   # CREATE RBAC FOR OIDC USER


### PR DESCRIPTION
Harden the openid-openshift-test molecule test to protect against race condition that causes flaky test failures.

The kube-apiserver can report Available via ClusterOperator before its OIDC authenticator is fully initialized, causing a transient 401 when Kiali exchanges the authorization code. This replaces the arbitrary 30s pause with a check that all apiserver nodes are at the latest static pod revision, and wraps the OIDC handshaking flow in block/rescue retries (up to 3 attempts) so the real auth flow rides out any remaining initialization window.

Generated-by: Cursor