### PR TITLE
Mark CR spec values as unsafe to prevent Jinja2 template injection

### DIFF
--- a/watches-k8s-ns.yaml
+++ b/watches-k8s-ns.yaml
@@ -5,6 +5,7 @@
   group: kiali.io
   kind: Kiali
   playbook: playbooks/kiali-deploy.yml
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: True
@@ -17,6 +18,7 @@
   kind: Secret
   playbook: playbooks/kiali-multi-cluster-secret-detected.yml
   manageStatus: False
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: False
@@ -29,6 +31,7 @@
   kind: Namespace
   playbook: playbooks/kiali-new-namespace-detected.yml
   manageStatus: False
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: False

--- a/watches-k8s.yaml
+++ b/watches-k8s.yaml
@@ -5,6 +5,7 @@
   group: kiali.io
   kind: Kiali
   playbook: playbooks/kiali-deploy.yml
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: True
@@ -17,6 +18,7 @@
   kind: Secret
   playbook: playbooks/kiali-multi-cluster-secret-detected.yml
   manageStatus: False
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: False

--- a/watches-os-ns.yaml
+++ b/watches-os-ns.yaml
@@ -5,6 +5,7 @@
   group: kiali.io
   kind: Kiali
   playbook: playbooks/kiali-deploy.yml
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: True
@@ -17,6 +18,7 @@
   kind: Secret
   playbook: playbooks/kiali-multi-cluster-secret-detected.yml
   manageStatus: False
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: False
@@ -29,6 +31,7 @@
   kind: Namespace
   playbook: playbooks/kiali-new-namespace-detected.yml
   manageStatus: False
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: False
@@ -37,6 +40,7 @@
   group: kiali.io
   kind: OSSMConsole
   playbook: playbooks/ossmconsole-deploy.yml
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   snakeCaseParameters: False

--- a/watches-os.yaml
+++ b/watches-os.yaml
@@ -5,6 +5,7 @@
   group: kiali.io
   kind: Kiali
   playbook: playbooks/kiali-deploy.yml
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: True
@@ -17,6 +18,7 @@
   kind: Secret
   playbook: playbooks/kiali-multi-cluster-secret-detected.yml
   manageStatus: False
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   watchAnnotationsChanges: False
@@ -28,6 +30,7 @@
   group: kiali.io
   kind: OSSMConsole
   playbook: playbooks/ossmconsole-deploy.yml
+  markUnsafe: True
   watchDependentResources: False
   watchClusterScopedResources: False
   snakeCaseParameters: False


### PR DESCRIPTION
Add markUnsafe: True to every watch entry in all watches files. Without this setting, the ansible-operator base image defaults markUnsafe to false, passing CR spec string values to Ansible playbooks without the __ansible_unsafe wrapper. This means Jinja2 template expressions in CR spec fields would be evaluated inside the operator pod, potentially allowing code execution as the operator ServiceAccount.

The kiali-operator playbooks do not intentionally evaluate CR spec values as Jinja2 templates, so this change is safe.