### PR TITLE
revert timestamp from old metadata csv

### DIFF
--- a/manifests/kiali-upstream/2.29.0/manifests/kiali.v2.29.0.clusterserviceversion.yaml
+++ b/manifests/kiali-upstream/2.29.0/manifests/kiali.v2.29.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
     support: Kiali
     description: "Kiali project provides answers to the questions: What microservices are part of my Istio service mesh and how are they connected?"
     repository: https://github.com/kiali/kiali
-    createdAt: 2026-07-12T09:23:43Z
+    createdAt: 2026-06-28T10:16:09Z
     alm-examples: |-
       [
         {


### PR DESCRIPTION
Trivial change.

We need to revert this timestamp, otherwise the operatorhub.io metadata gets screwed up and our operator hub update PRs won't be mergeable.

This is due to a bad PR merge we did in the past.

The real timestamp was a few weeks earlier (2026-07-12T09:23:43Z); this has no practical effects if we revert this.