### PR TITLE
[v2.27] Support installing OSSM Console without a Kiali server present ("lite mode")

### DIFF
--- a/crd-docs/cr/kiali.io_v1alpha1_ossmconsole.yaml
+++ b/crd-docs/cr/kiali.io_v1alpha1_ossmconsole.yaml
@@ -16,7 +16,12 @@ spec:
     imageVersion: ""
     namespace: ""
 
+  # default: internal is an empty object (techPreview is disabled)
+  # internal:
+  #   techPreview: true
+
   kiali:
+    autoDiscover: true
     serviceName: ""
     serviceNamespace: ""
     servicePort: 0

--- a/crd-docs/crd/kiali.io_ossmconsoles.yaml
+++ b/crd-docs/crd/kiali.io_ossmconsoles.yaml
@@ -91,15 +91,22 @@ spec:
                   namespace:
                     description: "The namespace into which OSSM Console is to be installed. If this is empty or not defined, the default will be the namespace where the OSSMConsole CR is located. Currently the only namespace supported is the namespace where the OSSMConsole CR is located."
                     type: string
+              internal:
+                description: "Unstructured section for internal testing and debugging features. Not officially supported - fields here may change or be removed without notice."
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               kiali:
                 type: object
                 properties:
+                  autoDiscover:
+                    description: "Controls whether the operator will opportunistically auto-discover a Kiali installation via its OpenShift Route when none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set. If those three settings are all empty and this is set to `false`, OSSM Console is installed without Kiali integration rather than attempting discovery. This setting has no effect if all three of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are explicitly set (auto-discovery is already skipped in that case, and the explicitly configured Kiali installation is used). Setting this to `false` while only some (not all, and not none) of those three settings are specified is invalid and will fail reconciliation. Defaults to `true`."
+                    type: boolean
                   serviceName:
-                    description: "The internal Kiali service that the OpenShift Console will use to proxy API calls. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+                    description: "The internal Kiali service that the OpenShift Console will use to proxy API calls. If empty and `kiali.autoDiscover` is `true` (the default), an attempt will be made to auto-discover it from the Kiali OpenShift Route. If none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set and no Kiali installation can be auto-discovered (or `kiali.autoDiscover` is `false`), OSSM Console will still be installed, but without Kiali integration. If any of these three settings are explicitly set, a Kiali installation matching that configuration is required and the install will fail if it cannot be found or its version does not match. See `kiali.autoDiscover` for what happens when only some (not all) of these three settings are specified."
                     type: string
                   serviceNamespace:
-                    description: "The namespace where the Kiali service is deployed. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace."
+                    description: "The namespace where the Kiali service is deployed. If empty and `kiali.autoDiscover` is `true` (the default), an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace. If none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set and no Kiali installation can be auto-discovered (or `kiali.autoDiscover` is `false`), OSSM Console will still be installed, but without Kiali integration. If any of these three settings are explicitly set, a Kiali installation matching that configuration is required and the install will fail if it cannot be found or its version does not match. See `kiali.autoDiscover` for what happens when only some (not all) of these three settings are specified."
                     type: string
                   servicePort:
-                    description: "The internal port used by the Kiali service for the API. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+                    description: "The internal port used by the Kiali service for the API. If empty and `kiali.autoDiscover` is `true` (the default), an attempt will be made to auto-discover it from the Kiali OpenShift Route. If none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set and no Kiali installation can be auto-discovered (or `kiali.autoDiscover` is `false`), OSSM Console will still be installed, but without Kiali integration. If any of these three settings are explicitly set, a Kiali installation matching that configuration is required and the install will fail if it cannot be found or its version does not match. See `kiali.autoDiscover` for what happens when only some (not all) of these three settings are specified."
                     type: integer

--- a/deploy/ossmconsole/ossmconsole_cr_dev.yaml
+++ b/deploy/ossmconsole/ossmconsole_cr_dev.yaml
@@ -12,7 +12,10 @@ spec:
     imagePullPolicy: "Always"
     imagePullSecrets:
     - ${PULL_SECRET_NAME}
+  internal:
+    techPreview: true
   kiali:
+    autoDiscover: ${OSSMCONSOLE_CR_AUTO_DISCOVER}
     serviceName: ""
     serviceNamespace: ""
     servicePort: 0

--- a/manifests/kiali-ossm/manifests/ossmconsole.crd.yaml
+++ b/manifests/kiali-ossm/manifests/ossmconsole.crd.yaml
@@ -91,15 +91,22 @@ spec:
                   namespace:
                     description: "The namespace into which OSSM Console is to be installed. If this is empty or not defined, the default will be the namespace where the OSSMConsole CR is located. Currently the only namespace supported is the namespace where the OSSMConsole CR is located."
                     type: string
+              internal:
+                description: "Unstructured section for internal testing and debugging features. Not officially supported - fields here may change or be removed without notice."
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               kiali:
                 type: object
                 properties:
+                  autoDiscover:
+                    description: "Controls whether the operator will opportunistically auto-discover a Kiali installation via its OpenShift Route when none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set. If those three settings are all empty and this is set to `false`, OSSM Console is installed without Kiali integration rather than attempting discovery. This setting has no effect if all three of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are explicitly set (auto-discovery is already skipped in that case, and the explicitly configured Kiali installation is used). Setting this to `false` while only some (not all, and not none) of those three settings are specified is invalid and will fail reconciliation. Defaults to `true`."
+                    type: boolean
                   serviceName:
-                    description: "The internal Kiali service that the OpenShift Console will use to proxy API calls. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+                    description: "The internal Kiali service that the OpenShift Console will use to proxy API calls. If empty and `kiali.autoDiscover` is `true` (the default), an attempt will be made to auto-discover it from the Kiali OpenShift Route. If none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set and no Kiali installation can be auto-discovered (or `kiali.autoDiscover` is `false`), OSSM Console will still be installed, but without Kiali integration. If any of these three settings are explicitly set, a Kiali installation matching that configuration is required and the install will fail if it cannot be found or its version does not match. See `kiali.autoDiscover` for what happens when only some (not all) of these three settings are specified."
                     type: string
                   serviceNamespace:
-                    description: "The namespace where the Kiali service is deployed. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace."
+                    description: "The namespace where the Kiali service is deployed. If empty and `kiali.autoDiscover` is `true` (the default), an attempt will be made to auto-discover it from the Kiali OpenShift Route. It will assume that the OpenShift Route and the Kiali service are deployed in the same namespace. If none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set and no Kiali installation can be auto-discovered (or `kiali.autoDiscover` is `false`), OSSM Console will still be installed, but without Kiali integration. If any of these three settings are explicitly set, a Kiali installation matching that configuration is required and the install will fail if it cannot be found or its version does not match. See `kiali.autoDiscover` for what happens when only some (not all) of these three settings are specified."
                     type: string
                   servicePort:
-                    description: "The internal port used by the Kiali service for the API. If empty, an attempt will be made to auto-discover it from the Kiali OpenShift Route."
+                    description: "The internal port used by the Kiali service for the API. If empty and `kiali.autoDiscover` is `true` (the default), an attempt will be made to auto-discover it from the Kiali OpenShift Route. If none of `kiali.serviceName`, `kiali.serviceNamespace`, and `kiali.servicePort` are set and no Kiali installation can be auto-discovered (or `kiali.autoDiscover` is `false`), OSSM Console will still be installed, but without Kiali integration. If any of these three settings are explicitly set, a Kiali installation matching that configuration is required and the install will fail if it cannot be found or its version does not match. See `kiali.autoDiscover` for what happens when only some (not all) of these three settings are specified."
                     type: integer

--- a/molecule/ossmconsole-common/wait_for_ossmconsole_cr_failure.yml
+++ b/molecule/ossmconsole-common/wait_for_ossmconsole_cr_failure.yml
@@ -1,0 +1,18 @@
+- name: Wait for the OSSMConsole CR reconciliation to fail
+  k8s_info:
+    api_version: kiali.io/v1alpha1
+    kind: OSSMConsole
+    name: "{{ custom_resource.metadata.name }}"
+    namespace: "{{ ossmconsole_cr_namespace }}"
+  register: ossmconsole_cr_failure_list
+  until:
+  - ossmconsole_cr_failure_list is success
+  - ossmconsole_cr_failure_list.resources is defined
+  - ossmconsole_cr_failure_list.resources | length > 0
+  - ossmconsole_cr_failure_list | json_query('resources[*].status.conditions[?type==`Failure`].status') | flatten | join == 'True'
+  - ossmconsole_cr_failure_list | json_query('resources[*].status.conditions[?type==`Failure`].reason') | flatten | join == 'Failed'
+  retries: "{{ wait_retries }}"
+  delay: 5
+
+- set_fact:
+    ossmconsole_cr_failure_message: "{{ ossmconsole_cr_failure_list | json_query('resources[0].status.conditions[?type==`Failure`].message') | flatten | join }}"

--- a/molecule/ossmconsole-config-values-test/converge.yml
+++ b/molecule/ossmconsole-config-values-test/converge.yml
@@ -10,6 +10,12 @@
   - import_tasks: ../ossmconsole-common/tasks.yml
   - import_tasks: ../ossmconsole-common/wait_for_ossmconsole_cr_changes.yml
 
+  - name: Confirm the default CR renders internal.techPreview as false in the plugin-conf ConfigMap
+    assert:
+      that:
+      - ossmconsole_configmap.internal.techPreview == false
+      fail_msg: "Expected internal.techPreview to default to false: {{ ossmconsole_configmap }}"
+
   - set_fact:
       current_ossmconsole_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='OSSMConsole', namespace=ossmconsole_cr_namespace, resource_name=custom_resource.metadata.name) }}"
 
@@ -63,3 +69,75 @@
       that:
       - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.port == (current_ossmconsole_cr.status.kiali.servicePort | int)
       - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.port == 20001
+
+  # ---------------------------------------------------------------------------------------------
+  # Test kiali.autoDiscover. A real Kiali is installed and discoverable in this scenario, so this
+  # is the only place we can prove that autoDiscover: false forces installation without Kiali integration even though Kiali
+  # could otherwise be found -- and that it has no effect once fully configured (this is exactly
+  # what the OSSMC Connect/Disconnect actions rely on).
+  # ---------------------------------------------------------------------------------------------
+
+  # Re-fetch first - the fact above is stale (from before the servicePort patch/reconcile cycle) and
+  # would carry a resourceVersion the API server has since moved past, causing a 409 Conflict on patch.
+  - set_fact:
+      current_ossmconsole_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='OSSMConsole', namespace=ossmconsole_cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: Remember the working Kiali service settings before testing autoDiscover
+    set_fact:
+      known_good_kiali_service_name: "{{ current_ossmconsole_cr.status.kiali.serviceName }}"
+      known_good_kiali_service_namespace: "{{ current_ossmconsole_cr.status.kiali.serviceNamespace }}"
+
+  - name: Disable auto-discovery and clear the Kiali service settings to force installation without Kiali integration
+    set_fact:
+      current_ossmconsole_cr: "{{ current_ossmconsole_cr | combine({'spec': {'kiali': {'autoDiscover': false, 'serviceName': '', 'serviceNamespace': '', 'servicePort': 0}}}, recursive=True) }}"
+
+  - import_tasks: ../ossmconsole-common/set_ossmconsole_cr.yml
+    vars:
+      new_ossmconsole_cr: "{{ current_ossmconsole_cr }}"
+  - import_tasks: ../ossmconsole-common/wait_for_ossmconsole_cr_changes.yml
+  - import_tasks: ../ossmconsole-common/tasks.yml
+
+  - set_fact:
+      current_ossmconsole_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='OSSMConsole', namespace=ossmconsole_cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: Confirm autoDiscover false with nothing configured forces installation without Kiali integration even though a real Kiali is present
+    assert:
+      that:
+      - current_ossmconsole_cr.status.kiali.available == false
+      - ossmconsole_consoleplugin.spec.proxy is not defined or ossmconsole_consoleplugin.spec.proxy | length == 0
+
+  - name: Re-enable Kiali integration with explicit service settings while autoDiscover remains false
+    set_fact:
+      current_ossmconsole_cr: "{{ current_ossmconsole_cr | combine({'spec': {'kiali': {'autoDiscover': false, 'serviceName': known_good_kiali_service_name, 'serviceNamespace': known_good_kiali_service_namespace, 'servicePort': 20001}}}, recursive=True) }}"
+
+  - import_tasks: ../ossmconsole-common/set_ossmconsole_cr.yml
+    vars:
+      new_ossmconsole_cr: "{{ current_ossmconsole_cr }}"
+  - import_tasks: ../ossmconsole-common/wait_for_ossmconsole_cr_changes.yml
+  - import_tasks: ../ossmconsole-common/tasks.yml
+
+  - set_fact:
+      current_ossmconsole_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='OSSMConsole', namespace=ossmconsole_cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: Confirm explicit config still works with autoDiscover false, proving discovery-disabled has no effect once fully configured
+    assert:
+      that:
+      - current_ossmconsole_cr.status.kiali.available == true
+      - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.name == known_good_kiali_service_name
+      - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.namespace == known_good_kiali_service_namespace
+      - ossmconsole_consoleplugin.spec.proxy[0].endpoint.service.port == 20001
+
+  - name: Set only a partial Kiali configuration while autoDiscover is false
+    set_fact:
+      broken_ossmconsole_cr: "{{ current_ossmconsole_cr | combine({'spec': {'kiali': {'autoDiscover': false, 'serviceName': '', 'serviceNamespace': '', 'servicePort': 20001}}}, recursive=True) }}"
+
+  - import_tasks: ../ossmconsole-common/set_ossmconsole_cr.yml
+    vars:
+      new_ossmconsole_cr: "{{ broken_ossmconsole_cr }}"
+
+  - import_tasks: ../ossmconsole-common/wait_for_ossmconsole_cr_failure.yml
+
+  - name: Confirm the reconciliation failure is about the ambiguous partial autoDiscover configuration
+    assert:
+      that:
+      - "'autoDiscover' in ossmconsole_cr_failure_message"

--- a/molecule/ossmconsole-lite-test/converge.yml
+++ b/molecule/ossmconsole-lite-test/converge.yml
@@ -1,0 +1,59 @@
+- name: Tests
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  vars:
+    custom_resource: "{{ lookup('template', ossmconsole_cr_file_path) | from_yaml }}"
+  tasks:
+  - import_tasks: ../ossmconsole-common/confirm_openshift.yml
+  - import_tasks: ../ossmconsole-common/tasks.yml
+
+  - set_fact:
+      current_ossmconsole_cr: "{{ lookup('kubernetes.core.k8s', api_version='kiali.io/v1alpha1', kind='OSSMConsole', namespace=ossmconsole_cr_namespace, resource_name=custom_resource.metadata.name) }}"
+
+  - name: The current CR status
+    debug:
+      msg: "{{ current_ossmconsole_cr.status }}"
+
+  - name: Confirm all the core OSSM Console resources exist even though no Kiali is installed
+    assert:
+      that:
+      - ossmconsole_deployment.resources | length == 1
+      - ossmconsole_configmap_resource is defined
+      - ossmconsole_consoleplugin is defined
+      - ossmconsole_consoleplugin.spec.backend.service.name == 'ossmconsole'
+
+  - name: Confirm the CR status reports Kiali as unavailable
+    assert:
+      that:
+      - current_ossmconsole_cr.status.kiali.available == false
+      - current_ossmconsole_cr.status.kiali.serviceName == ""
+      - current_ossmconsole_cr.status.kiali.serviceNamespace == ""
+      - current_ossmconsole_cr.status.kiali.servicePort|int == 0
+
+  - name: Confirm the ConsolePlugin was created without a Kiali proxy entry
+    assert:
+      that:
+      - ossmconsole_consoleplugin.spec.proxy is not defined or ossmconsole_consoleplugin.spec.proxy | length == 0
+
+  # Now confirm that explicitly configuring Kiali (even partially) when no Kiali can be found is
+  # treated as a bad deployment scenario and hard-fails the reconciliation, rather than silently
+  # falling back to installation without Kiali integration. This is different than the "nothing configured, nothing found" case
+  # tested above: here the user asked for Kiali integration, so we must not silently degrade.
+
+  - name: Explicitly configure a Kiali servicePort even though no Kiali is installed on the cluster
+    set_fact:
+      broken_ossmconsole_cr: "{{ current_ossmconsole_cr | combine({'spec': {'kiali': {'servicePort': 15014}}}, recursive=True) }}"
+
+  - import_tasks: ../ossmconsole-common/set_ossmconsole_cr.yml
+    vars:
+      new_ossmconsole_cr: "{{ broken_ossmconsole_cr }}"
+
+  - import_tasks: ../ossmconsole-common/wait_for_ossmconsole_cr_failure.yml
+
+  - name: Confirm the reconciliation failure is about the inability to find Kiali
+    assert:
+      that:
+      - "'Kiali' in ossmconsole_cr_failure_message"
+      - "'Make sure Kiali is installed' in ossmconsole_cr_failure_message"

--- a/molecule/ossmconsole-lite-test/destroy.yml
+++ b/molecule/ossmconsole-lite-test/destroy.yml
@@ -1,0 +1,75 @@
+- name: Destroy
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  tasks:
+  - name: Skip test if not on OpenShift
+    import_tasks: ../ossmconsole-common/confirm_openshift.yml
+
+- name: Uninstall the OSSM Console
+  import_playbook: ../ossmconsole-default/remove_ossmconsole.yml
+
+- name: Uninstall the operator - no Kiali installation to remove since none was installed
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  tasks:
+  - include_tasks: ../common/cluster-info.yml
+
+  - name: Determine if the operator installation is managed externally or not
+    set_fact:
+      operator_installer: "{{ lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) }}" # can be 'helm' or 'skip'
+
+  - name: Uninstall Operator via Helm
+    command:
+      argv:
+      - "helm"
+      - "uninstall"
+      - "--namespace={{ kiali.operator_namespace }}"
+      - "--debug"
+      - "kiali-operator"
+    when:
+    - operator_installer == "helm"
+    ignore_errors: yes
+
+  # Helm does not uninstall CRDs, we need to do it here
+  - name: Remove CRDs
+    vars:
+      crds_yaml: "{{ lookup('env', 'MOLECULE_HELM_CHARTS_REPO') + '/kiali-operator/crds/crds.yaml' }}"
+    k8s:
+      state: absent
+      src: "{{ crds_yaml }}"
+      wait: yes
+    when:
+    - operator_installer == "helm"
+    ignore_errors: yes
+    retries: "{{ wait_retries }}"
+    delay: 5
+
+  - name: Removing Operator namespace
+    k8s:
+      state: absent
+      api_version: v1
+      kind: Namespace
+      name: "{{ kiali.operator_namespace }}"
+      wait: yes
+    when:
+    - operator_installer == "helm"
+    - kiali.operator_namespace != istio.control_plane_namespace
+    retries: "{{ wait_retries }}"
+    delay: 5
+
+  - name: Removing CR namespace if it is different than control plane and operator namespace
+    k8s:
+      state: absent
+      api_version: v1
+      kind: Namespace
+      name: "{{ ossmconsole_cr_namespace }}"
+      wait: yes
+    when:
+    - ossmconsole_cr_namespace != istio.control_plane_namespace
+    - ossmconsole_cr_namespace != kiali.operator_namespace
+    retries: "{{ wait_retries }}"
+    delay: 5

--- a/molecule/ossmconsole-lite-test/molecule.yml
+++ b/molecule/ossmconsole-lite-test/molecule.yml
@@ -1,0 +1,46 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: $DORP
+platforms:
+- name: default
+  groups:
+  - k8s
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      callbacks_enabled: junit
+  playbooks:
+    destroy: ../ossmconsole-lite-test/destroy.yml
+    prepare: ../ossmconsole-lite-test/prepare.yml
+    cleanup: ../default/cleanup.yml
+  inventory:
+    group_vars:
+      all:
+        wait_retries: "{{ lookup('env', 'MOLECULE_WAIT_RETRIES') | default('360', True) }}"
+        istio:
+          control_plane_namespace: istio-system
+        kiali:
+          operator_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else ('openshift-operators' if (query('kubernetes.core.k8s', kind='Namespace', resource_name='openshift-operators') | length > 0) else 'operators') }}" # if external operator, assume operator is in OLM location
+          operator_image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/kiali-operator' if lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME') == 'dev' else (lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_NAME')|default('quay.io/kiali/kiali-operator', True)) }}"
+          operator_version: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_VERSION')|default('latest', True) }}"
+          operator_watch_namespace: kiali-operator
+          operator_cluster_role_creator: "true"
+          operator_image_pull_policy: "{{ lookup('env', 'MOLECULE_KIALI_OPERATOR_IMAGE_PULL_POLICY')|default('Always', True) }}"
+        ossmconsole_cr_file_path: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/molecule/ossmconsole-cr.yaml"
+        ossmconsole_cr_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # if external operator, assume CR will go in control plane namespace
+        plugin_image_pull_secret_json: "{{ lookup('env', 'PLUGIN_IMAGE_PULL_SECRET_JSON') | default('') }}"
+        ossmconsole:
+          install_namespace: "{{ 'kiali-operator' if (lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) == 'helm') else 'istio-system' }}" # install namespace must be the same as the CR namespace today
+          spec_version: "{{ lookup('env', 'MOLECULE_OSSMCONSOLE_CR_SPEC_VERSION') | default('default', True) }}"
+          image_name: "{{ 'image-registry.openshift-image-registry.svc:5000/kiali/ossmconsole' if lookup('env', 'MOLECULE_PLUGIN_IMAGE_NAME') == 'dev' else ('quay.io/kiali/ossmconsole' if ansible_env.MOLECULE_PLUGIN_IMAGE_NAME is not defined else lookup('env', 'MOLECULE_PLUGIN_IMAGE_NAME')) }}"
+          image_version: "{{ 'latest' if ansible_env.MOLECULE_PLUGIN_IMAGE_VERSION is not defined else lookup('env', 'MOLECULE_PLUGIN_IMAGE_VERSION') }}"
+          image_pull_policy: "{{ lookup('env', 'MOLECULE_PLUGIN_IMAGE_PULL_POLICY')|default('Always', True) }}"
+scenario:
+  name: ossmconsole-lite-test
+  test_sequence:
+  - prepare
+  - converge
+  - destroy

--- a/molecule/ossmconsole-lite-test/prepare.yml
+++ b/molecule/ossmconsole-lite-test/prepare.yml
@@ -1,0 +1,85 @@
+- name: Prepare
+  hosts: localhost
+  connection: local
+  collections:
+  - kubernetes.core
+  tasks:
+  - name: Skip test if not on OpenShift
+    import_tasks: ../ossmconsole-common/confirm_openshift.yml
+
+  - include_tasks: ../common/cluster-info.yml
+
+  - name: Determine if the operator installation is managed externally or not
+    set_fact:
+      operator_installer: "{{ lookup('env', 'MOLECULE_OPERATOR_INSTALLER') | default('helm', True) }}" # can be 'helm' or 'skip'
+
+  - name: Make sure the operator namespace exists
+    k8s:
+      state: present
+      api_version: v1
+      kind: Namespace
+      name: "{{ kiali.operator_namespace }}"
+
+  - name: Find the latest Operator Helm Chart
+    shell: "ls -dt1 {{ lookup('env', 'MOLECULE_HELM_CHARTS_REPO') }}/_output/charts/kiali-operator*.tgz | head -n 1"
+    register: helm_chart_op_ls
+    when:
+    - operator_installer == "helm"
+
+  - set_fact:
+      helm_chart_location: "{{ helm_chart_op_ls.stdout | trim }}"
+    when:
+    - operator_installer == "helm"
+    - helm_chart_op_ls.stdout is defined
+
+  - fail:
+      msg: "The helm chart does not appear to be built. Run 'make build-helm-chart'."
+    when:
+    - operator_installer == "helm"
+    - helm_chart_location is not defined or helm_chart_location | length == 0
+
+  # This test deliberately does NOT install Kiali - it confirms OSSM Console can be installed
+  # without Kiali integration when no Kiali installation is found on the cluster.
+  - name: Install Operator via Helm
+    command:
+      argv:
+      - "helm"
+      - "upgrade"
+      - "--install"
+      - "--atomic"
+      - "--cleanup-on-fail"
+      - "--namespace={{ kiali.operator_namespace }}"
+      - "--set"
+      - "debug.enableProfiler={{ lookup('env', 'MOLECULE_OPERATOR_PROFILER_ENABLED') | default('true', True) }}"
+      - "--set"
+      - "allowAdHocKialiNamespace=true"
+      - "--set"
+      - "allowAdHocKialiImage=true"
+      - "--set"
+      - "allowAdHocOSSMConsoleImage=true"
+      - "--set"
+      - "allowAdHocContainers=true"
+      - "--set"
+      - "allowSecurityContextOverride=true"
+      - "--set"
+      - "cr.create=false"
+      - "--set"
+      - "image.repo={{ kiali.operator_image_name }}"
+      - "--set"
+      - "image.tag={{ kiali.operator_version }}"
+      - "--set"
+      - "image.pullPolicy={{ kiali.operator_image_pull_policy }}"
+      - "--set"
+      - "image.pullSecrets={{ '{' + lookup('env', 'OPERATOR_IMAGE_PULL_SECRET_NAME') + '}' }}"
+      - "--set"
+      - "watchNamespace={{ kiali.operator_watch_namespace }}"
+      - "--set"
+      - "clusterRoleCreator={{ kiali.operator_cluster_role_creator | default('true') }}"
+      - "--debug"
+      - "kiali-operator"
+      - "{{ helm_chart_location }}"
+    when:
+    - operator_installer == "helm"
+
+- name: Install OSSM Console without a Kiali installation present
+  import_playbook: ../ossmconsole-default/install_ossmconsole.yml

--- a/roles/default/ossmconsole-deploy/defaults/main.yml
+++ b/roles/default/ossmconsole-deploy/defaults/main.yml
@@ -18,7 +18,10 @@ ossmconsole_defaults:
     imageVersion: ""
     namespace: ""
 
+  internal: {}
+
   kiali:
+    autoDiscover: true
     serviceName: ""
     serviceNamespace: ""
     servicePort: 0

--- a/roles/default/ossmconsole-deploy/tasks/main.yml
+++ b/roles/default/ossmconsole-deploy/tasks/main.yml
@@ -118,27 +118,112 @@
   - current_cr.status.deployment.namespace is defined
   - current_cr.status.deployment.namespace != ossmconsole_vars.deployment.namespace
 
-# If we need to auto-discover some things that require the Kiali Route, get the route now - first look in the CR's namespace then anywhere else. If Kiali is not found, abort.
-- name: Auto-discover the Kiali Route - preference goes to a Kiali installed in the same namespace as the CR
-  vars:
-    kiali_in_namespace: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route', namespace=current_cr.metadata.namespace) }}"
-    kiali_anywhere: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route') }}"
+# Determine if the user explicitly asked for a specific Kiali service. If they did, we treat Kiali as a
+# hard requirement and will fail the install if it cannot be found/reached. If they did not, this is the
+# common case where we opportunistically look for Kiali but are willing to install OSSMC without it
+# without Kiali integration when none can be found.
+- name: Determine if the user explicitly configured a Kiali service to use
   set_fact:
-    kiali_route: "{{ kiali_in_namespace[0] if kiali_in_namespace | length > 0 else (kiali_anywhere[0] if kiali_anywhere | length > 0 else '') }}"
+    kiali_explicitly_configured: "{{ ossmconsole_vars.kiali.serviceName != '' or ossmconsole_vars.kiali.serviceNamespace != '' or ossmconsole_vars.kiali.servicePort|int != 0 }}"
+
+- name: Determine if the user explicitly configured all three Kiali service settings
+  set_fact:
+    kiali_all_explicitly_configured: "{{ ossmconsole_vars.kiali.serviceName != '' and ossmconsole_vars.kiali.serviceNamespace != '' and ossmconsole_vars.kiali.servicePort|int != 0 }}"
+
+# kiali.autoDiscover only controls the opportunistic Route-discovery step below. It has no effect when
+# all three kiali.serviceName/serviceNamespace/servicePort settings are explicitly configured, since
+# discovery is already skipped in that case. Disabling it while only some of those three are set is
+# ambiguous (we would need to auto-discover the rest, which is exactly what is disabled), so fail fast
+# with a clear message instead of leaving kiali_route undefined for the tasks below that depend on it.
+- fail:
+    msg: "When kiali.autoDiscover is false, you must specify all of kiali.serviceName, kiali.serviceNamespace, and kiali.servicePort together, or leave all three empty to install without Kiali integration."
   when:
-  - ossmconsole_vars.kiali.serviceName == "" or ossmconsole_vars.kiali.serviceNamespace == "" or ossmconsole_vars.kiali.servicePort|int == 0
+  - not (ossmconsole_vars.kiali.autoDiscover | bool)
+  - kiali_explicitly_configured == True
+  - kiali_all_explicitly_configured == False
+
+- set_fact:
+    kiali_available: true
+
+- name: Auto-discovery is disabled and no Kiali was explicitly configured - OSSM Console will be installed without Kiali integration
+  debug:
+    msg: "kiali.autoDiscover is false and no Kiali service was explicitly configured. OSSM Console will be installed without Kiali integration; no auto-discovery will be attempted."
+  when:
+  - not (ossmconsole_vars.kiali.autoDiscover | bool)
+  - kiali_explicitly_configured == False
+
+- set_fact:
+    kiali_available: false
+  when:
+  - not (ossmconsole_vars.kiali.autoDiscover | bool)
+  - kiali_explicitly_configured == False
+
+# Auto-discover the Kiali Route when service settings were not fully configured. Prefer a Route in the OSSMConsole
+# CR's own namespace; if none exists there, use a Route from another namespace. If no Route is found, abort only when
+# the user explicitly configured Kiali; otherwise install without Kiali integration. The Route may not
+# exist on the first attempt if Kiali is still starting, so retry briefly before giving up.
+- name: Auto-discover the Kiali Route - preference goes to a Kiali installed in the same namespace as the CR
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    label_selectors:
+    - app.kubernetes.io/name=kiali
+  register: kiali_routes_discovered
+  until:
+  - kiali_routes_discovered.resources is defined
+  - kiali_routes_discovered.resources | length > 0
+  retries: 24
+  delay: 5
   ignore_errors: yes
+  when:
+  - ossmconsole_vars.kiali.autoDiscover | bool
+  - kiali_all_explicitly_configured == False
+
+- name: Select the preferred Kiali Route from discovered routes
+  set_fact:
+    kiali_route: "{{ (kiali_routes_discovered.resources | selectattr('metadata.namespace', 'equalto', current_cr.metadata.namespace) | list | first) | default(kiali_routes_discovered.resources[0], true) }}"
+  when:
+  - ossmconsole_vars.kiali.autoDiscover | bool
+  - kiali_all_explicitly_configured == False
+  - kiali_routes_discovered is defined
+  - kiali_routes_discovered.resources is defined
+  - kiali_routes_discovered.resources | length > 0
+
+- name: Remember that no Kiali Route was discovered
+  set_fact:
+    kiali_route: ""
+  when:
+  - ossmconsole_vars.kiali.autoDiscover | bool
+  - kiali_all_explicitly_configured == False
+  - kiali_route is not defined
 
 - fail:
     msg: "Failed to auto-discover the Kiali Route. Make sure Kiali is installed. You can specify the full 'kiali' section in the CR if there is a Kiali installed but cannot be auto-discovered by this operator."
   when:
   - kiali_route is defined
   - kiali_route == ""
+  - kiali_explicitly_configured == True
+
+- name: No Kiali was found and none was explicitly configured - OSSM Console will be installed without Kiali integration
+  debug:
+    msg: "No Kiali installation was found. OSSM Console will be installed without Kiali integration. If a Kiali is installed later, re-apply the OSSMConsole CR to enable Kiali integration."
+  when:
+  - kiali_route is defined
+  - kiali_route == ""
+  - kiali_explicitly_configured == False
+
+- set_fact:
+    kiali_available: false
+  when:
+  - kiali_route is defined
+  - kiali_route == ""
+  - kiali_explicitly_configured == False
 
 - name: Auto-discover the Kiali Service Name
   set_fact:
     kiali_service_name: "{{ kiali_route.spec.to.name }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceName == ""
   ignore_errors: yes
 
@@ -146,6 +231,7 @@
   set_fact:
     kiali_service_namespace: "{{ kiali_route.metadata.namespace }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceNamespace == ""
   ignore_errors: yes
 
@@ -153,24 +239,28 @@
   set_fact:
     kiali_service_port: "{{ kiali_route.spec.port.targetPort }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.servicePort|int == 0
   ignore_errors: yes
 
 - fail:
     msg: "Failed to auto-discover the Kiali Service Name. Make sure Kiali is installed. You can specify 'kiali.serviceName' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceName == ""
   - kiali_service_name is not defined or kiali_service_name == ""
 
 - fail:
     msg: "Failed to auto-discover the Kiali Service Namespace. Make sure Kiali is installed. You can specify 'kiali.serviceNamespace' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceNamespace == ""
   - kiali_service_namespace is not defined or kiali_service_namespace == ""
 
 - fail:
     msg: "Failed to auto-discover the Kiali Service Port. Make sure Kiali is installed. You can specify 'kiali.servicePort' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.servicePort|int == 0
   - kiali_service_port is not defined or kiali_service_port == ""
 
@@ -178,14 +268,17 @@
 - set_fact:
     ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'serviceName': kiali_service_name}}, recursive=True) }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceName == ""
 - set_fact:
     ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'serviceNamespace': kiali_service_namespace}}, recursive=True) }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceNamespace == ""
 - set_fact:
     ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'servicePort': kiali_service_port}}, recursive=True) }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.servicePort|int == 0
 
 - name: Ask Kiali for information about itself
@@ -204,6 +297,8 @@
   retries: 60
   delay: 5
   ignore_errors: yes
+  when:
+  - kiali_available == True
 
 # If Kiali returned 401, it is likely because server.require_auth is set to true in the Kiali CR.
 # In that case we cannot obtain the Kiali version, so skip the version check and proceed with the install.
@@ -211,6 +306,7 @@
   debug:
     msg: "WARNING: Kiali returned HTTP 401 Unauthorized for the /api endpoint. This is likely because 'server.require_auth: true' is set in the Kiali CR. The Kiali version check will be skipped and OSSMC will be installed without verifying that the Kiali version matches. See https://github.com/kiali/kiali/issues/9964"
   when:
+  - kiali_available == True
   - kiali_info_results is defined
   - kiali_info_results.status is defined
   - kiali_info_results.status == 401
@@ -221,6 +317,7 @@
   set_fact:
     kiali_version: "{{ kiali_info_results.json | json_query(q) }}"
   when:
+  - kiali_available == True
   - kiali_info_results is defined
   - kiali_info_results.json is defined
   ignore_errors: yes
@@ -246,9 +343,10 @@
       deployment:
         namespace: "{{ ossmconsole_vars.deployment.namespace }}"
       kiali:
-        serviceName: "{{ ossmconsole_vars.kiali.serviceName }}"
-        serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
-        servicePort: "{{ ossmconsole_vars.kiali.servicePort|int }}"
+        available: "{{ kiali_available }}"
+        serviceName: "{{ ossmconsole_vars.kiali.serviceName if kiali_available else '' }}"
+        serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace if kiali_available else '' }}"
+        servicePort: "{{ ossmconsole_vars.kiali.servicePort|int if kiali_available else 0 }}"
 
 # The OSSMC plugin must talk to a Kiali of the same version.
 # We asked the Kiali Server what version it is, so we already have that.
@@ -271,6 +369,7 @@
   fail:
     msg: "The version of the Kiali Server [{{ kiali_version_to_match }}] does not match the OSSMC version [{{ ossmc_version_to_match }}]. OSSMC will not be installed. To skip this check and allow for the install to continue, set the operator environment variable OSSMC_SKIP_VERSION_CHECK to 'true'."
   when:
+  - kiali_available == True
   - kiali_version_to_match != ossmc_version_to_match
   - lookup('env', 'OSSMC_SKIP_VERSION_CHECK') | default('false', True) != "true"
   - kiali_info_results.status | default(0) != 401
@@ -400,7 +499,7 @@
   - processed_resources_dict is defined
   - processed_resources_dict[keyname] is defined
   - processed_resources_dict[keyname].changed == True
-  - processed_resources_dict[keyname].method == "patch"
+  - processed_resources_dict[keyname].method == "update"
 
 - include_tasks: update-status-progress.yml
   vars:

--- a/roles/default/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
@@ -7,4 +7,7 @@ metadata:
 data:
   plugin-config.json: |
     {
+      "internal": {
+        "techPreview": {{ (ossmconsole_vars.internal.techPreview | default(false) | bool) | tojson }}
+      }
     }

--- a/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/default/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -14,6 +14,7 @@ spec:
       port: 9443
       basePath: "/"
     type: Service
+{% if kiali_available %}
   proxy:
   - alias: kiali
     authorization: UserToken
@@ -23,3 +24,8 @@ spec:
         namespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         port: {{ ossmconsole_vars.kiali.servicePort | int }}
       type: Service
+{% else %}
+  # Explicitly null (rather than simply omitting the key) so the patch clears any proxy that was set by a
+  # previous reconciliation - a merge patch leaves keys absent from the payload untouched on the live object.
+  proxy: null
+{% endif %}

--- a/roles/default/ossmconsole-deploy/vars/main.yml
+++ b/roles/default/ossmconsole-deploy/vars/main.yml
@@ -22,6 +22,13 @@ ossmconsole_vars:
     {{ ossmconsole_defaults.deployment }}
     {%- endif -%}
 
+  internal: |
+    {%- if internal is defined and internal is iterable -%}
+    {{ ossmconsole_defaults.internal | combine((internal | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmconsole_defaults.internal }}
+    {%- endif -%}
+
   kiali: |
     {%- if kiali is defined and kiali is iterable -%}
     {{ ossmconsole_defaults.kiali | combine((kiali | stripnone), recursive=True) }}

--- a/roles/v2.27/ossmconsole-deploy/defaults/main.yml
+++ b/roles/v2.27/ossmconsole-deploy/defaults/main.yml
@@ -18,7 +18,10 @@ ossmconsole_defaults:
     imageVersion: ""
     namespace: ""
 
+  internal: {}
+
   kiali:
+    autoDiscover: true
     serviceName: ""
     serviceNamespace: ""
     servicePort: 0

--- a/roles/v2.27/ossmconsole-deploy/tasks/main.yml
+++ b/roles/v2.27/ossmconsole-deploy/tasks/main.yml
@@ -118,27 +118,112 @@
   - current_cr.status.deployment.namespace is defined
   - current_cr.status.deployment.namespace != ossmconsole_vars.deployment.namespace
 
-# If we need to auto-discover some things that require the Kiali Route, get the route now - first look in the CR's namespace then anywhere else. If Kiali is not found, abort.
-- name: Auto-discover the Kiali Route - preference goes to a Kiali installed in the same namespace as the CR
-  vars:
-    kiali_in_namespace: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route', namespace=current_cr.metadata.namespace) }}"
-    kiali_anywhere: "{{ query(k8s_plugin, label_selector='app.kubernetes.io/name=kiali', api_version='route.openshift.io/v1', kind='Route') }}"
+# Determine if the user explicitly asked for a specific Kiali service. If they did, we treat Kiali as a
+# hard requirement and will fail the install if it cannot be found/reached. If they did not, this is the
+# common case where we opportunistically look for Kiali but are willing to install OSSMC without it
+# without Kiali integration when none can be found.
+- name: Determine if the user explicitly configured a Kiali service to use
   set_fact:
-    kiali_route: "{{ kiali_in_namespace[0] if kiali_in_namespace | length > 0 else (kiali_anywhere[0] if kiali_anywhere | length > 0 else '') }}"
+    kiali_explicitly_configured: "{{ ossmconsole_vars.kiali.serviceName != '' or ossmconsole_vars.kiali.serviceNamespace != '' or ossmconsole_vars.kiali.servicePort|int != 0 }}"
+
+- name: Determine if the user explicitly configured all three Kiali service settings
+  set_fact:
+    kiali_all_explicitly_configured: "{{ ossmconsole_vars.kiali.serviceName != '' and ossmconsole_vars.kiali.serviceNamespace != '' and ossmconsole_vars.kiali.servicePort|int != 0 }}"
+
+# kiali.autoDiscover only controls the opportunistic Route-discovery step below. It has no effect when
+# all three kiali.serviceName/serviceNamespace/servicePort settings are explicitly configured, since
+# discovery is already skipped in that case. Disabling it while only some of those three are set is
+# ambiguous (we would need to auto-discover the rest, which is exactly what is disabled), so fail fast
+# with a clear message instead of leaving kiali_route undefined for the tasks below that depend on it.
+- fail:
+    msg: "When kiali.autoDiscover is false, you must specify all of kiali.serviceName, kiali.serviceNamespace, and kiali.servicePort together, or leave all three empty to install without Kiali integration."
   when:
-  - ossmconsole_vars.kiali.serviceName == "" or ossmconsole_vars.kiali.serviceNamespace == "" or ossmconsole_vars.kiali.servicePort|int == 0
+  - not (ossmconsole_vars.kiali.autoDiscover | bool)
+  - kiali_explicitly_configured == True
+  - kiali_all_explicitly_configured == False
+
+- set_fact:
+    kiali_available: true
+
+- name: Auto-discovery is disabled and no Kiali was explicitly configured - OSSM Console will be installed without Kiali integration
+  debug:
+    msg: "kiali.autoDiscover is false and no Kiali service was explicitly configured. OSSM Console will be installed without Kiali integration; no auto-discovery will be attempted."
+  when:
+  - not (ossmconsole_vars.kiali.autoDiscover | bool)
+  - kiali_explicitly_configured == False
+
+- set_fact:
+    kiali_available: false
+  when:
+  - not (ossmconsole_vars.kiali.autoDiscover | bool)
+  - kiali_explicitly_configured == False
+
+# Auto-discover the Kiali Route when service settings were not fully configured. Prefer a Route in the OSSMConsole
+# CR's own namespace; if none exists there, use a Route from another namespace. If no Route is found, abort only when
+# the user explicitly configured Kiali; otherwise install without Kiali integration. The Route may not
+# exist on the first attempt if Kiali is still starting, so retry briefly before giving up.
+- name: Auto-discover the Kiali Route - preference goes to a Kiali installed in the same namespace as the CR
+  k8s_info:
+    api_version: route.openshift.io/v1
+    kind: Route
+    label_selectors:
+    - app.kubernetes.io/name=kiali
+  register: kiali_routes_discovered
+  until:
+  - kiali_routes_discovered.resources is defined
+  - kiali_routes_discovered.resources | length > 0
+  retries: 24
+  delay: 5
   ignore_errors: yes
+  when:
+  - ossmconsole_vars.kiali.autoDiscover | bool
+  - kiali_all_explicitly_configured == False
+
+- name: Select the preferred Kiali Route from discovered routes
+  set_fact:
+    kiali_route: "{{ (kiali_routes_discovered.resources | selectattr('metadata.namespace', 'equalto', current_cr.metadata.namespace) | list | first) | default(kiali_routes_discovered.resources[0], true) }}"
+  when:
+  - ossmconsole_vars.kiali.autoDiscover | bool
+  - kiali_all_explicitly_configured == False
+  - kiali_routes_discovered is defined
+  - kiali_routes_discovered.resources is defined
+  - kiali_routes_discovered.resources | length > 0
+
+- name: Remember that no Kiali Route was discovered
+  set_fact:
+    kiali_route: ""
+  when:
+  - ossmconsole_vars.kiali.autoDiscover | bool
+  - kiali_all_explicitly_configured == False
+  - kiali_route is not defined
 
 - fail:
     msg: "Failed to auto-discover the Kiali Route. Make sure Kiali is installed. You can specify the full 'kiali' section in the CR if there is a Kiali installed but cannot be auto-discovered by this operator."
   when:
   - kiali_route is defined
   - kiali_route == ""
+  - kiali_explicitly_configured == True
+
+- name: No Kiali was found and none was explicitly configured - OSSM Console will be installed without Kiali integration
+  debug:
+    msg: "No Kiali installation was found. OSSM Console will be installed without Kiali integration. If a Kiali is installed later, re-apply the OSSMConsole CR to enable Kiali integration."
+  when:
+  - kiali_route is defined
+  - kiali_route == ""
+  - kiali_explicitly_configured == False
+
+- set_fact:
+    kiali_available: false
+  when:
+  - kiali_route is defined
+  - kiali_route == ""
+  - kiali_explicitly_configured == False
 
 - name: Auto-discover the Kiali Service Name
   set_fact:
     kiali_service_name: "{{ kiali_route.spec.to.name }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceName == ""
   ignore_errors: yes
 
@@ -146,6 +231,7 @@
   set_fact:
     kiali_service_namespace: "{{ kiali_route.metadata.namespace }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceNamespace == ""
   ignore_errors: yes
 
@@ -153,24 +239,28 @@
   set_fact:
     kiali_service_port: "{{ kiali_route.spec.port.targetPort }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.servicePort|int == 0
   ignore_errors: yes
 
 - fail:
     msg: "Failed to auto-discover the Kiali Service Name. Make sure Kiali is installed. You can specify 'kiali.serviceName' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceName == ""
   - kiali_service_name is not defined or kiali_service_name == ""
 
 - fail:
     msg: "Failed to auto-discover the Kiali Service Namespace. Make sure Kiali is installed. You can specify 'kiali.serviceNamespace' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceNamespace == ""
   - kiali_service_namespace is not defined or kiali_service_namespace == ""
 
 - fail:
     msg: "Failed to auto-discover the Kiali Service Port. Make sure Kiali is installed. You can specify 'kiali.servicePort' in the CR if there is a Kiali Service the plugin can use but cannot be auto-discovered by this operator."
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.servicePort|int == 0
   - kiali_service_port is not defined or kiali_service_port == ""
 
@@ -178,14 +268,17 @@
 - set_fact:
     ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'serviceName': kiali_service_name}}, recursive=True) }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceName == ""
 - set_fact:
     ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'serviceNamespace': kiali_service_namespace}}, recursive=True) }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.serviceNamespace == ""
 - set_fact:
     ossmconsole_vars: "{{ ossmconsole_vars | combine({'kiali': {'servicePort': kiali_service_port}}, recursive=True) }}"
   when:
+  - kiali_available == True
   - ossmconsole_vars.kiali.servicePort|int == 0
 
 - name: Ask Kiali for information about itself
@@ -204,6 +297,8 @@
   retries: 60
   delay: 5
   ignore_errors: yes
+  when:
+  - kiali_available == True
 
 # If Kiali returned 401, it is likely because server.require_auth is set to true in the Kiali CR.
 # In that case we cannot obtain the Kiali version, so skip the version check and proceed with the install.
@@ -211,6 +306,7 @@
   debug:
     msg: "WARNING: Kiali returned HTTP 401 Unauthorized for the /api endpoint. This is likely because 'server.require_auth: true' is set in the Kiali CR. The Kiali version check will be skipped and OSSMC will be installed without verifying that the Kiali version matches. See https://github.com/kiali/kiali/issues/9964"
   when:
+  - kiali_available == True
   - kiali_info_results is defined
   - kiali_info_results.status is defined
   - kiali_info_results.status == 401
@@ -221,6 +317,7 @@
   set_fact:
     kiali_version: "{{ kiali_info_results.json | json_query(q) }}"
   when:
+  - kiali_available == True
   - kiali_info_results is defined
   - kiali_info_results.json is defined
   ignore_errors: yes
@@ -246,9 +343,10 @@
       deployment:
         namespace: "{{ ossmconsole_vars.deployment.namespace }}"
       kiali:
-        serviceName: "{{ ossmconsole_vars.kiali.serviceName }}"
-        serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
-        servicePort: "{{ ossmconsole_vars.kiali.servicePort|int }}"
+        available: "{{ kiali_available }}"
+        serviceName: "{{ ossmconsole_vars.kiali.serviceName if kiali_available else '' }}"
+        serviceNamespace: "{{ ossmconsole_vars.kiali.serviceNamespace if kiali_available else '' }}"
+        servicePort: "{{ ossmconsole_vars.kiali.servicePort|int if kiali_available else 0 }}"
 
 # The OSSMC plugin must talk to a Kiali of the same version.
 # We asked the Kiali Server what version it is, so we already have that.
@@ -271,6 +369,7 @@
   fail:
     msg: "The version of the Kiali Server [{{ kiali_version_to_match }}] does not match the OSSMC version [{{ ossmc_version_to_match }}]. OSSMC will not be installed. To skip this check and allow for the install to continue, set the operator environment variable OSSMC_SKIP_VERSION_CHECK to 'true'."
   when:
+  - kiali_available == True
   - kiali_version_to_match != ossmc_version_to_match
   - lookup('env', 'OSSMC_SKIP_VERSION_CHECK') | default('false', True) != "true"
   - kiali_info_results.status | default(0) != 401
@@ -400,7 +499,7 @@
   - processed_resources_dict is defined
   - processed_resources_dict[keyname] is defined
   - processed_resources_dict[keyname].changed == True
-  - processed_resources_dict[keyname].method == "patch"
+  - processed_resources_dict[keyname].method == "update"
 
 - include_tasks: update-status-progress.yml
   vars:

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/configmap-plugin.yaml
@@ -7,4 +7,7 @@ metadata:
 data:
   plugin-config.json: |
     {
+      "internal": {
+        "techPreview": {{ (ossmconsole_vars.internal.techPreview | default(false) | bool) | tojson }}
+      }
     }

--- a/roles/v2.27/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
+++ b/roles/v2.27/ossmconsole-deploy/templates/openshift/consoleplugin.yaml
@@ -14,6 +14,7 @@ spec:
       port: 9443
       basePath: "/"
     type: Service
+{% if kiali_available %}
   proxy:
   - alias: kiali
     authorization: UserToken
@@ -23,3 +24,8 @@ spec:
         namespace: "{{ ossmconsole_vars.kiali.serviceNamespace }}"
         port: {{ ossmconsole_vars.kiali.servicePort | int }}
       type: Service
+{% else %}
+  # Explicitly null (rather than simply omitting the key) so the patch clears any proxy that was set by a
+  # previous reconciliation - a merge patch leaves keys absent from the payload untouched on the live object.
+  proxy: null
+{% endif %}

--- a/roles/v2.27/ossmconsole-deploy/vars/main.yml
+++ b/roles/v2.27/ossmconsole-deploy/vars/main.yml
@@ -22,6 +22,13 @@ ossmconsole_vars:
     {{ ossmconsole_defaults.deployment }}
     {%- endif -%}
 
+  internal: |
+    {%- if internal is defined and internal is iterable -%}
+    {{ ossmconsole_defaults.internal | combine((internal | stripnone), recursive=True) }}
+    {%- else -%}
+    {{ ossmconsole_defaults.internal }}
+    {%- endif -%}
+
   kiali: |
     {%- if kiali is defined and kiali is iterable -%}
     {{ ossmconsole_defaults.kiali | combine((kiali | stripnone), recursive=True) }}


### PR DESCRIPTION
backport:
* #1082 

This also includes:
* https://github.com/kiali/kiali-operator/pull/1090